### PR TITLE
Firmware update fixes

### DIFF
--- a/scripts/flash.py
+++ b/scripts/flash.py
@@ -270,15 +270,15 @@ class Flash():
       for addr in reversed(range(start, end, ADDRS_PER_OP)):
         self.status = self.flash_type + " Flash: Programming address" + \
                                         " 0x%08X" % addr
-        if stream:
-          if mod_print == 0 or mod_print != 0 and self.print_count % mod_print == 0:
+        if mod_print == 0 or mod_print != 0 and self.print_count % mod_print == 0:
+          if stream:
             stream.write('\r' + self.status)
             stream.flush()
-            self.print_count = 1
-            if elapsed_ops_cb != None:
-              elapsed_ops_cb(self.ihx_elapsed_ops)
-          else:
-            self.print_count += 1
+          self.print_count = 1
+          if elapsed_ops_cb != None:
+            elapsed_ops_cb(self.ihx_elapsed_ops)
+        else:
+          self.print_count += 1
 
         binary = ihx.tobinstr(start=addr, size=ADDRS_PER_OP)
 

--- a/scripts/flash.py
+++ b/scripts/flash.py
@@ -17,8 +17,13 @@ import time
 import sys
 from itertools import groupby
 import new
+from intelhex import IntelHex
+from threading import Lock
 
+# 0.5 * ADDRS_PER_OP * MAX_QUEUED_OPS (plus SBP overhead) is how much each of
+# the STM32 TX/RX buffers will be filled by the program/read callback messages.
 ADDRS_PER_OP = 128
+MAX_QUEUED_OPS = 20
 
 M25_SR_SRWD = 1 << 7
 M25_SR_BP2  = 1 << 4
@@ -100,37 +105,38 @@ def ihx_n_ops(ihx, addr_sector_map):
 
 # Lock sector of STM flash (0-11).
 def _stm_lock_sector(self, sector):
-  self._waiting_for_callback = True
   msg_buf = struct.pack("B", sector)
+  self.inc_n_queued_ops()
   self.link.send_message(ids.STM_FLASH_LOCK_SECTOR, msg_buf)
-  while self._waiting_for_callback:
+  while self.get_n_queued_ops() > 0:
     time.sleep(0.001)
 
 # Unlock sector of STM flash (0-11).
 def _stm_unlock_sector(self, sector):
-  self._waiting_for_callback = True
   msg_buf = struct.pack("B", sector)
+  self.inc_n_queued_ops()
   self.link.send_message(ids.STM_FLASH_UNLOCK_SECTOR, msg_buf)
-  while self._waiting_for_callback:
+  while self.get_n_queued_ops() > 0:
     time.sleep(0.001)
 
 # Write M25 status register (8 bits).
 def _m25_write_status(self, sr):
-  self._waiting_for_callback = True
   msg_buf = struct.pack("B", sr)
+  self.inc_n_queued_ops()
   self.link.send_message(ids.M25_FLASH_WRITE_STATUS, msg_buf)
-  while self._waiting_for_callback:
+  while self.get_n_queued_ops() > 0:
     time.sleep(0.001)
 
 class Flash():
 
   def __init__(self, link, flash_type):
+    self._n_queued_ops = 0
+    self.nqo_lock = Lock()
     self.stopped = False
     self.status = ''
     self.link = link
     self.flash_type = flash_type
-    self._waiting_for_callback = False
-    self._read_callback_data = []
+    self._read_callback_ihx = IntelHex()
     self.link.add_callback(ids.FLASH_DONE, self._done_callback)
     self.link.add_callback(ids.FLASH_READ, self._read_callback)
     self.ihx_elapsed_ops = 0 # N operations finished in self.write_ihx
@@ -156,6 +162,19 @@ class Flash():
     else:
       raise ValueError("flash_type must be \"STM\" or \"M25\"")
 
+  def inc_n_queued_ops(self):
+    self.nqo_lock.acquire()
+    self._n_queued_ops += 1
+    self.nqo_lock.release()
+
+  def dec_n_queued_ops(self):
+    self.nqo_lock.acquire()
+    self._n_queued_ops -= 1
+    self.nqo_lock.release()
+
+  def get_n_queued_ops(self):
+    return self._n_queued_ops
+
   def __del__(self):
     if not self.stopped:
       self.stop()
@@ -174,35 +193,24 @@ class Flash():
              (self.flash_type, sector)
       raise Warning(text)
     msg_buf = struct.pack("BB", self.flash_type_byte, sector)
-    self._waiting_for_callback = True
+    self.inc_n_queued_ops()
     self.link.send_message(ids.FLASH_ERASE, msg_buf)
-    while self._waiting_for_callback == True:
+    while self.get_n_queued_ops() > 0:
       time.sleep(0.001)
 
   def program(self, address, data):
     msg_buf = struct.pack("B", self.flash_type_byte)
     msg_buf += struct.pack("<I", address)
     msg_buf += struct.pack("B", len(data))
-    self._waiting_for_callback = True
+    self.inc_n_queued_ops()
     self.link.send_message(ids.FLASH_PROGRAM, msg_buf + data)
-    while self._waiting_for_callback == True:
-      time.sleep(0.001)
 
   def read(self, address, length):
     msg_buf = struct.pack("B", self.flash_type_byte)
     msg_buf += struct.pack("<I", address)
     msg_buf += struct.pack("B", length)
-    self._waiting_for_callback = True
+    self.inc_n_queued_ops()
     self.link.send_message(ids.FLASH_READ, msg_buf)
-    while self._waiting_for_callback == True:
-      time.sleep(0.001)
-    assert address == self._read_callback_address, \
-        "Address received (0x%08x) does not match address sent (0x%08x)" % \
-        (self._read_callback_address, address)
-    assert length == self._read_callback_length, \
-        "Length received (0x%08x) does not match length sent (0x%08x)" % \
-        (self._read_callback_length, length)
-    return self._read_callback_data
 
   # Returned for all commands other than read. Returned for read if failed.
   def _done_callback(self, data):
@@ -211,21 +219,28 @@ class Flash():
     if (ret != 0):
       print "Flash operation returned error (%d)" % ret
 
-    self._waiting_for_callback = False
+    self.dec_n_queued_ops()
+    assert self.get_n_queued_ops() >= 0, \
+      "Number of queued flash operations is negative"
 
   # Returned for read if successful.
   def _read_callback(self, data):
     # 4 bytes addr, 1 byte length, length bytes data
-    self._read_callback_address = struct.unpack('<I', data[0:4])[0]
-    self._read_callback_length = struct.unpack('B', data[4])[0]
-    length = self._read_callback_length
-    self._read_callback_data = list(struct.unpack(str(length)+'B', data[5:]))
-    self._waiting_for_callback = False
+    address = struct.unpack('<I', data[0:4])[0]
+    length = struct.unpack('B', data[4])[0]
+
+    self._read_callback_ihx.puts(address, data[5:])
+
+    self.dec_n_queued_ops()
+    assert self.get_n_queued_ops() >= 0, \
+      "Number of queued flash operations is negative"
 
   def write_ihx(self, ihx, stream=None, mod_print=0):
     self.ihx_total_ops = ihx_n_ops(ihx, self.addr_sector_map)
     self.ihx_elapsed_ops = 0
     self.count = 0
+
+    start_time = time.time()
 
     # Erase sectors
     ihx_addrs = ihx_ranges(ihx)
@@ -239,11 +254,9 @@ class Flash():
     if stream:
       stream.write('\n')
 
-    # Write data to flash and validate
-    start_time = time.time()
-    # STM's lowest address is used by bootloader to check that the application
-    # is valid, so program from high to low to ensure this address is programmed
-    # last.
+    # Write data to flash and read back to later validate. STM's lowest address
+    # is used by bootloader to check that the application is valid, so program
+    # from high to low to ensure this address is programmed last.
     for start, end in reversed(ihx_addrs):
       for addr in reversed(range(start, end, ADDRS_PER_OP)):
         self.status = self.flash_type + " Flash: Programming address" + \
