### PR TITLE
New ChibiOS repository URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/swift-nav/libswiftnav.git
 [submodule "ChibiOS-RT"]
 	path = ChibiOS-RT
-	url = https://github.com/ChibiOS/ChibiOS-RT.git
+	url = https://github.com/mabl/ChibiOS.git


### PR DESCRIPTION
The original ChibiOS git mirror we were using no longer exists!

Moved from:

https://github.com/ChibiOS/ChibiOS-RT

to

https://github.com/mabl/ChibiOS
