### PR TITLE
serial_link: Give up on IOError in ListenerThread.

### DIFF
--- a/scripts/serial_link.py
+++ b/scripts/serial_link.py
@@ -97,7 +97,7 @@ class ListenerThread (threading.Thread):
                 cb(md, sender=ms)
               except TypeError:
                 cb(md)
-      except IOError:
+      except (IOError, OSError):
         # Piksi was disconnected
         print "ERROR: Piksi disconnected!"
         return


### PR DESCRIPTION
This prevents spinning and eating memory when the USB port is unplugged with pyserial.
pylibftdi will still fail.

<!---
@huboard:{"order":114.875,"milestone_order":145.0,"custom_state":""}
-->