@@ -255,13 +268,32 @@ class Flash():
             self.count = 1
           else:
             self.count += 1
+
         binary = ihx.tobinstr(start=addr, size=ADDRS_PER_OP)
+
+        while self.get_n_queued_ops() >= MAX_QUEUED_OPS:
+          time.sleep(0.001)
         self.program(addr, binary)
         self.ihx_elapsed_ops += 1
-        flash_readback = self.read(addr, ADDRS_PER_OP)
+
+        while self.get_n_queued_ops() >= MAX_QUEUED_OPS:
+          time.sleep(0.001)
+        self.read(addr, ADDRS_PER_OP)
         self.ihx_elapsed_ops += 1
-        if flash_readback != map(ord, binary):
-          raise Exception('Data read from flash != Data written to flash')
+
+    # Verify that data written to flash matches data read from flash.
+    while self.get_n_queued_ops() > 0:
+      time.sleep(0.001)
+    for start, end in reversed(ihx_addrs):
+      if self._read_callback_ihx.gets(start, end-start+1) != \
+          ihx.gets(start, end-start+1):
+        for i in range(start, end):
+          r = self._read_callback_ihx.gets(i,1)
+          p = ihx.gets(i,1)
+          if r != p:
+            raise Exception('Data read from flash != Data programmed to flash'
+              ('Addr: %x, Programmed: %x, Read: %x' % (i,r,p)).upper())
+
     self.status = self.flash_type + " Flash: Successfully programmed and " + \
                                     "verified, total time = %d seconds" % \
                                     int(time.time()-start_time)

