### PR TITLE
Use new libswiftnav logging infrastructure

### DIFF
--- a/src/acq.c
+++ b/src/acq.c
@@ -12,9 +12,10 @@
 
 #include <math.h>
 #include <string.h>
-#include <stdio.h>
 
 #include <ch.h>
+
+#include <libswiftnav/logging.h>
 
 #include "board/nap/acq_channel.h"
 #include "acq.h"
@@ -32,8 +33,9 @@ void acq_set_prn(u8 prn)
 {
   chBSemInit(&load_wait_sem, TRUE);
   nap_acq_code_wr_blocking(prn);
-  if (chBSemWaitTimeout(&load_wait_sem, 1000) == RDY_TIMEOUT)
-    printf("acq: Timeout waiting for code load!\n");
+  if (chBSemWaitTimeout(&load_wait_sem, 1000) == RDY_TIMEOUT) {
+    log_warn("acq: Timeout waiting for code load!\n");
+  }
 }
 
 /** Send results of an acquisition to the host.
@@ -75,7 +77,7 @@ bool acq_load(u32 count)
   nap_acq_load_wr_enable_blocking();
   nap_timing_strobe(count);
   if (chBSemWaitTimeout(&load_wait_sem, 1000) == RDY_TIMEOUT) {
-    printf("acq: Timeout waiting for sample load!\n");
+    log_warn("acq: Timeout waiting for sample load!\n");
     return false;
   }
   return true;
@@ -139,16 +141,18 @@ void acq_search(float cf_min_, float cf_max_, float cf_bin_width)
     (float)cf_step);
 
   for (s16 cf = cf_min; cf < cf_max; cf += cf_step) {
-    if (chSemWaitTimeout(&acq_pipeline_sem, 1000) == RDY_TIMEOUT)
-      printf("acq: Timeout waiting for search!\n");
+    if (chSemWaitTimeout(&acq_pipeline_sem, 1000) == RDY_TIMEOUT) {
+      log_warn("acq: Timeout waiting for search!\n");
+    }
     acq_state.pipeline[acq_state.p_head].cf = cf;
     acq_state.p_head = (acq_state.p_head + 1) % NAP_ACQ_PIPELINE_STAGES;
     nap_acq_init_wr_params_blocking(cf);
   }
 
   for (int i = 0; i < NAP_ACQ_PIPELINE_STAGES; i++) {
-    if (chSemWaitTimeout(&acq_pipeline_sem, 1000) == RDY_TIMEOUT)
-      printf("acq: Timeout waiting for search!\n");
+    if (chSemWaitTimeout(&acq_pipeline_sem, 1000) == RDY_TIMEOUT) {
+      log_warn("acq: Timeout waiting for search!\n");
+    }
   }
 }
 

--- a/src/base_obs.c
+++ b/src/base_obs.c
@@ -10,11 +10,11 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
 
+#include <libswiftnav/logging.h>
 #include <libswiftnav/sbp_utils.h>
 #include <libswiftnav/pvt.h>
 #include <libswiftnav/constants.h>
@@ -82,8 +82,8 @@ static void base_pos_callback(u16 sender_id, u8 len, u8 msg[], void* context)
 static void obs_old_callback(u16 sender_id, u8 len, u8 msg[], void* context)
 {
   (void) context; (void) len; (void) msg; (void) sender_id;
-  printf("Receiving an old deprecated observation message.\n");
-  printf("Please update your base station firmware.\n");
+  log_warn("Receiving an old deprecated observation message.\n");
+  log_warn("Please update your base station firmware.\n");
 }
 
 /** Update the #base_obss state given a new set of obss.
@@ -167,7 +167,7 @@ static void update_obss(obss_t *new_obss)
       base_obss.has_pos = 1;
     } else {
       /* There was an error calculating the position solution. */
-      printf("Error calculating base station position (%ld)\n", ret);
+      log_error("Error calculating base station position (%ld)\n", ret);
     }
   }
   /* If the base station position is known then calculate the satellite ranges.
@@ -237,7 +237,7 @@ static void obs_callback(u16 sender_id, u8 len, u8 msg[], void* context)
    * i.e. is it going to time match one of our local obs. */
   double epoch_count = t.tow * (soln_freq / obs_output_divisor);
   if (fabs(epoch_count - round(epoch_count)) > TIME_MATCH_THRESHOLD) {
-    printf("Unaligned observation from base station ignored.\n");
+    log_warn("Unaligned observation from base station ignored.\n");
     return;
   }
 
