### PR TITLE
Adding ARM to the list of reasons to rename strnicmp to the posix strncasecmp

### DIFF
--- a/src/minIni/minIni.c
+++ b/src/minIni/minIni.c
@@ -73,7 +73,7 @@
   #pragma warning(disable: 4996)	/* for Microsoft Visual C/C++ */
 #endif
 #if !defined strnicmp && !defined PORTABLE_STRNICMP
-  #if defined __LINUX__ || defined __FreeBSD__ || defined __OpenBSD__ || defined __APPLE__
+  #if defined __LINUX__ || defined __FreeBSD__ || defined __OpenBSD__ || defined __APPLE__ || defined __arm__
     #define strnicmp  strncasecmp
   #endif
 #endif


### PR DESCRIPTION
This fixes the current issue with the compilation on Ubuntu 14.10/14.04