--- a/scripts/flash.py
+++ b/scripts/flash.py
@@ -204,7 +204,7 @@ def _stm_unlock_sector(self, sector):
   sector : int
       Sector of STM flash to unlock (> 0, <= 11).
   """
-  if not 0 <= sector <+ 11:
+  if not 0 <= sector <= 11:
     raise ValueError("Must have 0 <= sector <= 11, received %d" % sector)
   msg_buf = struct.pack("B", sector)
   self.inc_n_queued_ops()

--- a/scripts/flash.py
+++ b/scripts/flash.py
@@ -89,13 +89,15 @@ def sectors_used(addrs, addr_sector_map):
   return sorted(list(sectors))
 
 # Operations it will take to write a particular hexfile using flash.write_ihx.
-def ihx_n_ops(ihx, addr_sector_map):
+def ihx_n_ops(ihx, addr_sector_map, erase=True):
   ihx_addrs = ihx_ranges(ihx)
   erase_ops = len(sectors_used(ihx_addrs, addr_sector_map))
   program_ops_addr_args = [range(s,e,ADDRS_PER_OP) for s,e in ihx_addrs]
   program_ops = sum([len(l) for l in program_ops_addr_args])
   read_ops = program_ops # One read callback for every program callback.
-  return erase_ops + program_ops + read_ops
+  if erase:
+    return erase_ops + program_ops + read_ops
+  return program_ops + read_ops
 
 # Defining separate functions to lock/unlock STM sectors and to read/write M25
 # status register, as there isn't a great way to define lock/unlock sector
@@ -163,8 +165,8 @@ class Flash():
                        % flash_type)
 
   # Operations it will take to write a particular hexfile using self.write_ihx.
-  def ihx_n_ops(self, ihx):
-    return ihx_n_ops(ihx, self.addr_sector_map)
+  def ihx_n_ops(self, ihx, erase=True):
+    return ihx_n_ops(ihx, self.addr_sector_map, erase)
 
   def inc_n_queued_ops(self):
     self.nqo_lock.acquire()
@@ -239,25 +241,27 @@ class Flash():
     assert self.get_n_queued_ops() >= 0, \
       "Number of queued flash operations is negative"
 
-  def write_ihx(self, ihx, stream=None, mod_print=0, elapsed_ops_cb=None):
+  def write_ihx(self, ihx, stream=None, mod_print=0, elapsed_ops_cb=None, erase=True):
     self.ihx_elapsed_ops = 0
     self.print_count = 0
 
     start_time = time.time()
 
-    # Erase sectors
     ihx_addrs = ihx_ranges(ihx)
-    for sector in sectors_used(ihx_addrs, self.addr_sector_map):
-      self.status = self.flash_type + " Flash: Erasing sector %d" % sector
+
+    # Erase sectors
+    if erase:
+      for sector in sectors_used(ihx_addrs, self.addr_sector_map):
+        self.status = self.flash_type + " Flash: Erasing sector %d" % sector
+        if stream:
+          stream.write('\r' + self.status)
+          stream.flush()
+        self.erase_sector(sector)
+        self.ihx_elapsed_ops += 1
+        if elapsed_ops_cb != None:
+          elapsed_ops_cb(self.ihx_elapsed_ops)
       if stream:
-        stream.write('\r' + self.status)
-        stream.flush()
-      self.erase_sector(sector)
-      self.ihx_elapsed_ops += 1
-      if elapsed_ops_cb != None:
-        elapsed_ops_cb(self.ihx_elapsed_ops)
-    if stream:
-      stream.write('\n')
+        stream.write('\n')
 
     # Write data to flash and read back to later validate. STM's lowest address
     # is used by bootloader to check that the application is valid, so program

--- a/scripts/flash.py
+++ b/scripts/flash.py
@@ -39,6 +39,19 @@ M25_RESTRICTED_SECTORS = [15]
 M25_N_SECTORS = 16
 
 def stm_addr_sector_map(addr):
+  """
+  Map an STM32F4 flash address to a sector.
+
+  Parameters
+  ----------
+  addr : int
+      STM flash address.
+
+  Returns
+  -------
+  out : int
+      STM flash sector.
+  """
   if   addr >= 0x08000000 and addr < 0x08004000:
     return 0
   elif addr >= 0x08004000 and addr < 0x08008000:
@@ -68,11 +81,37 @@ def stm_addr_sector_map(addr):
     return None
 
 def m25_addr_sector_map(addr):
+  """
+  Map an M25 flash address to a sector.
+
+  Parameters
+  ----------
+  addr : int
+      M25 flash address.
+
+  Returns
+  -------
+  out : int
+      M25 flash sector.
+  """
   if addr < 0 or addr > 0xFFFFF:
     raise IndexError("Attempted to access flash memory at (%s) outside of range (wrong firmware file?)." % hex(addr))
   return addr >> 16
 
 def ihx_ranges(ihx):
+  """
+  Find occupied address ranges in intelhex.IntelHex object.
+
+  Parameters
+  ----------
+  ihx : intelhex.Intelhex
+      intelhex.IntelHex object to find occupied address ranges of.
+
+  Returns
+  -------
+  out : list[(int, int), (int, int), ...]
+      List of min/max tuples of occupied address ranges.
+  """
   def first_last(x):
     first = x.next()
     last = first
@@ -83,13 +122,47 @@ def ihx_ranges(ihx):
           groupby(enumerate(ihx.addresses()), lambda (i, x) : i - x)]
 
 def sectors_used(addrs, addr_sector_map):
+  """
+  Given a list of min/max address pairs, find the sectors they occupy.
+
+  Parameters
+  ----------
+  addrs : list[(int, int), (int, int), ...]
+      List of min/max tuples of occupied address ranges to be mapped to sectors.
+  addr_sector_map : function
+      Function that maps an address to a sector.
+
+  Returns
+  -------
+  out : list[int]
+      List of sectors in which the passed addresses reside in the passed
+      address sector map.
+  """
   sectors = set()
   for s, e in addrs:
     sectors |= set(range(addr_sector_map(s), addr_sector_map(e)+1))
   return sorted(list(sectors))
 
-# Operations it will take to write a particular hexfile using flash.write_ihx.
 def ihx_n_ops(ihx, addr_sector_map, erase=True):
+  """
+  Find the number of sent SBP messages (erase, program, read) Flash.write_ihx
+  will require to write a particular intelhex.IntelHex.
+
+  Parameters
+  ----------
+  ihx : intelhex.Intelhex
+      intelhex.IntelHex to be written.
+  addr_sector_map : function
+      Function that maps an address to a sector.
+  erase : bool
+      Include number of erase operations required in total.
+
+  Returns
+  -------
+  out : int
+      Number of sent SBP messages (erase, program, read) Flash.write_ihx will
+      require to write ihx.
+  """
   ihx_addrs = ihx_ranges(ihx)
   erase_ops = len(sectors_used(ihx_addrs, addr_sector_map))
   program_ops_addr_args = [range(s,e,ADDRS_PER_OP) for s,e in ihx_addrs]
@@ -105,24 +178,51 @@ def ihx_n_ops(ihx, addr_sector_map, erase=True):
 # Functions conditionally bound to Flash instance in Flash.__init__(),
 # depending on flash_type.
 
-# Lock sector of STM flash (0-11).
 def _stm_lock_sector(self, sector):
+  """
+  Lock a sector of the STM flash.
+
+  Parameters
+  ----------
+  sector : int
+      Sector of STM flash to lock (> 0, <= 11).
+  """
+  if not 0 <= sector <+ 11:
+    raise ValueError("Must have 0 <= sector <= 11, received %d" % sector)
   msg_buf = struct.pack("B", sector)
   self.inc_n_queued_ops()
   self.link.send_message(ids.STM_FLASH_LOCK_SECTOR, msg_buf)
   while self.get_n_queued_ops() > 0:
     time.sleep(0.001)
 
-# Unlock sector of STM flash (0-11).
 def _stm_unlock_sector(self, sector):
+  """
+  Unlock a sector of the STM flash.
+
+  Parameters
+  ----------
+  sector : int
+      Sector of STM flash to unlock (> 0, <= 11).
+  """
+  if not 0 <= sector <+ 11:
+    raise ValueError("Must have 0 <= sector <= 11, received %d" % sector)
   msg_buf = struct.pack("B", sector)
   self.inc_n_queued_ops()
   self.link.send_message(ids.STM_FLASH_UNLOCK_SECTOR, msg_buf)
   while self.get_n_queued_ops() > 0:
     time.sleep(0.001)
 
-# Write M25 status register (8 bits).
 def _m25_write_status(self, sr):
+  """
+  Write to the M25 status register.
+
+  Parameters
+  ----------
+  sr : int
+      Value to write to the M25 status register (> 0, <= 255).
+  """
+  if not 0 <= sr <= 255:
+    raise ValueError("Must have 0 <= sr <= 255, received %d" % sr)
   msg_buf = struct.pack("B", sr)
   self.inc_n_queued_ops()
   self.link.send_message(ids.M25_FLASH_WRITE_STATUS, msg_buf)
@@ -132,12 +232,28 @@ def _m25_write_status(self, sr):
 class Flash():
 
   def __init__(self, link, flash_type):
+    """
+    Object representing either of the two flashes (STM/M25) on the Piksi,
+    including methods to erase, program, and read.
+
+    Parameters
+    ----------
+    link : serial_link.SerialLink
+      SerialLink to send messages to Piksi over and register callbacks with.
+    flash_type : string
+      Which Piksi flash to interact with ("M25" or "STM").
+
+    Returns
+    -------
+    out : Flash instance
+    """
     self._n_queued_ops = 0
     self.nqo_lock = Lock()
     self.stopped = False
     self.status = ''
     self.link = link
     self.flash_type = flash_type
+    # IntelHex object to store read flash data in that was read from device.
     self._read_callback_ihx = IntelHex()
     self.link.add_callback(ids.FLASH_DONE, self._done_callback)
     self.link.add_callback(ids.FLASH_READ, self._read_callback)
@@ -164,36 +280,82 @@ class Flash():
       raise ValueError("flash_type must be \"STM\" or \"M25\", got \"%s\"" \
                        % flash_type)
 
-  # Operations it will take to write a particular hexfile using self.write_ihx.
   def ihx_n_ops(self, ihx, erase=True):
+    """
+    Find the number of sent SBP messages (erase, program, read) self.write_ihx
+    will require to write a particular intelhex.IntelHex for this instance's
+    flash type.
+
+    Parameters
+    ----------
+    ihx : intelhex.Intelhex
+      intelhex.IntelHex to be written.
+    erase : bool
+      Include number of erase operations required in total.
+
+    Returns
+    -------
+    out : int
+      Number of sent SBP messages (erase, program, read) self.write_ihx will
+      require to write ihx.
+    """
     return ihx_n_ops(ihx, self.addr_sector_map, erase)
 
   def inc_n_queued_ops(self):
+    """
+    Increment the count of queued flash operation SBP messages in the STM's
+    flash in a thread safe way.
+    """
     self.nqo_lock.acquire()
     self._n_queued_ops += 1
     self.nqo_lock.release()
 
   def dec_n_queued_ops(self):
+    """
+    Decrement the count of queued flash operation SBP messages in the STM's
+    flash in a thread safe way.
+    """
     self.nqo_lock.acquire()
     self._n_queued_ops -= 1
     self.nqo_lock.release()
 
   def get_n_queued_ops(self):
+    """
+    Get the current count of queued flash operation SBP messages.
+
+    Returns
+    -------
+    out : int
+      Get the current count of queued flash operation SBP messages.
+    """
     return self._n_queued_ops
 
   def __del__(self):
+    """ Calls self.stop() before instance is deleted. """
     if not self.stopped:
       self.stop()
 
   def stop(self):
+    """ Remove instance callbacks from serial_link.SerialLink. """
     self.stopped = True
     self.link.rm_callback(ids.FLASH_DONE, self._done_callback)
     self.link.rm_callback(ids.FLASH_READ, self._read_callback)
 
   def __str__(self):
+    """ Return flashing status. """
     return self.status
 
   def erase_sector(self, sector, warn=True):
+    """
+    Erase a sector of the flash.
+
+    Parameters
+    ----------
+    sector : int
+      Sector to be erased.
+    warn : bool
+      Warn if sector is restricted and should most likely not be erased.
+    """
     if warn and sector in self.restricted_sectors:
       text = 'Attempting to erase %s flash restricted sector %d' % \
              (self.flash_type, sector)
@@ -205,6 +367,16 @@ class Flash():
       time.sleep(0.001)
 
   def program(self, address, data):
+    """
+    Program a set of addresses of the flash.
+
+    Parameters
+    ----------
+    address : int
+      Starting address of set of addresses to program with data.
+    data : string
+      String of bytes to program to flash starting at address.
+    """
     msg_buf = struct.pack("B", self.flash_type_byte)
     msg_buf += struct.pack("<I", address)
     msg_buf += struct.pack("B", len(data))
@@ -212,14 +384,31 @@ class Flash():
     self.link.send_message(ids.FLASH_PROGRAM, msg_buf + data)
 
   def read(self, address, length):
+    """
+    Read a set of addresses of the flash.
+
+    Parameters
+    ----------
+    address : int
+      Starting address of length addresses to read.
+    length : int
+      Number of addresses to read.
+    """
     msg_buf = struct.pack("B", self.flash_type_byte)
     msg_buf += struct.pack("<I", address)
     msg_buf += struct.pack("B", length)
     self.inc_n_queued_ops()
     self.link.send_message(ids.FLASH_READ, msg_buf)
 
-  # Returned for all commands other than read. Returned for read if failed.
   def _done_callback(self, data):
+    """
+    Handles flash done message sent from device.
+
+    Parameters
+    ----------
+    data : string
+      Binary data sent from device.
+    """
     ret = ord(data)
 
     if (ret != 0):
@@ -229,8 +418,15 @@ class Flash():
     assert self.get_n_queued_ops() >= 0, \
       "Number of queued flash operations is negative"
 
-  # Returned for read if successful.
   def _read_callback(self, data):
+    """
+    Handles flash read message sent from device.
+
+    Parameters
+    ----------
+    data : string
+      Binary data sent from device.
+    """
     # 4 bytes addr, 1 byte length, length bytes data
     address = struct.unpack('<I', data[0:4])[0]
     length = struct.unpack('B', data[4])[0]
@@ -242,6 +438,23 @@ class Flash():
       "Number of queued flash operations is negative"
 
   def write_ihx(self, ihx, stream=None, mod_print=0, elapsed_ops_cb=None, erase=True):
+    """
+    Perform all operations to write an intelhex.IntelHex to the flash
+    and verify.
+
+    Parameters
+    ----------
+    ihx : intelhex.IntelHex
+      intelhex.IntelHex to write to the flash.
+    stream : stream
+      Object implementing write and flush methods to write status updates to.
+    mod_print : int
+      How many loops to run through before writing to stream.
+    elapsed_ops_cb : function
+      Callback to execute every mod_print loops.
+    erase : bool
+      Erase sectors before writing.
+    """
     self.ihx_elapsed_ops = 0
     self.print_count = 0
 

--- a/scripts/flash.py
+++ b/scripts/flash.py
@@ -271,6 +271,8 @@ class Flash():
             stream.write('\r' + self.status)
             stream.flush()
             self.print_count = 1
+            if elapsed_ops_cb != None:
+              elapsed_ops_cb(self.ihx_elapsed_ops)
           else:
             self.print_count += 1
 
@@ -281,16 +283,12 @@ class Flash():
           time.sleep(0.001)
         self.program(addr, binary)
         self.ihx_elapsed_ops += 1
-        if elapsed_ops_cb != None:
-          elapsed_ops_cb(self.ihx_elapsed_ops)
 
         # Read ADDRS_PER_OP addresses
         while self.get_n_queued_ops() >= MAX_QUEUED_OPS:
           time.sleep(0.001)
         self.read(addr, ADDRS_PER_OP)
         self.ihx_elapsed_ops += 1
-        if elapsed_ops_cb != None:
-          elapsed_ops_cb(self.ihx_elapsed_ops)
 
     # Verify that data written to flash matches data read from flash.
     while self.get_n_queued_ops() > 0:

--- a/scripts/flash.py
+++ b/scripts/flash.py
@@ -140,7 +140,6 @@ class Flash():
     self.link.add_callback(ids.FLASH_DONE, self._done_callback)
     self.link.add_callback(ids.FLASH_READ, self._read_callback)
     self.ihx_elapsed_ops = 0 # N operations finished in self.write_ihx
-    self.ihx_total_ops = None # Total operations in self.write_ihx call
     if self.flash_type == "STM":
       self.flash_type_byte = 0
       self.addr_sector_map = stm_addr_sector_map
@@ -160,7 +159,12 @@ class Flash():
       self.n_sectors = M25_N_SECTORS
       self.restricted_sectors = M25_RESTRICTED_SECTORS
     else:
-      raise ValueError("flash_type must be \"STM\" or \"M25\"")
+      raise ValueError("flash_type must be \"STM\" or \"M25\", got \"%s\"" \
+                       % flash_type)
+
+  # Operations it will take to write a particular hexfile using self.write_ihx.
+  def ihx_n_ops(self, ihx):
+    return ihx_n_ops(ihx, self.addr_sector_map)
 
   def inc_n_queued_ops(self):
     self.nqo_lock.acquire()
@@ -235,8 +239,7 @@ class Flash():
     assert self.get_n_queued_ops() >= 0, \
       "Number of queued flash operations is negative"
 
-  def write_ihx(self, ihx, stream=None, mod_print=0):
-    self.ihx_total_ops = ihx_n_ops(ihx, self.addr_sector_map)
+  def write_ihx(self, ihx, stream=None, mod_print=0, elapsed_ops_cb=None):
     self.ihx_elapsed_ops = 0
     self.print_count = 0
 
@@ -251,6 +254,8 @@ class Flash():
         stream.flush()
       self.erase_sector(sector)
       self.ihx_elapsed_ops += 1
+      if elapsed_ops_cb != None:
+        elapsed_ops_cb(self.ihx_elapsed_ops)
     if stream:
       stream.write('\n')
 
@@ -271,15 +276,21 @@ class Flash():
 
         binary = ihx.tobinstr(start=addr, size=ADDRS_PER_OP)
 
+        # Program ADDRS_PER_OP addresses
         while self.get_n_queued_ops() >= MAX_QUEUED_OPS:
           time.sleep(0.001)
         self.program(addr, binary)
         self.ihx_elapsed_ops += 1
+        if elapsed_ops_cb != None:
+          elapsed_ops_cb(self.ihx_elapsed_ops)
 
+        # Read ADDRS_PER_OP addresses
         while self.get_n_queued_ops() >= MAX_QUEUED_OPS:
           time.sleep(0.001)
         self.read(addr, ADDRS_PER_OP)
         self.ihx_elapsed_ops += 1
+        if elapsed_ops_cb != None:
+          elapsed_ops_cb(self.ihx_elapsed_ops)
 
     # Verify that data written to flash matches data read from flash.
     while self.get_n_queued_ops() > 0:

--- a/scripts/flash.py
+++ b/scripts/flash.py
@@ -238,7 +238,7 @@ class Flash():
   def write_ihx(self, ihx, stream=None, mod_print=0):
     self.ihx_total_ops = ihx_n_ops(ihx, self.addr_sector_map)
     self.ihx_elapsed_ops = 0
-    self.count = 0
+    self.print_count = 0
 
     start_time = time.time()
 
@@ -262,12 +262,12 @@ class Flash():
         self.status = self.flash_type + " Flash: Programming address" + \
                                         " 0x%08X" % addr
         if stream:
-          if mod_print == 0 or mod_print != 0 and self.count % mod_print == 0:
+          if mod_print == 0 or mod_print != 0 and self.print_count % mod_print == 0:
             stream.write('\r' + self.status)
             stream.flush()
-            self.count = 1
+            self.print_count = 1
           else:
-            self.count += 1
+            self.print_count += 1
 
         binary = ihx.tobinstr(start=addr, size=ADDRS_PER_OP)
 

--- a/scripts/flash.py
+++ b/scripts/flash.py
@@ -280,6 +280,14 @@ class Flash():
       raise ValueError("flash_type must be \"STM\" or \"M25\", got \"%s\"" \
                        % flash_type)
 
+  def __enter__(self):
+    return self
+
+  def __exit__(self, type, value, traceback):
+    """ Calls self.stop() before instance is deleted. """
+    if not self.stopped:
+      self.stop()
+
   def ihx_n_ops(self, ihx, erase=True):
     """
     Find the number of sent SBP messages (erase, program, read) self.write_ihx
