### PR TITLE
Make port chooser dialog wider

### DIFF
--- a/scripts/console.py
+++ b/scripts/console.py
@@ -212,7 +212,7 @@ class PortChooser(HasTraits):
     buttons = ['OK', 'Cancel'],
     close_result=False,
     icon = icon,
-    width = 200,
+    width = 250,
     title = 'Select serial device',
   )
 


### PR DESCRIPTION
The new narrower width cuts off text in OS X.
