### PR TITLE
Console: Fix PRN numbering off-by-one in observation view

### DIFF
--- a/scripts/observation_view.py
+++ b/scripts/observation_view.py
@@ -78,7 +78,7 @@ class ObservationView(HasTraits):
       self.rinex_file = None
 
   def update_obs(self):
-    self._obs_table_list = [(prn,) + obs for prn, obs in sorted(self.obs.items(), key=lambda x: x[0])]
+    self._obs_table_list = [(prn + 1,) + obs for prn, obs in sorted(self.obs.items(), key=lambda x: x[0])]
 
   def obs_hdr_callback(self, data):
     tow, wn, obs_count, n_obs = struct.unpack("<dHBB", data)


### PR DESCRIPTION
This fixes the symptom; please check that I didn't miss any other places since I am unfamiliar with the console code