@@ -329,11 +337,6 @@ class Flash():
       Get the current count of queued flash operation SBP messages.
     """
     return self._n_queued_ops
-
-  def __del__(self):
-    """ Calls self.stop() before instance is deleted. """
-    if not self.stopped:
-      self.stop()
 
   def stop(self):
     """ Remove instance callbacks from serial_link.SerialLink. """

--- a/scripts/update_view.py
+++ b/scripts/update_view.py
@@ -100,6 +100,30 @@ class IntelHexFileDialog(HasTraits):
     else:
       self.set_status('Error while selecting file')
 
+class PulsableProgressDialog(ProgressDialog):
+
+  def __init__(self, max, pulsed=False):
+    super(PulsableProgressDialog, self).__init__()
+    self.min = 0
+    self.max = 0
+    self.pulsed = pulsed
+    self.passed_max = max
+
+  def progress(self, count):
+    # Provide user feedback initially via pulse for slow sector erases.
+    if self.pulsed:
+      if count > 20:
+        self.max = self.passed_max
+    else:
+      self.max = self.passed_max
+    self.update(count)
+
+  def reset(self, max, pulsed=False):
+    self.max = 0
+    self.passed_max = max
+    self.pulsed = pulsed
+    self.progress(0)
+
 class UpdateView(HasTraits):
 
   piksi_stm_vers = String('Waiting for Piksi to send settings...')
@@ -169,9 +193,6 @@ class UpdateView(HasTraits):
     self.stm_fw.on_trait_change(self._manage_enables, 'status')
     self.nap_fw = IntelHexFileDialog('M25')
     self.nap_fw.on_trait_change(self._manage_enables, 'status')
-    self.progress_dialog = ProgressDialog(min=0)
-    self.progress_dialog_max = 0
-    self.pulse_progress_initially = False
     self.stream = OutputStream()
     self.get_latest_version_info()
 
@@ -385,13 +406,6 @@ class UpdateView(HasTraits):
       self._write("\nError: Index downloaded from Swift Navigation's website (%s) doesn't contain all keys. Please contact Swift Navigation.\n" % INDEX_URL)
       return
 
-  def update_progress_dialog(self, count):
-    # Provide user feedback via pulse for slow sector erases.
-    if self.pulse_progress_initially:
-      if count > 20:
-        self.progress_dialog.max = self.progress_dialog_max
-    self.progress_dialog.update(count)
-
   # Executed in GUI thread, called from Handler.
   def manage_firmware_updates(self):
     self.updating = True
@@ -402,16 +416,15 @@ class UpdateView(HasTraits):
     if self.erase_stm:
       text = "Erasing STM"
       self._write(text)
-      self.progress_dialog.title = text
       self.create_flash("STM")
       sectors_to_erase = \
           set(range(self.pk_flash.n_sectors)).difference(set(self.pk_flash.restricted_sectors))
-      self.progress_dialog.max = len(sectors_to_erase)
-      self.pulse_progress_initially = False
-      GUI.invoke_later(self.progress_dialog.open)
+      progress_dialog = PulsableProgressDialog(len(sectors_to_erase), False)
+      progress_dialog.title = text
+      GUI.invoke_later(progress_dialog.open)
       erase_count = 0
       for s in sorted(sectors_to_erase):
-        self.update_progress_dialog(erase_count)
+        progress_dialog.progress(erase_count)
         self._write('Erasing %s sector %d' % (self.pk_flash.flash_type,s))
         self.pk_flash.erase_sector(s)
         erase_count += 1
@@ -421,28 +434,28 @@ class UpdateView(HasTraits):
     # Flash STM.
     text = "Updating STM"
     self._write(text)
-    self.progress_dialog.title = text
     self.create_flash("STM")
-    self.progress_dialog.max = 0
-    self.progress_dialog_max = self.pk_flash.ihx_n_ops(self.stm_fw.ihx)
-    self.pulse_progress_initially = True
-    GUI.invoke_later(self.progress_dialog.open)
-    self.pk_flash.write_ihx(self.stm_fw.ihx, self.stream, mod_print=0x10, \
-                            elapsed_ops_cb = self.update_progress_dialog)
+    stm_n_ops = self.pk_flash.ihx_n_ops(self.stm_fw.ihx)
+    progress_dialog.reset(stm_n_ops, True)
+    progress_dialog.title = text
+    GUI.invoke_later(progress_dialog.open)
+    self.pk_flash.write_ihx(self.stm_fw.ihx, self.stream, mod_print=0x80, \
+                            elapsed_ops_cb = progress_dialog.progress)
     self.stop_flash()
     self._write("")
 
     # Flash NAP.
     text = "Updating NAP"
     self._write(text)
-    self.progress_dialog.title = text
     self.create_flash("M25")
-    self.progress_dialog.max = 0
-    self.progress_dialog_max = self.pk_flash.ihx_n_ops(self.nap_fw.ihx)
-    self.pulse_progress_initially = True
-    GUI.invoke_later(self.progress_dialog.open)
-    self.pk_flash.write_ihx(self.nap_fw.ihx, self.stream, mod_print=0x10, \
-                            elapsed_ops_cb = self.update_progress_dialog)
+    nap_n_ops = self.pk_flash.ihx_n_ops(self.nap_fw.ihx)
+    progress_dialog.reset(nap_n_ops, True)
+    progress_dialog.title = text
+    GUI.invoke_later(progress_dialog.open)
+    self.pk_flash.write_ihx(self.nap_fw.ihx, self.stream, mod_print=0x80, \
+                            elapsed_ops_cb = progress_dialog.progress)
+    progress_dialog.close()
+    del progress_dialog
     self.stop_flash()
     self._write("")
 

--- a/scripts/update_view.py
+++ b/scripts/update_view.py
@@ -59,21 +59,47 @@ class IntelHexFileDialog(HasTraits):
              )
 
   def __init__(self, flash_type):
+    """
+    Pop-up file dialog to choose an IntelHex file, with status and button to
+    display in traitsui window.
+
+    Parameters
+    ----------
+    flash_type : string
+      Which Piksi flash to interact with ("M25" or "STM").
+    """
     if not flash_type=='M25' and not flash_type=='STM':
       raise ValueError("flash_type must be 'M25' or 'STM'")
     self._flash_type = flash_type
     self.ihx = None
 
-  def set_status(self, status):
+  def clear(self, status):
+    """
+    Set text of status box and clear IntelHex file.
+
+    Parameters
+    ----------
+    status : string
+      Error text to replace status box text with.
+    """
     self.ihx = None
     self.status = status
 
   def load_ihx(self, filepath):
+    """
+    Load IntelHex file and set status to indicate if file was
+    successfully loaded.
+
+    Parameters
+    ----------
+    filepath : string
+      Path to IntelHex file.
+    """
     try:
       self.ihx = IntelHex(filepath)
       self.status = os.path.split(filepath)[1]
     except HexRecordError:
-      self.set_status('Error: File is not a valid Intel HEX File')
+      self.clear('Error: File is not a valid Intel HEX File')
 
     # Check that address ranges are valid for self._flash_type.
     ihx_addrs = flash.ihx_ranges(self.ihx)
@@ -81,16 +107,17 @@ class IntelHexFileDialog(HasTraits):
       try:
         sectors = flash.sectors_used(ihx_addrs, flash.m25_addr_sector_map)
       except IndexError:
-        self.set_status('Error: HEX File contains restricted address ' + \
+        self.clear('Error: HEX File contains restricted address ' + \
                         '(STM Firmware File Chosen?)')
     elif self._flash_type == "STM":
       try:
         sectors = flash.sectors_used(ihx_addrs, flash.stm_addr_sector_map)
       except:
-        self.set_status('Error: HEX File contains restricted address ' + \
+        self.clear('Error: HEX File contains restricted address ' + \
                         '(NAP Firmware File Chosen?)')
 
   def _choose_fw_fired(self):
+    """ Activate file dialog window to choose IntelHex firmware file. """
     dialog = FileDialog(label='Choose Firmware File',
                         action='open', wildcard=self.file_wildcard)
     dialog.open()
@@ -98,11 +125,21 @@ class IntelHexFileDialog(HasTraits):
       filepath = os.path.join(dialog.directory, dialog.filename)
       self.load_ihx(filepath)
     else:
-      self.set_status('Error while selecting file')
+      self.clear('Error while selecting file')
 
 class PulsableProgressDialog(ProgressDialog):
 
   def __init__(self, max, pulsed=False):
+    """
+    Pop-up window for showing a process's progress.
+
+    Parameters
+    ----------
+    max : int
+      Maximum value of the progress bar.
+    pulsed : bool
+      Show non-partial progress initially.
+    """
     super(PulsableProgressDialog, self).__init__()
     self.min = 0
     self.max = 0
@@ -110,16 +147,26 @@ class PulsableProgressDialog(ProgressDialog):
     self.passed_max = max
 
   def progress(self, count):
+    """
+    Update progress of progress bar. If pulsing initially, wait until count
+    is at least 12 before changing to discrete progress bar.
+
+    Parameters
+    ----------
+    count : int
+      Current value of progress.
+    """
     # Provide user feedback initially via pulse for slow sector erases.
     if self.pulsed:
-      if count > 20:
-        self.max = self.passed_max
-        GUI.invoke_later(self.update, count)
+      if count > 12:
+        self.max = 100
+        GUI.invoke_later(self.update, int(100*float(count)/self.passed_max))
     else:
-      self.max = self.passed_max
-      GUI.invoke_later(self.update, count)
+      self.max = 100
+      GUI.invoke_later(self.update, int(100*float(count)/self.passed_max))
 
   def close(self):
+    """ Close progress bar window. """
     GUI.invoke_after(0.1, super(PulsableProgressDialog, self).close)
     sleep(0.2)
 
@@ -180,6 +227,16 @@ class UpdateView(HasTraits):
   )
 
   def __init__(self, link, prompt=True):
+    """
+    Traits tab with UI for updating Piksi firmware.
+
+    Parameters
+    ----------
+    link : serial_link.SerialLink
+      Link for SBP transfer to/from Piksi.
+    prompt : bool
+      Prompt user to update console/firmware if out of date.
+    """
     self.link = link
     self.settings = {}
     self.prompt = prompt
@@ -196,6 +253,7 @@ class UpdateView(HasTraits):
     self.get_latest_version_info()
 
   def _manage_enables(self):
+    """ Manages whether traits widgets are enabled in the UI or not. """
     if self.updating == True or self.downloading == True:
       self.update_en = False
       self.download_fw_en = False
@@ -212,17 +270,32 @@ class UpdateView(HasTraits):
       self.erase_en = True
 
   def _updating_changed(self):
+    """ Handles self.updating trait being changed. """
     self._manage_enables()
 
   def _downloading_changed(self):
+    """ Handles self.downloading trait being changed. """
     self._manage_enables()
 
   def _write(self, text):
+    """
+    Stream style write function. Allows flashing debugging messages to be
+    routed to embedded text console.
+
+    Parameters
+    ----------
+    text : string
+      Text to be written to screen.
+    """
     self.stream.write(text)
     self.stream.write('\n')
     self.stream.flush()
 
   def _update_firmware_fired(self):
+    """
+    Handle update_firmware button. Starts thread so as not to block the GUI
+    thread.
+    """
     try:
       if self._firmware_update_thread.is_alive():
         return
@@ -233,7 +306,7 @@ class UpdateView(HasTraits):
     self._firmware_update_thread.start()
 
   def _download_firmware(self):
-
+    """ Download latest firmware from swiftnav.com. """
     self._write('')
 
     # Check that we received the index file from the website.
@@ -244,8 +317,8 @@ class UpdateView(HasTraits):
     self.downloading = True
 
     status = 'Downloading Newest Firmware...'
-    self.nap_fw.set_status(status)
-    self.stm_fw.set_status(status)
+    self.nap_fw.clear(status)
+    self.stm_fw.clear(status)
     self._write(status)
 
     # Get firmware files from Swift Nav's website, save to disk, and load.
@@ -255,13 +328,13 @@ class UpdateView(HasTraits):
       self._write('Saved file to %s' % filepath)
       self.nap_fw.load_ihx(filepath)
     except AttributeError:
-      self.nap_fw.set_status("Error downloading firmware")
+      self.nap_fw.clear("Error downloading firmware")
       self._write("Error downloading firmware: index file not downloaded yet")
     except KeyError:
-      self.nap_fw.set_status("Error downloading firmware")
+      self.nap_fw.clear("Error downloading firmware")
       self._write("Error downloading firmware: URL not present in index")
     except URLError:
-      self.nap_fw.set_status("Error downloading firmware")
+      self.nap_fw.clear("Error downloading firmware")
       self._write("Error: Failed to download latest NAP firmware from Swift Navigation's website")
 
     try:
@@ -270,18 +343,22 @@ class UpdateView(HasTraits):
       self._write('Saved file to %s' % filepath)
       self.stm_fw.load_ihx(filepath)
     except AttributeError:
-      self.stm_fw.set_status("Error downloading firmware")
+      self.stm_fw.clear("Error downloading firmware")
       self._write("Error downloading firmware: index file not downloaded yet")
     except KeyError:
-      self.stm_fw.set_status("Error downloading firmware")
+      self.stm_fw.clear("Error downloading firmware")
       self._write("Error downloading firmware: URL not present in index")
     except URLError:
-      self.stm_fw.set_status("Error downloading firmware")
+      self.stm_fw.clear("Error downloading firmware")
       self._write("Error: Failed to download latest STM firmware from Swift Navigation's website")
 
     self.downloading = False
 
   def _download_firmware_fired(self):
+    """
+    Handle download_firmware button. Starts thread so as not to block the GUI
+    thread.
+    """
     try:
       if self._download_firmware_thread.is_alive():
         return
@@ -292,6 +369,11 @@ class UpdateView(HasTraits):
     self._download_firmware_thread.start()
 
   def compare_versions(self):
+    """
+    To be called after latest Piksi firmware info has been received from
+    device, to decide if current firmware on Piksi is out of date. Starts a
+    thread so as not to block GUI thread.
+    """
     try:
       if self._compare_versions_thread.is_alive():
         return
@@ -302,7 +384,11 @@ class UpdateView(HasTraits):
     self._compare_versions_thread.start()
 
   def _compare_versions(self):
-
+    """
+    Compares version info between received firmware version / current console
+    and firmware / console info from website to decide if current firmware or
+    console is out of date. Prompt user to update if so.
+    """
     # Check that settings received from Piksi contain FW versions.
     try:
       self.piksi_stm_vers = \
@@ -378,7 +464,10 @@ class UpdateView(HasTraits):
         fw_update_prompt.run()
 
   def get_latest_version_info(self):
-
+    """
+    Get latest firmware / console version from website. Starts thread so as not
+    to block the GUI thread.
+    """
     try:
       if self._get_latest_version_info_thread.is_alive():
         return
@@ -389,7 +478,7 @@ class UpdateView(HasTraits):
     self._get_latest_version_info_thread.start()
 
   def _get_latest_version_info(self):
-
+    """ Get latest firmware / console version from website. """
     try:
       self.update_dl = UpdateDownloader()
     except URLError:
@@ -407,6 +496,10 @@ class UpdateView(HasTraits):
 
   # Executed in GUI thread, called from Handler.
   def manage_firmware_updates(self):
+    """
+    Update Piksi firmware. Erase entire STM flash (other than bootloader)
+    if so directed. Flash NAP only if new firmware is available.
+    """
     self.updating = True
 
     self._write('')
@@ -478,7 +571,15 @@ class UpdateView(HasTraits):
     self.updating = False
 
   def create_flash(self, flash_type):
+    """
+    Create flash.Flash instance and set Piksi into bootloader mode, prompting
+    user to reset if necessary.
 
