### PR TITLE
Simulator fixes

### DIFF
--- a/src/simulator.h
+++ b/src/simulator.h
@@ -21,13 +21,15 @@
  * \{ */
 
 /** \defgroup simulator GPS Simulator
-* Functions used to simulate PVT and baseline fixes for hardware-in-the-loop testing.
-* Generates GPS output from Piksi as if the GPS was performing solutions.
+* Functions used to simulate PVT and baseline fixes for hardware-in-the-loop
+* testing. Generates GPS output from Piksi as if the GPS was performing
+* solutions.
 *
 * Expected usage:
 * First call `simulation_setup()`,
 * To update the simulation, call `simulation_step()`
-* and to get the current simulated data, call any of the `simulation_current_xxx` functions
+* and to get the current simulated data, call any of the
+* `simulation_current_xxx` functions
 *
  * \{ */
 

--- a/src/solution.c
+++ b/src/solution.c
@@ -491,7 +491,7 @@ static msg_t solution_thread(void *arg)
 
         u8 flags = simulation_enabled_for(SIMULATION_MODE_RTK) ? 1 : 0;
 
-        solution_send_baseline(&soln->time,
+        solution_send_baseline(&(soln->time),
           simulation_current_num_sats(),
           simulation_current_baseline_ecef(),
           simulation_ref_ecef(), flags);
@@ -499,7 +499,7 @@ static msg_t solution_thread(void *arg)
         double t_check = expected_tow * (soln_freq / obs_output_divisor);
         if (fabs(t_check - (u32)t_check) < TIME_MATCH_THRESHOLD) {
           send_observations(simulation_current_num_sats(),
-            &soln->time, simulation_current_navigation_measurements());
+            &(soln->time), simulation_current_navigation_measurements());
         }
       }
     }

--- a/src/solution.c
+++ b/src/solution.c
@@ -496,8 +496,11 @@ static msg_t solution_thread(void *arg)
           simulation_current_baseline_ecef(),
           simulation_ref_ecef(), flags);
 
-        send_observations(simulation_current_num_sats(),
-          &soln->time, simulation_current_navigation_measurements());
+        double t_check = expected_tow * (soln_freq / obs_output_divisor);
+        if (fabs(t_check - (u32)t_check) < TIME_MATCH_THRESHOLD) {
+          send_observations(simulation_current_num_sats(),
+            &soln->time, simulation_current_navigation_measurements());
+        }
       }
     }
   }

--- a/src/solution.c
+++ b/src/solution.c
@@ -467,36 +467,37 @@ static msg_t solution_thread(void *arg)
 
       simulation_step();
 
+      /* TODO: The simulator's handling of time is a bit crazy. This is a hack
+       * for now but the simulator should be refactored so that it can give the
+       * exact correct solution time output without this nonsense. */
+      gnss_solution *soln = simulation_current_gnss_solution();
+      double expected_tow = \
+        round(soln->time.tow * soln_freq) / soln_freq;
+      soln->time.tow = expected_tow;
+      soln->time = normalize_gps_time(soln->time);
+
       if (simulation_enabled_for(SIMULATION_MODE_PVT)) {
         /* Then we send fake messages. */
-        solution_send_sbp(simulation_current_gnss_solution(),
-                          simulation_current_dops_solution());
-        solution_send_nmea(simulation_current_gnss_solution(),
-                           simulation_current_dops_solution(),
+        solution_send_sbp(soln, simulation_current_dops_solution());
+        solution_send_nmea(soln, simulation_current_dops_solution(),
                            simulation_current_num_sats(),
                            simulation_current_navigation_measurements(),
                            NMEA_GGA_FIX_GPS);
 
       }
 
-      double expected_tow = \
-        round(simulation_current_gnss_solution()->time.tow * soln_freq) / soln_freq;
-      double t_check = expected_tow * (soln_freq / obs_output_divisor);
-
-      if ((simulation_enabled_for(SIMULATION_MODE_FLOAT) ||
-           simulation_enabled_for(SIMULATION_MODE_RTK)) &&
-          fabs(t_check - (u32)t_check) < TIME_MATCH_THRESHOLD) {
+      if (simulation_enabled_for(SIMULATION_MODE_FLOAT) ||
+          simulation_enabled_for(SIMULATION_MODE_RTK)) {
 
         u8 flags = simulation_enabled_for(SIMULATION_MODE_RTK) ? 1 : 0;
 
-        solution_send_baseline(&simulation_current_gnss_solution()->time,
+        solution_send_baseline(&soln->time,
           simulation_current_num_sats(),
           simulation_current_baseline_ecef(),
           simulation_ref_ecef(), flags);
 
         send_observations(simulation_current_num_sats(),
-          &simulation_current_gnss_solution()->time,
-          simulation_current_navigation_measurements());
+          &soln->time, simulation_current_navigation_measurements());
       }
     }
   }


### PR DESCRIPTION
 - Corrects time of simulated solution outputs
 - Respects the `obs_output_divisor` setting when sending simulated observations

@cbeighley @gsmcmullin