@@ -255,7 +255,7 @@ static void obs_callback(u16 sender_id, u8 len, u8 msg[], void* context)
   } else if (prev_t.tow != t.tow ||
              prev_t.wn != t.wn ||
              prev_count + 1 != count) {
-    printf("Dropped one of the observation packets! Skipping this sequence.\n");
+    log_info("Dropped one of the observation packets! Skipping this sequence.\n");
     prev_count = -1;
     return;
   } else {

--- a/src/board/max2769.c
+++ b/src/board/max2769.c
@@ -10,7 +10,7 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include <stdio.h>
+#include <libswiftnav/logging.h>
 
 #include <libopencm3/stm32/f4/gpio.h>
 #include <libopencm3/stm32/f4/rcc.h>
@@ -164,7 +164,7 @@ bool antenna_changed(struct setting *s, const char *val)
       break;
     }
     max2769_write(MAX2769_CONF1, max2769_conf1);
-    printf("Antenna changed to: %s\n", val);
+    log_info("Antenna changed to: %s\n", val);
 
     return true;
   }

--- a/src/cfs/cfs-coffee.c
+++ b/src/cfs/cfs-coffee.c
@@ -51,7 +51,7 @@
 #define DEBUG 0
 #if DEBUG
 #include <stdio.h>
-#define PRINTF(...) printf(__VA_ARGS__)
+#define PRINTF(...) log_debug(__VA_ARGS__)
 #else
 #define PRINTF(...)
 #endif

--- a/src/init.c
+++ b/src/init.c
@@ -10,10 +10,10 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include <stdio.h>
-
 #include <libopencm3/stm32/f4/flash.h>
 #include <libopencm3/stm32/f4/rcc.h>
+
+#include <libswiftnav/logging.h>
 #include <libswiftnav/sbp.h>
 
 #include "main.h"
@@ -110,12 +110,13 @@ void check_nap_auth(void)
   if (nhs != NAP_HASH_MATCH) {
     led_on(LED_GREEN);
     led_off(LED_RED);
-    while (1)
+    while (1) {
       DO_EVERY(10000000,
-        printf("NAP Verification Failed\n");
+        log_error("NAP Verification Failed\n");
         led_toggle(LED_GREEN);
         led_toggle(LED_RED);
       );
+    }
   }
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -10,10 +10,10 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include <libswiftnav/logging.h>
 #include <libswiftnav/sbp_messages.h>
 
 #include <ch.h>
