### PR TITLE
Handle RX DMA buffer overflow more gracefully

### DIFF
--- a/scripts/system_monitor_view.py
+++ b/scripts/system_monitor_view.py
@@ -65,13 +65,13 @@ class SystemMonitorView(HasTraits):
   msg_obs_window_latency_ms = Int(0)
 
   traits_view = View(
-    HSplit(
+    VGroup(
       Item(
         '_threads_table_list', style = 'readonly',
         editor = TabularEditor(adapter=SimpleAdapter()),
         show_label=False, width=0.85,
       ),
-      VGroup(
+      HGroup(
         VGroup(
           Item('msg_obs_window_latency_ms', label='Obs Latency',
             style='readonly', format_str='%dms'),

--- a/src/peripherals/usart.h
+++ b/src/peripherals/usart.h
@@ -81,6 +81,7 @@ typedef struct {
 
     u32 byte_counter;    /**< Counts the number of bytes received since
                               statistics were last calculated */
+    u32 errors;          /**< Counts the number of USART DMA errors */
     u32 last_byte_ticks; /**< Tick count of the last time throughput statistics
                               were calculated */
 
@@ -101,6 +102,7 @@ typedef struct {
 
     u32 byte_counter;    /**< Counts the number of bytes received since
                               statistics were last calculated */
+    u32 errors;          /**< Counts the number of USART DMA errors */
     u32 last_byte_ticks; /**< Tick count of the last time throughput statistics
                               were calculated */
   } tx;

--- a/src/sbp.c
+++ b/src/sbp.c
@@ -76,10 +76,13 @@ static msg_t sbp_thread(void *arg)
     DO_EVERY(100,
       uart_state_msg.uarts[0].tx_throughput = usart_tx_throughput(&uarta_state.tx);
       uart_state_msg.uarts[0].rx_throughput = usart_rx_throughput(&uarta_state.rx);
+      uart_state_msg.uarts[0].io_error_count = uarta_state.rx.errors + uarta_state.tx.errors;
       uart_state_msg.uarts[1].tx_throughput = usart_tx_throughput(&uartb_state.tx);
       uart_state_msg.uarts[1].rx_throughput = usart_rx_throughput(&uartb_state.rx);
+      uart_state_msg.uarts[1].io_error_count = uartb_state.rx.errors + uartb_state.tx.errors;
       uart_state_msg.uarts[2].tx_throughput = usart_tx_throughput(&ftdi_state.tx);
       uart_state_msg.uarts[2].rx_throughput = usart_rx_throughput(&ftdi_state.rx);
+      uart_state_msg.uarts[2].io_error_count = ftdi_state.rx.errors + ftdi_state.tx.errors;
 
       if (latency_count > 0) {
         uart_state_msg.obs_latency.avg = (s32) (latency_accum_ms / latency_count);

--- a/src/sbp_piksi.h
+++ b/src/sbp_piksi.h
@@ -126,6 +126,7 @@ typedef struct __attribute__((packed)) {
     float tx_throughput;
     float rx_throughput;
     u16 crc_error_count;
+    u16 io_error_count;
     u8 tx_buffer_level;
     u8 rx_buffer_level;
   } uarts[3];


### PR DESCRIPTION
Buffer overflow error is now non-fatal.

Add 'IO error' count functionality, reported by the UART state message and in the console system monitor view.

Fixes #218