### PR TITLE
Fix wakeup of solution thread.

### DIFF
--- a/src/solution.c
+++ b/src/solution.c
@@ -367,7 +367,7 @@ void send_observations(u8 n, gps_time_t *t, navigation_measurement_t *m)
 
 }
 
-static BSEMAPHORE_DECL(solution_wakeup_sem, true);
+static BinarySemaphore solution_wakeup_sem;
 #define tim5_isr Vector108
 #define NVIC_TIM5_IRQ 50
 void tim5_isr()
@@ -391,7 +391,8 @@ static void timer_set_period_check(uint32_t timer_peripheral, uint32_t period)
   uint32_t tmp = TIM_CNT(timer_peripheral);
   if (tmp > period) {
     TIM_CNT(timer_peripheral) = period;
-    printf("TIM counter = %lu, period = %lu\n", tmp, period);
+    printf("WARNING: Solution thread missed deadline, "
+           "TIM counter = %lu, period = %lu\n", tmp, period);
   }
   __asm__("CPSIE i;");
 }
@@ -786,18 +787,6 @@ void init_base_callback(u16 sender_id, u8 len, u8 msg[], void* context)
 
 void solution_setup()
 {
-  /* Enable TIM5 clock. */
-  rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_TIM5EN);
-  nvicEnableVector(NVIC_TIM5_IRQ,
-      CORTEX_PRIORITY_MASK(CORTEX_MAX_KERNEL_PRIORITY+1));
-  timer_reset(TIM5);
-  timer_set_mode(TIM5, TIM_CR1_CKD_CK_INT, TIM_CR1_CMS_EDGE, TIM_CR1_DIR_UP);
-  timer_set_prescaler(TIM5, 0);
-  timer_disable_preload(TIM5);
-  timer_set_period(TIM5, 65472000); /* 1 second. */
-  timer_enable_counter(TIM5);
-  timer_enable_irq(TIM5, TIM_DIER_UIE);
-
   /* Set time of last differential solution in the past. */
   last_dgnss = chTimeNow() - DGNSS_TIMEOUT;
 
@@ -848,8 +837,22 @@ void solution_setup()
   static obss_t obs_buff[OBS_N_BUFF] _CCM;
   chPoolLoadArray(&obs_buff_pool, obs_buff, OBS_N_BUFF);
 
+  /* Initialise solution thread wakeup semaphore */
+  chBSemInit(&solution_wakeup_sem, TRUE);
+  /* Start solution thread */
   chThdCreateStatic(wa_solution_thread, sizeof(wa_solution_thread),
                     HIGHPRIO-1, solution_thread, NULL);
+  /* Enable TIM5 clock. */
+  rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_TIM5EN);
+  nvicEnableVector(NVIC_TIM5_IRQ,
+      CORTEX_PRIORITY_MASK(CORTEX_MAX_KERNEL_PRIORITY+1));
+  timer_reset(TIM5);
+  timer_set_mode(TIM5, TIM_CR1_CKD_CK_INT, TIM_CR1_CMS_EDGE, TIM_CR1_DIR_UP);
+  timer_set_prescaler(TIM5, 0);
+  timer_disable_preload(TIM5);
+  timer_set_period(TIM5, 65472000); /* 1 second. */
+  timer_enable_counter(TIM5);
+  timer_enable_irq(TIM5, TIM_DIER_UIE);
 
   chThdCreateStatic(wa_time_matched_obs_thread, sizeof(wa_time_matched_obs_thread),
                     LOWPRIO, time_matched_obs_thread, NULL);


### PR DESCRIPTION
Check timer counter when resetting period and use a semaphore to
wake up.  Fixes #69

<!---
@huboard:{"order":106.5,"milestone_order":136.75,"custom_state":""}
-->