@@ -87,18 +87,18 @@ static msg_t nav_msg_thread(void *arg)
         __asm__("CPSIE i;");
 
         if (ret < 0) {
-          printf("PRN %02d ret %d\n", tracking_channel[i].prn+1, ret);
+          log_info("PRN %02d ret %d\n", tracking_channel[i].prn+1, ret);
         } else if (ret == 1) {
           /* Decoded a new ephemeris. */
 
           if (memcmp(&es[tracking_channel[i].prn],
                      &es_old[tracking_channel[i].prn],
                      sizeof(ephemeris_t))) {
-            printf("New ephemeris for PRN %02d\n", tracking_channel[i].prn+1);
+            log_info("New ephemeris for PRN %02d\n", tracking_channel[i].prn+1);
           }
 
           if (!es[tracking_channel[i].prn].healthy) {
-            printf("PRN %02d unhealthy\n", tracking_channel[i].prn+1);
+            log_info("PRN %02d unhealthy\n", tracking_channel[i].prn+1);
           } else {
             sbp_send_msg(MSG_EPHEMERIS,
                          sizeof(ephemeris_t),
@@ -223,14 +223,14 @@ int main(void)
 
   static char nap_version_string[64] = {0};
   nap_conf_rd_version_string(nap_version_string);
-  printf("NAP firmware version: %s\n", nap_version_string);
+  log_info("NAP firmware version: %s\n", nap_version_string);
 
   /* Check we are running a compatible version of the NAP firmware. */
   const char *required_nap_version = "v0.9-46";
   if (compare_version(nap_version_string, required_nap_version) < 0) {
-    printf("ERROR: NAP firmware version newer than %s required, please update!\n"
-           "(instructions can be found at http://docs.swift-nav.com/)\n",
-           required_nap_version);
+    log_error("NAP firmware version newer than %s required, please update!\n"
+              "(instructions can be found at http://docs.swift-nav.com/)\n",
+              required_nap_version);
     while (1) {
       chThdSleepSeconds(60);
     }

--- a/src/peripherals/3drradio.c
+++ b/src/peripherals/3drradio.c
@@ -10,10 +10,14 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include <ch.h>
-#include <libopencm3/stm32/f4/usart.h>
-#include <stdio.h>
 #include <string.h>
+
+#include <ch.h>
+
+#include <libopencm3/stm32/f4/usart.h>
+
+#include <libswiftnav/logging.h>
+
 #include "3drradio.h"
 #include "../settings.h"
 
@@ -137,8 +141,8 @@ void radio_preconfigure_hook(u32 usart, u32 default_baud, char* uart_name)
 
   /* If we found a radio, we send it a configuration string. */
   if (found_radio) {
-    printf("Telemetry radio found on %s at baudrate %lu, "
-           "sending configuration string.\n", uart_name, baud_rate);
+    log_info("Telemetry radio found on %s at baudrate %lu, "
+             "sending configuration string.\n", uart_name, baud_rate);
 
     char* command = commandstr;
     while (*command != 0) {
@@ -158,8 +162,8 @@ void radio_preconfigure_hook(u32 usart, u32 default_baud, char* uart_name)
     busy_wait_for_str(usart, "\x00", WAIT_BETWEEN_COMMANDS);
 
   } else {
-    printf("No telemetry radio found on %s, skipping configuration.\n",
-           uart_name);
+    log_info("No telemetry radio found on %s, skipping configuration.\n",
+             uart_name);
   }
 
   /* Reset the UART to the original baudrate. */
@@ -169,5 +173,6 @@ void radio_preconfigure_hook(u32 usart, u32 default_baud, char* uart_name)
 
 void radio_setup()
 {
-    SETTING("telemetry_radio", "configuration_string", commandstr, TYPE_STRING);
+  SETTING("telemetry_radio", "configuration_string", commandstr, TYPE_STRING);
 }
+

--- a/src/peripherals/usart.c
+++ b/src/peripherals/usart.c
@@ -15,8 +15,9 @@
 #include <libopencm3/stm32/f4/rcc.h>
 #include <libopencm3/stm32/f4/usart.h>
 
+#include <libswiftnav/logging.h>
+
 #include <ch.h>
-#include <stdio.h>
 
 #include "../settings.h"
 #include "usart.h"
@@ -183,9 +184,9 @@ void usarts_enable(u32 ftdi_baud, u32 uarta_baud, u32 uartb_baud, bool do_precon
 
   if (do_preconfigure_hooks) {
 
-    printf("\n\nPiksi Starting...\n"
-       "Firmware Version: " GIT_VERSION "\n" \
-       "Built: " __DATE__ " " __TIME__ "\n");
+    log_info("Piksi Starting...\n");
+    log_info("Firmware Version: " GIT_VERSION "\n");
+    log_info("Built: " __DATE__ " " __TIME__ "\n");
 
     if (uarta_usart.configure_telemetry_radio_on_boot) {
       radio_preconfigure_hook(USART1, uarta_baud, "UARTA");

--- a/src/peripherals/usart_chat.c
+++ b/src/peripherals/usart_chat.c
@@ -11,7 +11,8 @@
  */
 
 #include <string.h>
-#include <stdio.h>
+
+#include <libswiftnav/logging.h>
 
 #include "peripherals/usart.h"
 #include "peripherals/usart_chat.h"
@@ -64,7 +65,7 @@ bool usart_sendwait(enum uart u, const char *send, const char *wait, u32 timeout
     for (i = 0; send[i]; i++) {
       usart_read_dma_timeout(&uart_state(u)->rx, &c, 1, TIMEOUT_CHAR);
       if (c != send[i]) {
-        printf("No echo: '%s'\n", send);
+        log_debug("No echo: '%s'\n", send);
         return false;
       }
     }

--- a/src/peripherals/usart_rx.c
+++ b/src/peripherals/usart_rx.c
@@ -20,6 +20,8 @@
 #include <libopencm3/stm32/f4/rcc.h>
 #include <libopencm3/stm32/f4/usart.h>
 
+#include <libswiftnav/logging.h>
+
 #include "../error.h"
 #include "usart.h"
 
@@ -198,7 +200,7 @@ u32 usart_n_read_dma(usart_rx_dma_state* s)
     n_available = 0;
   else if (n_available > USART_RX_BUFFER_LEN) {
     /* If greater than a whole buffer then we have had an overflow. */
-    printf("ERROR: DMA RX buffer overrun\n");
+    log_error("DMA RX buffer overrun\n");
     n_available = 0;
     s->errors++;
     /* Disable and re-enable the DMA channel to get back to a known good

--- a/src/rtcm.c
+++ b/src/rtcm.c
@@ -128,7 +128,6 @@ static void gen_obs_gps(rtcm_t *rtcm, const navigation_measurement_t *data,
 
     /* L1 phaserange - L1 pseudorange */
     ppr = cp_pr(data->carrier_phase, pr1c / lam1);
-    /*printf("%02d - cp: %g, pr1c: %g, ppr: %g\n", data->prn+1, data->carrier_phase, pr1c/lam1, ppr);*/
     if (ppr1) *ppr1 = ROUND(ppr * lam1 / 0.0005);
   }
   /*lt1 = locktime(data->time, rtcm->lltime[data->sat - 1], data->LLI[0]);*/

--- a/src/sbp.c
+++ b/src/sbp.c
@@ -20,6 +20,7 @@
 #include <libopencm3/stm32/f4/dma.h>
 #include <libopencm3/stm32/f4/usart.h>
 
+#include <libswiftnav/logging.h>
 #include <libswiftnav/edc.h>
 #include <libswiftnav/sbp.h>
 
@@ -303,11 +304,21 @@ void sbp_process_messages()
   }
 }
 
+void __assert_func(const char *_file, int _line, const char *_func,
+                   const char *_expr)
+{
+  log_error("assertion '%s' failed: file '%s', line %d, function: %s\n",
+            _expr, _file, _line, _func);
+  abort();
+}
+
 /** Directs printf's output to the SBP interface */
 int _write(int file, char *ptr, int len)
 {
   switch (file) {
+  /* Direct stdout and stderr to MSG_PRINT */
   case 1:
+  case 2:
     if (len > 255) len = 255;   /* Send maximum of 255 chars at a time */
     sbp_send_msg(MSG_PRINT, len, (u8 *)ptr);
     return len;

--- a/src/sbp_piksi.c
+++ b/src/sbp_piksi.c
@@ -12,7 +12,6 @@
 
 
 
-#include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <limits.h>
@@ -20,9 +19,9 @@
 
 #include "chdebug.h"
 
-#include "error.h"
 #include "sbp_piksi.h"
 
+#include <libswiftnav/logging.h>
 
 void unpack_obs_header(msg_obs_header_t *msg, gps_time_t* t, u8* total, u8* count)
 {
@@ -68,7 +67,7 @@ s8 pack_obs_content(double P, double L, double snr, u16 lock_counter, u8 prn,
 
   s64 P_fp = llround(P * MSG_OBS_P_MULTIPLIER);
   if (P < 0 || P_fp > UINT32_MAX) {
-    printf("ERROR: observation message packing: P integer overflow (%f)\n", P);
+    log_error("observation message packing: P integer overflow (%f)\n", P);
     return -1;
   }
 
@@ -76,7 +75,7 @@ s8 pack_obs_content(double P, double L, double snr, u16 lock_counter, u8 prn,
 
   double Li = floor(L);
   if (Li < INT32_MIN || Li > INT32_MAX) {
-    printf("ERROR: observation message packing: L integer overflow (%f)\n", L);
+    log_error("observation message packing: L integer overflow (%f)\n", L);
     return -1;
   }
 
@@ -87,8 +86,7 @@ s8 pack_obs_content(double P, double L, double snr, u16 lock_counter, u8 prn,
 
   s32 snr_fp = lround(snr * MSG_OBS_SNR_MULTIPLIER);
   if (snr < 0 || snr_fp > UINT8_MAX) {
-    printf("ERROR: observation message packing: SNR integer overflow (%f)\n",
-           snr);
+    log_error("observation message packing: SNR integer overflow (%f)\n", snr);
     return -1;
   }
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -10,13 +10,14 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
+#include <string.h>
+
+#include <libswiftnav/logging.h>
+
 #include "peripherals/usart.h"
+#include "minIni/minIni.h"
 #include "sbp.h"
 #include "settings.h"
-#include "minIni/minIni.h"
-
-#include <string.h>
-#include <stdio.h>
 
 #define SETTINGS_FILE "config"
 
@@ -332,7 +333,7 @@ static void settings_msg_callback(u16 sender_id, u8 len, u8 msg[], void* context
   return;
 
 error:
-  printf("Error in settings read message\n");
+  log_error("Error in settings read message\n");
 }
 
 static void settings_read_by_index_callback(u16 sender_id, u8 len, u8 msg[], void* context)
@@ -344,7 +345,7 @@ static void settings_read_by_index_callback(u16 sender_id, u8 len, u8 msg[], voi
   u8 buflen = 0;
 
   if (len != 2) {
-    printf("Invalid length for settings read by index!");
+    log_error("Invalid length for settings read by index!");
     return;
   }
   u16 index = (msg[1] << 8) | msg[0];
@@ -374,7 +375,7 @@ static void settings_save_callback(u16 sender_id, u8 len, u8 msg[], void* contex
   (void)sender_id; (void) context; (void)len; (void)msg;
 
   if (f == -1) {
-    printf("Error opening config file!\n");
+    log_error("Error opening config file!\n");
     return;
   }
 
@@ -387,19 +388,21 @@ static void settings_save_callback(u16 sender_id, u8 len, u8 msg[], void* contex
       /* New section, write section header */
       sec = s->section;
       i = snprintf(buf, sizeof(buf), "[%s]\n", sec);
-      if (cfs_write(f, buf, i) != i)
-        printf("Error writing to config file!\n");
+      if (cfs_write(f, buf, i) != i) {
+        log_error("Error writing to config file!\n");
+      }
     }
 
     /* Write setting */
     i = snprintf(buf, sizeof(buf), "%s=", s->name);
     i += s->type->to_string(s->type->priv, &buf[i], sizeof(buf) - i - 1, s->addr, s->len);
     buf[i++] = '\n';
-    if (cfs_write(f, buf, i) != i)
-      printf("Error writing to config file!\n");
+    if (cfs_write(f, buf, i) != i) {
+      log_error("Error writing to config file!\n");
+    }
   }
 
   cfs_close(f);
-  printf("Wrote settings to config file.\n");
+  log_info("Wrote settings to config file.\n");
 }
 

--- a/src/system_monitor.c
+++ b/src/system_monitor.c
@@ -10,11 +10,11 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include <stdio.h>
 #include <string.h>
 
 #include <ch.h>
 
+#include <libswiftnav/logging.h>
 #include <libswiftnav/sbp_messages.h>
 #include <libswiftnav/dgnss_management.h>
 
@@ -129,8 +129,9 @@ static msg_t system_monitor_thread(void *arg)
     send_thread_states();
 
     u32 err = nap_error_rd_blocking();
-    if (err)
-      printf("Error: 0x%08X\n", (unsigned int)err);
+    if (err) {
+      log_error("SwiftNAP Error: 0x%08X\n", (unsigned int)err);
+    }
   }
 
   return 0;

--- a/src/timing.c
+++ b/src/timing.c
@@ -11,10 +11,10 @@
  */
 
 #include <math.h>
-#include <stdio.h>
 #include <string.h>
 #include <time.h>
 
+#include <libswiftnav/logging.h>
 #include <libswiftnav/linear_algebra.h>
 #include <libswiftnav/sbp.h>
 
@@ -57,7 +57,7 @@ void set_time(time_quality_t quality, gps_time_t t)
 
     time_quality = quality;
     time_t unix_t = gps2time(t);
-    printf("Time set to: %s (quality=%d)\n", ctime(&unix_t), quality);
+    log_info("Time set to: %s (quality=%d)\n", ctime(&unix_t), quality);
   }
 }
 

--- a/src/track.c
+++ b/src/track.c
@@ -11,7 +11,6 @@
  */
 
 #include <math.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -22,6 +21,7 @@
 #include "peripherals/random.h"
 
 #include <libswiftnav/constants.h>
+#include <libswiftnav/logging.h>
 
 
 u8 n_rollovers = 20;
@@ -220,8 +220,8 @@ void tracking_channel_update(u8 channel)
 
       if (TOW_ms > 0 && chan->TOW_ms != TOW_ms) {
         if (chan->TOW_ms > 0) {
-          printf("PRN %d TOW mismatch: %ld, %lu\n",
-              chan->prn+1, chan->TOW_ms, TOW_ms);
+          log_warn("PRN %d TOW mismatch: %ld, %lu\n",
+                   chan->prn+1, chan->TOW_ms, TOW_ms);
         }
         chan->TOW_ms = TOW_ms;
       }


### PR DESCRIPTION
Replace `printf()` with calls to `log_error`, `log_warn` and `log_info` to annotate different messages with a log level.

For now these macros just map back to `printf` with a prefix to identify the log level but now the various messages going through the logging calls its easy to change the handling of different message levels on the backend.

\cc: @gsmcmullin @denniszollo @mookerji 