### PR TITLE
Handle 'observation message packing: integer overflow' more gracefully

### DIFF
--- a/src/sbp_piksi.c
+++ b/src/sbp_piksi.c
@@ -50,34 +50,42 @@ void unpack_obs_content(msg_obs_content_t *msg, double *P, double *L,
   *prn = msg->prn;
 }
 
-void pack_obs_content(double P, double L, double snr, u16 lock_counter, u8 prn,
-                      msg_obs_content_t *msg)
+s8 pack_obs_content(double P, double L, double snr, u16 lock_counter, u8 prn,
+                    msg_obs_content_t *msg)
 {
 
-  if (P < 0 || P > INT_MAX) {
-    screaming_death("observation message packing: integer overflow");
+  s64 P_fp = llround(P * MSG_OBS_P_MULTIPLIER);
+  if (P < 0 || P_fp > UINT32_MAX) {
+    printf("ERROR: observation message packing: P integer overflow (%f)\n", P);
+    return -1;
   }
 
-  msg->P = (u32) round(P * MSG_OBS_P_MULTIPLIER);
-
-  if (L < -(INT_MAX) || L > INT_MAX) {
-    screaming_death("observation message packing: integer overflow");
-  }
+  msg->P = (u32)P_fp;
 
   double Li = floor(L);
+  if (Li < INT32_MIN || Li > INT32_MAX) {
+    printf("ERROR: observation message packing: L integer overflow (%f)\n", L);
+    return -1;
+  }
+
   double Lf = L - Li;
 
   msg->L.Li = (s32) Li;
   msg->L.Lf = (u8) (Lf * MSG_OSB_LF_MULTIPLIER);
 
-  if (snr < 0 || snr > ((1<<8) / MSG_OBS_SNR_MULTIPLIER)) {
-    screaming_death("observation message packing: integer overflow");
+  s32 snr_fp = lround(snr * MSG_OBS_SNR_MULTIPLIER);
+  if (snr < 0 || snr_fp > UINT8_MAX) {
+    printf("ERROR: observation message packing: SNR integer overflow (%f)\n",
+           snr);
+    return -1;
   }
 
-  msg->snr = (u8) round(snr * MSG_OBS_SNR_MULTIPLIER);
+  msg->snr = (u8)snr_fp;
 
   msg->lock_counter = lock_counter;
 
   msg->prn = prn;
+
+  return 0;
 }
 

--- a/src/sbp_piksi.c
+++ b/src/sbp_piksi.c
@@ -50,6 +50,18 @@ void unpack_obs_content(msg_obs_content_t *msg, double *P, double *L,
   *prn = msg->prn;
 }
 
+/** Pack GPS observables into a `msg_obs_content_t` struct.
+ * For use in constructing a `MSG_NEW_OBS` SBP message.
+ *
+ * \param P Pseudorange in meters
+ * \param L Carrier phase in cycles
+ * \param snr Signal-to-noise ratio
+ * \param lock_counter Lock counter is an arbitrary integer that should change
+ *                     if the carrier phase ambiguity is ever reset
+ * \param prn Satellite PRN identifier
+ * \param msg Pointer to a `msg_obs_content_t` struct to fill out
+ * \return `0` on success or `-1` on an overflow error
+ */
 s8 pack_obs_content(double P, double L, double snr, u16 lock_counter, u8 prn,
                     msg_obs_content_t *msg)
 {

--- a/src/sbp_piksi.h
+++ b/src/sbp_piksi.h
@@ -160,7 +160,7 @@ void pack_obs_header(gps_time_t *t, u8 total, u8 count,
 void unpack_obs_content(msg_obs_content_t *msg,
   double *P, double *L, double *snr, u16 *lock_counter, u8 *prn);
 
-void pack_obs_content(double P, double L, double snr, u16 lock_counter, u8 prn,
+s8 pack_obs_content(double P, double L, double snr, u16 lock_counter, u8 prn,
   msg_obs_content_t *msg);
 
 /** Value specifying the size of the SBP framing */

--- a/src/simulator.c
+++ b/src/simulator.c
@@ -337,7 +337,7 @@ void populate_nav_meas(navigation_measurement_t *nav_meas, double dist, double e
   nav_meas->carrier_phase +=   simulation_fake_carrier_bias[almanac_i];
   nav_meas->carrier_phase +=   rand_gaussian(sim_settings.phase_sigma);
 
-  nav_meas->snr             =  lerp(elevation, 0, M_PI/2, 4, 12) + rand_gaussian(sim_settings.cn0_sigma);
+  nav_meas->snr             =  lerp(elevation, 0, M_PI/2, 35, 45) + rand_gaussian(sim_settings.cn0_sigma);
 }
 
 /** Returns true if the simulation is at all enabled

--- a/src/solution.c
+++ b/src/solution.c
@@ -241,8 +241,6 @@ void obs_callback(u16 sender_id, u8 len, u8 msg[], void* context)
 
   u8 obs_in_msg = (len - sizeof(msg_obs_header_t)) / sizeof(msg_obs_content_t);
 
-
-
   if (count == 0) {
     base_obss_raw.n = 0;
     base_obss_raw.t = t;
@@ -370,12 +368,16 @@ void send_observations(u8 n, gps_time_t *t, navigation_measurement_t *m)
     msg_obs_content_t *obs = (msg_obs_content_t *)&buff[sizeof(msg_obs_header_t)];
 
     for (u8 i = 0; i < curr_n; i++, obs_i++) {
-      pack_obs_content(m[obs_i].raw_pseudorange,
-        m[obs_i].carrier_phase,
-        m[obs_i].snr,
-        m[obs_i].lock_counter,
-        m[obs_i].prn,
-        &obs[i]);
+      if (pack_obs_content(m[obs_i].raw_pseudorange,
+            m[obs_i].carrier_phase,
+            m[obs_i].snr,
+            m[obs_i].lock_counter,
+            m[obs_i].prn,
+            &obs[i]) < 0) {
+        /* Error packing this observation, skip it. */
+        i--;
+        curr_n--;
+      }
     }
 
     sbp_send_msg(MSG_PACKED_OBS,


### PR DESCRIPTION
This error does happen very occasionally as reported here:
https://groups.google.com/d/msg/swiftnav-discuss/8bdngdOkXKM/lz_Ov7PEL7wJ

This error should be non-fatal. This patch just reports the error and drops the offending satellite from the observation message.