+    Parameter
+    ---------
+    flash_type : string
+      Either "STM" or "M25".
+    """
     # Reset device if the application is running to put into bootloader mode.
     self.link.send_message(ids.RESET, '')
 
@@ -517,5 +618,8 @@ class UpdateView(HasTraits):
     self.pk_flash = flash.Flash(self.link, flash_type)
 
   def stop_flash(self):
+    """
+    Stop Flash and Bootloader instances (removes callback from SerialLink).
+    """
     self.pk_flash.stop()
     self.pk_boot.stop()

--- a/scripts/update_view.py
+++ b/scripts/update_view.py
@@ -22,7 +22,7 @@ from traits.api import HasTraits, Event, String, Button, Instance, Int, Bool, \
 from traitsui.api import View, Handler, Action, Item, TextEditor, VGroup, \
                          UItem, InstanceEditor, VSplit, HSplit, HGroup, \
                          BooleanEditor
-from pyface.api import GUI, FileDialog, OK
+from pyface.api import GUI, FileDialog, OK, ProgressDialog
 
 from version import VERSION as CONSOLE_VERSION
 import bootload
@@ -45,6 +45,7 @@ icon = ImageResource('icon',
          search_path=['images', os.path.join(basedir, 'images')])
 
 INDEX_URL = 'http://downloads.swiftnav.com/index.json'
+
 
 class IntelHexFileDialog(HasTraits):
 
@@ -168,6 +169,9 @@ class UpdateView(HasTraits):
     self.stm_fw.on_trait_change(self._manage_enables, 'status')
     self.nap_fw = IntelHexFileDialog('M25')
     self.nap_fw.on_trait_change(self._manage_enables, 'status')
+    self.progress_dialog = ProgressDialog(min=0)
+    self.progress_dialog_max = 0
+    self.pulse_progress_initially = False
     self.stream = OutputStream()
     self.get_latest_version_info()
 
@@ -381,26 +385,65 @@ class UpdateView(HasTraits):
       self._write("\nError: Index downloaded from Swift Navigation's website (%s) doesn't contain all keys. Please contact Swift Navigation.\n" % INDEX_URL)
       return
 
+  def update_progress_dialog(self, count):
+    # Provide user feedback via pulse for slow sector erases.
+    if self.pulse_progress_initially:
+      if count > 20:
+        self.progress_dialog.max = self.progress_dialog_max
+    self.progress_dialog.update(count)
+
   # Executed in GUI thread, called from Handler.
   def manage_firmware_updates(self):
     self.updating = True
 
     self._write('')
 
-    # Erase STM if so directed.
+    # Erase STM if box is checked.
     if self.erase_stm:
-      self._write("Erasing STM flash...")
-      self.erase_flash("STM")
+      text = "Erasing STM"
+      self._write(text)
+      self.progress_dialog.title = text
+      self.create_flash("STM")
+      sectors_to_erase = \
+          set(range(self.pk_flash.n_sectors)).difference(set(self.pk_flash.restricted_sectors))
+      self.progress_dialog.max = len(sectors_to_erase)
+      self.pulse_progress_initially = False
+      GUI.invoke_later(self.progress_dialog.open)
+      erase_count = 0
+      for s in sorted(sectors_to_erase):
+        self.update_progress_dialog(erase_count)
+        self._write('Erasing %s sector %d' % (self.pk_flash.flash_type,s))
+        self.pk_flash.erase_sector(s)
+        erase_count += 1
+      self.stop_flash()
       self._write("")
 
     # Flash STM.
-    self._write("Updating STM firmware...")
-    self.update_flash(self.stm_fw.ihx, "STM")
+    text = "Updating STM"
+    self._write(text)
+    self.progress_dialog.title = text
+    self.create_flash("STM")
+    self.progress_dialog.max = 0
+    self.progress_dialog_max = self.pk_flash.ihx_n_ops(self.stm_fw.ihx)
+    self.pulse_progress_initially = True
+    GUI.invoke_later(self.progress_dialog.open)
+    self.pk_flash.write_ihx(self.stm_fw.ihx, self.stream, mod_print=0x10, \
+                            elapsed_ops_cb = self.update_progress_dialog)
+    self.stop_flash()
     self._write("")
 
     # Flash NAP.
-    self._write("Updating SwiftNAP firmware...")
-    self.update_flash(self.nap_fw.ihx, "M25")
+    text = "Updating NAP"
+    self._write(text)
+    self.progress_dialog.title = text
+    self.create_flash("M25")
+    self.progress_dialog.max = 0
+    self.progress_dialog_max = self.pk_flash.ihx_n_ops(self.nap_fw.ihx)
+    self.pulse_progress_initially = True
+    GUI.invoke_later(self.progress_dialog.open)
+    self.pk_flash.write_ihx(self.nap_fw.ihx, self.stream, mod_print=0x10, \
+                            elapsed_ops_cb = self.update_progress_dialog)
+    self.stop_flash()
     self._write("")
 
     # Must tell Piksi to jump to application after updating firmware.
@@ -409,26 +452,6 @@ class UpdateView(HasTraits):
     self._write("")
 
     self.updating = False
-
-  def erase_flash(self, flash_type):
-
-    self.create_flash(flash_type)
-
-    sectors_to_erase = \
-        set(range(self.pk_flash.n_sectors)).difference(set(self.pk_flash.restricted_sectors))
-    for s in sorted(sectors_to_erase):
-      self._write('Erasing %s sector %d' % (self.pk_flash.flash_type,s))
-      self.pk_flash.erase_sector(s)
-
-    self.stop_flash()
-
-  def update_flash(self, ihx, flash_type):
-
-    self.create_flash(flash_type)
-
-    self.pk_flash.write_ihx(ihx, self.stream, mod_print = 0x10)
-
-    self.stop_flash()
 
   def create_flash(self, flash_type):
 

--- a/scripts/update_view.py
+++ b/scripts/update_view.py
@@ -119,12 +119,6 @@ class PulsableProgressDialog(ProgressDialog):
       self.max = self.passed_max
       GUI.invoke_later(self.update, count)
 
-  def reset(self, max, pulsed=False):
-    self.max = 0
-    self.passed_max = max
-    self.pulsed = pulsed
-    self.progress(0)
-
   def close(self):
     GUI.invoke_after(0.1, super(PulsableProgressDialog, self).close)
     sleep(0.2)
@@ -417,16 +411,13 @@ class UpdateView(HasTraits):
 
     self._write('')
 
-    progress_dialog = PulsableProgressDialog(0)
-
     # Erase all of STM's flash (other than bootloader) if box is checked.
     if self.erase_stm:
       text = "Erasing STM"
       self._write(text)
       self.create_flash("STM")
-      sectors_to_erase = \
-          set(range(self.pk_flash.n_sectors)).difference(set(self.pk_flash.restricted_sectors))
-      progress_dialog.reset(len(sectors_to_erase), False)
+      sectors_to_erase = set(range(self.pk_flash.n_sectors)).difference(set(self.pk_flash.restricted_sectors))
+      progress_dialog = PulsableProgressDialog(len(sectors_to_erase), False)
       progress_dialog.title = text
       GUI.invoke_later(progress_dialog.open)
       erase_count = 0
@@ -445,11 +436,11 @@ class UpdateView(HasTraits):
     self.create_flash("STM")
     stm_n_ops = self.pk_flash.ihx_n_ops(self.stm_fw.ihx, \
                                         erase = not self.erase_stm)
-    progress_dialog.reset(stm_n_ops, True)
+    progress_dialog = PulsableProgressDialog(stm_n_ops, True)
     progress_dialog.title = text
     GUI.invoke_later(progress_dialog.open)
     # Don't erase sectors if we've already done so above.
-    self.pk_flash.write_ihx(self.stm_fw.ihx, self.stream, mod_print=0x100, \
+    self.pk_flash.write_ihx(self.stm_fw.ihx, self.stream, mod_print=0x40, \
                             elapsed_ops_cb = progress_dialog.progress, \
                             erase = not self.erase_stm)
     self.stop_flash()
@@ -464,15 +455,16 @@ class UpdateView(HasTraits):
       nap_out_of_date = local_nap_version != remote_nap_version
     except KeyError:
       nap_out_of_date = True
+    nap_out_of_date = True
     if nap_out_of_date:
       text = "Updating NAP"
       self._write(text)
       self.create_flash("M25")
       nap_n_ops = self.pk_flash.ihx_n_ops(self.nap_fw.ihx)
-      progress_dialog.reset(nap_n_ops, True)
+      progress_dialog = PulsableProgressDialog(nap_n_ops, True)
       progress_dialog.title = text
       GUI.invoke_later(progress_dialog.open)
-      self.pk_flash.write_ihx(self.nap_fw.ihx, self.stream, mod_print=0x100, \
+      self.pk_flash.write_ihx(self.nap_fw.ihx, self.stream, mod_print=0x40, \
                               elapsed_ops_cb = progress_dialog.progress)
       self.stop_flash()
       self._write("")

--- a/scripts/update_view.py
+++ b/scripts/update_view.py
@@ -412,14 +412,16 @@ class UpdateView(HasTraits):
 
     self._write('')
 
-    # Erase STM if box is checked.
+    progress_dialog = PulsableProgressDialog(0)
+
+    # Erase all of STM's flash (other than bootloader) if box is checked.
     if self.erase_stm:
       text = "Erasing STM"
       self._write(text)
       self.create_flash("STM")
       sectors_to_erase = \
           set(range(self.pk_flash.n_sectors)).difference(set(self.pk_flash.restricted_sectors))
-      progress_dialog = PulsableProgressDialog(len(sectors_to_erase), False)
+      progress_dialog.reset(len(sectors_to_erase), False)
       progress_dialog.title = text
       GUI.invoke_later(progress_dialog.open)
       erase_count = 0
@@ -435,12 +437,15 @@ class UpdateView(HasTraits):
     text = "Updating STM"
     self._write(text)
     self.create_flash("STM")
-    stm_n_ops = self.pk_flash.ihx_n_ops(self.stm_fw.ihx)
+    stm_n_ops = self.pk_flash.ihx_n_ops(self.stm_fw.ihx, \
+                                        erase = not self.erase_stm)
     progress_dialog.reset(stm_n_ops, True)
     progress_dialog.title = text
     GUI.invoke_later(progress_dialog.open)
+    # Don't erase sectors if we've already done so above.
     self.pk_flash.write_ihx(self.stm_fw.ihx, self.stream, mod_print=0x80, \
-                            elapsed_ops_cb = progress_dialog.progress)
+                            elapsed_ops_cb = progress_dialog.progress, \
+                            erase = not self.erase_stm)
     self.stop_flash()
     self._write("")
 

--- a/scripts/update_view.py
+++ b/scripts/update_view.py
@@ -114,15 +114,20 @@ class PulsableProgressDialog(ProgressDialog):
     if self.pulsed:
       if count > 20:
         self.max = self.passed_max
+        GUI.invoke_later(self.update, count)
     else:
       self.max = self.passed_max
-    self.update(count)
+      GUI.invoke_later(self.update, count)
 
   def reset(self, max, pulsed=False):
     self.max = 0
     self.passed_max = max
     self.pulsed = pulsed
     self.progress(0)
+
+  def close(self):
+    GUI.invoke_after(0.1, super(PulsableProgressDialog, self).close)
+    sleep(0.2)
 
 class UpdateView(HasTraits):
 
@@ -432,6 +437,7 @@ class UpdateView(HasTraits):
         erase_count += 1
       self.stop_flash()
       self._write("")
+      progress_dialog.close()
 
     # Flash STM.
     text = "Updating STM"
@@ -443,17 +449,22 @@ class UpdateView(HasTraits):
     progress_dialog.title = text
     GUI.invoke_later(progress_dialog.open)
     # Don't erase sectors if we've already done so above.
-    self.pk_flash.write_ihx(self.stm_fw.ihx, self.stream, mod_print=0x80, \
+    self.pk_flash.write_ihx(self.stm_fw.ihx, self.stream, mod_print=0x100, \
                             elapsed_ops_cb = progress_dialog.progress, \
                             erase = not self.erase_stm)
     self.stop_flash()
     self._write("")
+    progress_dialog.close()
 
     # Flash NAP if out of date.
-    local_nap_version = parse_version(
-        self.settings['system_info']['nap_version'].value)
-    remote_nap_version = parse_version(self.newest_nap_vers)
-    if local_nap_version != remote_nap_version:
+    try:
+      local_nap_version = parse_version(
+          self.settings['system_info']['nap_version'].value)
+      remote_nap_version = parse_version(self.newest_nap_vers)
+      nap_out_of_date = local_nap_version != remote_nap_version
+    except KeyError:
+      nap_out_of_date = True
+    if nap_out_of_date:
       text = "Updating NAP"
       self._write(text)
       self.create_flash("M25")
@@ -461,13 +472,11 @@ class UpdateView(HasTraits):
       progress_dialog.reset(nap_n_ops, True)
       progress_dialog.title = text
       GUI.invoke_later(progress_dialog.open)
-      self.pk_flash.write_ihx(self.nap_fw.ihx, self.stream, mod_print=0x80, \
+      self.pk_flash.write_ihx(self.nap_fw.ihx, self.stream, mod_print=0x100, \
                               elapsed_ops_cb = progress_dialog.progress)
       self.stop_flash()
       self._write("")
-
-    progress_dialog.close()
-    del progress_dialog
+      progress_dialog.close()
 
     # Must tell Piksi to jump to application after updating firmware.
     self.link.send_message(ids.BOOTLOADER_JUMP_TO_APP, '\x00')

--- a/scripts/update_view.py
+++ b/scripts/update_view.py
@@ -449,20 +449,25 @@ class UpdateView(HasTraits):
     self.stop_flash()
     self._write("")
 
-    # Flash NAP.
-    text = "Updating NAP"
-    self._write(text)
-    self.create_flash("M25")
-    nap_n_ops = self.pk_flash.ihx_n_ops(self.nap_fw.ihx)
-    progress_dialog.reset(nap_n_ops, True)
-    progress_dialog.title = text
-    GUI.invoke_later(progress_dialog.open)
-    self.pk_flash.write_ihx(self.nap_fw.ihx, self.stream, mod_print=0x80, \
-                            elapsed_ops_cb = progress_dialog.progress)
+    # Flash NAP if out of date.
+    local_nap_version = parse_version(
+        self.settings['system_info']['nap_version'].value)
+    remote_nap_version = parse_version(self.newest_nap_vers)
+    if local_nap_version != remote_nap_version:
+      text = "Updating NAP"
+      self._write(text)
+      self.create_flash("M25")
+      nap_n_ops = self.pk_flash.ihx_n_ops(self.nap_fw.ihx)
+      progress_dialog.reset(nap_n_ops, True)
+      progress_dialog.title = text
+      GUI.invoke_later(progress_dialog.open)
+      self.pk_flash.write_ihx(self.nap_fw.ihx, self.stream, mod_print=0x80, \
+                              elapsed_ops_cb = progress_dialog.progress)
+      self.stop_flash()
+      self._write("")
+
     progress_dialog.close()
     del progress_dialog
-    self.stop_flash()
-    self._write("")
 
     # Must tell Piksi to jump to application after updating firmware.
     self.link.send_message(ids.BOOTLOADER_JUMP_TO_APP, '\x00')


### PR DESCRIPTION
Increase flashing speed (~5X on OSX 10.9)
Only update FPGA flash when there is new firmware
Only erase STM sectors once
Add pop-up progress bar to indicate flashing progress