### PR TITLE
Update exit code on serial_link KeyboardInterrupts.

### DIFF
--- a/scripts/serial_link.py
+++ b/scripts/serial_link.py
@@ -484,7 +484,12 @@ if __name__ == "__main__":
       # Wait until the timeout has elapsed
       time.sleep(float(args.timeout[0]))
   except KeyboardInterrupt:
-    pass
+    # Callbacks, such as the watchdog timer on SBP_HEARTBEAT call
+    # thread.interrupt_main(), which throw a KeyboardInterrupt
+    # exception. To get the proper error condition, return exit code
+    # of 1. Note that the finally block does get caught since exit
+    # itself throws a SystemExit exception.
+    sys.exit(1)
   finally:
     if log_file:
       log_file.close()


### PR DESCRIPTION
We have a watchdog timer on Piksi heartbeats, but the
KeyboardInterrupts need return with `exit(1)` for us to see the error.

/cc @fnoble @mfine @cbeighley