### PR TITLE
Base observation handling tweaks

### DIFF
--- a/src/base_obs.c
+++ b/src/base_obs.c
@@ -280,6 +280,11 @@ static void obs_callback(u16 sender_id, u8 len, u8 msg[], void* context)
   /* Pull out the contents of the message. */
   msg_obs_content_t *obs = (msg_obs_content_t *)(msg + sizeof(msg_obs_header_t));
   for (u8 i=0; i<obs_in_msg; i++) {
+    /* Check the PRN is valid. e.g. simulation mode outputs test observations
+     * with PRNs >200. */
+    if (obs[i].prn > 31) {
+      continue;
+    }
     /* Check if we have an ephemeris for this satellite, we will need this to
      * fill in satellite position etc. parameters. */
     if (ephemeris_good(&es[obs[i].prn], t)) {

--- a/src/base_obs.h
+++ b/src/base_obs.h
@@ -42,6 +42,9 @@ typedef struct {
   double sat_dists[MAX_CHANNELS];
 } obss_t;
 
+/** Maximum difference between observation times to consider them matched. */
+#define TIME_MATCH_THRESHOLD 2e-3
+
 /* \} */
 
 extern Mutex base_obs_lock;

--- a/src/solution.h
+++ b/src/solution.h
@@ -29,8 +29,6 @@ typedef enum {
   FILTER_FIXED,
 } dgnss_filter_t;
 
-/** Maximum difference between observation times to consider them matched. */
-#define TIME_MATCH_THRESHOLD 2e-3
 /** Maximum time that an observation will be propagated for to align it with a
  * solution epoch before it is discarded.  */
 #define OBS_PROPAGATION_LIMIT 10e-3


### PR DESCRIPTION
 - Better warning message
 - Fixes small error with time matching logic
 - Filters out PRNs >31, fixes crash on receiving simulated observations

@denniszollo