### PR TITLE
Integrate libsbp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "ChibiOS-RT"]
 	path = ChibiOS-RT
 	url = https://github.com/mabl/ChibiOS.git
+[submodule "libsbp"]
+	path = libsbp
+	url = https://github.com/swift-nav/libsbp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/mabl/ChibiOS.git
 [submodule "libsbp"]
 	path = libsbp
-	url = https://github.com/swift-nav/libsbp.git
+	url = git@github.com:swift-nav/libsbp.git

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endif
 
 all: firmware # tests
 
-firmware: libopencm3/lib/libopencm3_stm32f4.a libswiftnav/build/src/libswiftnav-static.a
+firmware: libopencm3/lib/libopencm3_stm32f4.a libsbp/c/build/src/libsbp-static.a libswiftnav/build/src/libswiftnav-static.a
 	@printf "BUILD   src\n"; \
 	$(MAKE) -r -C src $(MAKEFLAGS)
 
@@ -38,6 +38,12 @@ libopencm3/lib/libopencm3_stm32f4.a:
 	@printf "BUILD   libopencm3\n"; \
 	$(MAKE) -C libopencm3 $(MAKEFLAGS) lib/stm32/f4
 
+libsbp/c/build/src/libsbp-static.a:
+	@printf "BUILD   libsbp\n"; \
+	mkdir -p libsbp/c/build; cd libsbp/c/build; \
+	cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchain-gcc-arm-embedded.cmake $(CMAKEFLAGS) ../
+	$(MAKE) -C libsbp/c/build $(MAKEFLAGS)
+
 libswiftnav/build/src/libswiftnav-static.a: .FORCE
 	@printf "BUILD   libswiftnav\n"; \
 	mkdir -p libswiftnav/build; cd libswiftnav/build; \
@@ -49,6 +55,8 @@ clean:
 	$(MAKE) -C src $(MAKEFLAGS) clean
 	@printf "CLEAN   libopencm3\n"; \
 	$(MAKE) -C libopencm3 $(MAKEFLAGS) clean
+	@printf "CLEAN   libsbp\n"; \
+	$(RM) -rf libsbp/c/build
 	@printf "CLEAN   libswiftnav\n"; \
 	$(RM) -rf libswiftnav/build
 	$(Q)for i in tests/*; do \
@@ -63,4 +71,3 @@ docs:
 	doxygen docs/Doxyfile
 
 .FORCE:
-

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Documentation available online at http://docs.swift-nav.com/piksi_firmware
 Checking Out Submodules
 =========================
 
-ChibiOS, libopencm3 and libswiftnav are submodules of this git repository.
+ChibiOS, libopencm3, libsbp and libswiftnav are submodules of this git repository.
 Check them out using:
 
 	git submodule init

--- a/setup.sh
+++ b/setup.sh
@@ -44,7 +44,7 @@ function build () {
     # Pulls down git submodules and builds the project, assuming that
     # all other system, ARM GCC, and python dependencies have been
     # installed.
-    log_info "Initializing Git submodules for ChibiOS, libopencm3, and libswiftnav..."
+    log_info "Initializing Git submodules for ChibiOS, libopencm3, libsbp and libswiftnav..."
     git submodule init
     git submodule update
     log_info "Building piksi_firmware..."

--- a/src/Makefile
+++ b/src/Makefile
@@ -219,7 +219,7 @@ DINCDIR =
 
 # List the default directory to look for the libraries here
 DLIBDIR = $(SWIFTNAV_ROOT)/libopencm3/lib \
-          $(SWIFTNAV_ROOT)/libsp/c/build/src \
+          $(SWIFTNAV_ROOT)/libsbp/c/build/src \
           $(SWIFTNAV_ROOT)/libswiftnav/build/src \
           $(SWIFTNAV_ROOT)/libswiftnav/build/lapacke \
           $(SWIFTNAV_ROOT)/libswiftnav/build/CBLAS/src \

--- a/src/Makefile
+++ b/src/Makefile
@@ -112,6 +112,7 @@ CSRC := $(PORTSRC) \
         $(SWIFTNAV_ROOT)/src/sbp.o \
         $(SWIFTNAV_ROOT)/src/sbp_piksi.o \
         $(SWIFTNAV_ROOT)/src/sbp_fileio.o \
+        $(SWIFTNAV_ROOT)/src/sbp_utils.o \
         $(SWIFTNAV_ROOT)/src/error.o \
         $(SWIFTNAV_ROOT)/src/cw.o \
         $(SWIFTNAV_ROOT)/src/track.o \
@@ -157,6 +158,7 @@ TCPPSRC =
 ASMSRC = $(PORTASM)
 
 INCDIR = $(PORTINC) $(KERNINC) $(CHIBIOS)/os/various \
+         $(SWIFTNAV_ROOT)/libsbp/c/include \
          $(SWIFTNAV_ROOT)/libswiftnav/include \
          $(SWIFTNAV_ROOT)/src \
          $(SWIFTNAV_ROOT)/libopencm3/include
@@ -217,6 +219,8 @@ DINCDIR =
 
 # List the default directory to look for the libraries here
 DLIBDIR = $(SWIFTNAV_ROOT)/libopencm3/lib \
+          $(SWIFTNAV_ROOT)/libsp/c/build/src \
+          $(SWIFTNAV_ROOT)/libswiftnav/build/src \
           $(SWIFTNAV_ROOT)/libswiftnav/build/lapacke \
           $(SWIFTNAV_ROOT)/libswiftnav/build/CBLAS/src \
           $(SWIFTNAV_ROOT)/libswiftnav/build/clapack-3.2.1-CMAKE/BLAS/SRC \
@@ -225,7 +229,7 @@ DLIBDIR = $(SWIFTNAV_ROOT)/libopencm3/lib \
           $(SWIFTNAV_ROOT)/libswiftnav/build/src
 
 # List all default libraries here
-DLIBS = -lopencm3_stm32f4 -lswiftnav-static \
+DLIBS = -lopencm3_stm32f4 -lsbp-static -lswiftnav-static \
         -llapacke -llapack -lcblas -lblas \
         -lf2c -lm -lc -lnosys
 

--- a/src/base_obs.c
+++ b/src/base_obs.c
@@ -15,7 +15,6 @@
 #include <math.h>
 
 #include <libswiftnav/logging.h>
-#include <libswiftnav/sbp_utils.h>
 #include <libswiftnav/pvt.h>
 #include <libswiftnav/constants.h>
 #include <libswiftnav/ephemeris.h>
@@ -26,6 +25,7 @@
 #include "position.h"
 #include "nmea.h"
 #include "sbp.h"
+#include "sbp_utils.h"
 #include "solution.h"
 #include "manage.h"
 #include "simulator.h"

--- a/src/board/nap/nap_common.c
+++ b/src/board/nap/nap_common.c
@@ -13,7 +13,7 @@
 
 #include <libopencm3/stm32/f4/gpio.h>
 #include <libopencm3/stm32/f4/rcc.h>
-#include <libswiftnav/sbp.h>
+#include <libsbp/sbp.h>
 
 #include "../../error.h"
 #include "../../peripherals/spi.h"

--- a/src/cw.c
+++ b/src/cw.c
@@ -12,7 +12,7 @@
 
 #include <math.h>
 #include <stdio.h>
-#include <libswiftnav/sbp.h>
+#include <libsbp/sbp.h>
 
 #include "board/nap/cw_channel.h"
 #include "sbp.h"

--- a/src/error.c
+++ b/src/error.c
@@ -15,8 +15,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <libswiftnav/edc.h>
-#include <libswiftnav/sbp.h>
+#include <libsbp/sbp.h>
 
 #include "board/leds.h"
 #include "peripherals/usart.h"

--- a/src/flash_callbacks.c
+++ b/src/flash_callbacks.c
@@ -11,7 +11,7 @@
  */
 
 #include <string.h>
-#include <libswiftnav/sbp.h>
+#include <libsbp/sbp.h>
 
 #include "sbp.h"
 #include "peripherals/stm_flash.h"

--- a/src/init.c
+++ b/src/init.c
@@ -13,8 +13,8 @@
 #include <libopencm3/stm32/f4/flash.h>
 #include <libopencm3/stm32/f4/rcc.h>
 
+#include <libsbp/sbp.h>
 #include <libswiftnav/logging.h>
-#include <libswiftnav/sbp.h>
 
 #include "main.h"
 #include "board/leds.h"

--- a/src/main.c
+++ b/src/main.c
@@ -13,8 +13,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <libsbp/sbp_messages.h>
 #include <libswiftnav/logging.h>
-#include <libswiftnav/sbp_messages.h>
 
 #include <ch.h>
 

--- a/src/main.c
+++ b/src/main.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <libsbp/sbp_messages.h>
+#include <libsbp/standard.h>
 #include <libswiftnav/logging.h>
 
 #include <ch.h>
@@ -284,10 +284,9 @@ int main(void)
 
   /* Send message to inform host we are up and running. */
   u32 startup_flags = 0;
-  sbp_send_msg(SBP_STARTUP, sizeof(startup_flags), (u8 *)&startup_flags);
+  sbp_send_msg(SBP_MSG_STARTUP, sizeof(startup_flags), (u8 *)&startup_flags);
 
   while (1) {
     chThdSleepSeconds(60);
   }
 }
-

--- a/src/manage.c
+++ b/src/manage.c
@@ -15,11 +15,11 @@
 
 #include <ch.h>
 
+#include <libsbp/sbp.h>
 #include <libswiftnav/logging.h>
 #include <libswiftnav/almanac.h>
 #include <libswiftnav/constants.h>
 #include <libswiftnav/coord_system.h>
-#include <libswiftnav/sbp.h>
 
 #include "main.h"
 #include "board/nap/track_channel.h"

--- a/src/sbp.c
+++ b/src/sbp.c
@@ -20,9 +20,8 @@
 #include <libopencm3/stm32/f4/dma.h>
 #include <libopencm3/stm32/f4/usart.h>
 
+#include <libsbp/sbp.h>
 #include <libswiftnav/logging.h>
-#include <libswiftnav/edc.h>
-#include <libswiftnav/sbp.h>
 
 #include "board/leds.h"
 #include "board/m25_flash.h"

--- a/src/sbp.h
+++ b/src/sbp.h
@@ -13,9 +13,9 @@
 #ifndef SWIFTNAV_SBP_H
 #define SWIFTNAV_SBP_H
 
-#include <libswiftnav/common.h>
-#include <libswiftnav/sbp.h>
-#include <libswiftnav/sbp_messages.h>
+#include <libsbp/common.h>
+#include <libsbp/sbp.h>
+#include <libsbp/sbp_messages.h>
 
 #include "peripherals/usart.h"
 #include "sbp_piksi.h"

--- a/src/sbp.h
+++ b/src/sbp.h
@@ -15,7 +15,6 @@
 
 #include <libsbp/common.h>
 #include <libsbp/sbp.h>
-#include <libsbp/sbp_messages.h>
 
 #include "peripherals/usart.h"
 #include "sbp_piksi.h"
@@ -38,4 +37,3 @@ void debug_variable(char *name, double x);
   ); }
 
 #endif
-

--- a/src/sbp_utils.c
+++ b/src/sbp_utils.c
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2014 Swift Navigation Inc.
+ * Contact: Fergus Noble <fergus@swift-nav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <math.h>
+
+#include <libswiftnav/constants.h>
+#include "sbp_utils.h"
+
+/** \addtogroup sbp
+ * \{ */
+
+/** \defgroup sbp_utils SBP Utils
+ * Convert to and from SBP message types and other useful functions.
+ * \{ */
+
+void sbp_make_gps_time(sbp_gps_time_t *t_out, gps_time_t *t_in, u8 flags)
+{
+  t_out->wn = t_in->wn;
+  t_out->tow = round(t_in->tow * 1e3);
+  t_out->ns = round((t_in->tow - t_out->tow*1e-3) * 1e9);
+  t_out->flags = flags;
+}
+
+void sbp_make_pos_llh(sbp_pos_llh_t *pos_llh, gnss_solution *soln, u8 flags)
+{
+  pos_llh->tow = round(soln->time.tow * 1e3);
+  pos_llh->lat = soln->pos_llh[0] * R2D;
+  pos_llh->lon = soln->pos_llh[1] * R2D;
+  pos_llh->height = soln->pos_llh[2];
+  /* TODO: fill in accuracy fields. */
+  pos_llh->h_accuracy = 0;
+  pos_llh->v_accuracy = 0;
+  pos_llh->n_sats = soln->n_used;
+  pos_llh->flags = flags;
+}
+
+void sbp_make_pos_llh_vect(sbp_pos_llh_t *pos_llh, double llh[3],
+                           gps_time_t *gps_t, u8 n_used, u8 flags)
+{
+  pos_llh->tow = round(gps_t->tow * 1e3);
+  pos_llh->lat = llh[0] * R2D;
+  pos_llh->lon = llh[1] * R2D;
+  pos_llh->height = llh[2];
+  /* TODO: fill in accuracy field. */
+  pos_llh->h_accuracy = 0;
+  pos_llh->v_accuracy = 0;
+  pos_llh->n_sats = n_used;
+  pos_llh->flags = flags;
+}
+
+void sbp_make_pos_ecef(sbp_pos_ecef_t *pos_ecef, gnss_solution *soln, u8 flags)
+{
+  pos_ecef->tow = round(soln->time.tow * 1e3);
+  pos_ecef->x = soln->pos_ecef[0];
+  pos_ecef->y = soln->pos_ecef[1];
+  pos_ecef->z = soln->pos_ecef[2];
+  /* TODO: fill in accuracy field. */
+  pos_ecef->accuracy = 0;
+  pos_ecef->n_sats = soln->n_used;
+  pos_ecef->flags = flags;
+}
+
+void sbp_make_pos_ecef_vect(sbp_pos_ecef_t *pos_ecef, double ecef[3],
+                            gps_time_t *gps_t, u8 n_used, u8 flags)
+{
+  pos_ecef->tow = round(gps_t->tow * 1e3);
+  pos_ecef->x = ecef[0];
+  pos_ecef->y = ecef[1];
+  pos_ecef->z = ecef[2];
+  /* TODO: fill in accuracy field. */
+  pos_ecef->accuracy = 0;
+  pos_ecef->n_sats = n_used;
+  pos_ecef->flags = flags;
+}
+
+void sbp_make_vel_ned(sbp_vel_ned_t *vel_ned, gnss_solution *soln, u8 flags)
+{
+  vel_ned->tow = round(soln->time.tow * 1e3);
+  vel_ned->n = round(soln->vel_ned[0] * 1e3);
+  vel_ned->e = round(soln->vel_ned[1] * 1e3);
+  vel_ned->d = round(soln->vel_ned[2] * 1e3);
+  /* TODO: fill in accuracy fields. */
+  vel_ned->h_accuracy = 0;
+  vel_ned->v_accuracy = 0;
+  vel_ned->n_sats = soln->n_used;
+  vel_ned->flags = flags;
+}
+
+void sbp_make_vel_ecef(sbp_vel_ecef_t *vel_ecef, gnss_solution *soln, u8 flags)
+{
+  vel_ecef->tow = round(soln->time.tow * 1e3);
+  vel_ecef->x = round(soln->vel_ecef[0] * 1e3);
+  vel_ecef->y = round(soln->vel_ecef[1] * 1e3);
+  vel_ecef->z = round(soln->vel_ecef[2] * 1e3);
+  /* TODO: fill in accuracy field. */
+  vel_ecef->accuracy = 0;
+  vel_ecef->n_sats = soln->n_used;
+  vel_ecef->flags = flags;
+}
+
+void sbp_make_dops(sbp_dops_t *dops_out, dops_t *dops_in)
+{
+  dops_out->pdop = round(dops_in->pdop * 100);
+  dops_out->gdop = round(dops_in->gdop * 100);
+  dops_out->tdop = round(dops_in->tdop * 100);
+  dops_out->hdop = round(dops_in->hdop * 100);
+  dops_out->vdop = round(dops_in->vdop * 100);
+}
+
+void sbp_make_baseline_ecef(sbp_baseline_ecef_t *baseline_ecef, gps_time_t *t,
+                            u8 n_sats, double b_ecef[3], u8 flags) {
+  baseline_ecef->tow = round(t->tow * 1e3);
+  baseline_ecef->x = round(1e3 * b_ecef[0]);
+  baseline_ecef->y = round(1e3 * b_ecef[1]);
+  baseline_ecef->z = round(1e3 * b_ecef[2]);
+  baseline_ecef->accuracy = 0;
+  baseline_ecef->n_sats = n_sats;
+  baseline_ecef->flags = flags;
+}
+
+void sbp_make_baseline_ned(sbp_baseline_ned_t *baseline_ned, gps_time_t *t,
+                           u8 n_sats, double b_ned[3], u8 flags) {
+  baseline_ned->tow = round(t->tow * 1e3);
+  baseline_ned->n = round(1e3 * b_ned[0]);
+  baseline_ned->e = round(1e3 * b_ned[1]);
+  baseline_ned->d = round(1e3 * b_ned[2]);
+  baseline_ned->h_accuracy = 0;
+  baseline_ned->v_accuracy = 0;
+  baseline_ned->n_sats = n_sats;
+  baseline_ned->flags = flags;
+}
+
+/** \} */
+/** \} */

--- a/src/sbp_utils.c
+++ b/src/sbp_utils.c
@@ -22,7 +22,7 @@
  * Convert to and from SBP message types and other useful functions.
  * \{ */
 
-void sbp_make_gps_time(sbp_gps_time_t *t_out, gps_time_t *t_in, u8 flags)
+void sbp_make_gps_time(msg_gps_time_t *t_out, gps_time_t *t_in, u8 flags)
 {
   t_out->wn = t_in->wn;
   t_out->tow = round(t_in->tow * 1e3);
@@ -30,7 +30,7 @@ void sbp_make_gps_time(sbp_gps_time_t *t_out, gps_time_t *t_in, u8 flags)
   t_out->flags = flags;
 }
 
-void sbp_make_pos_llh(sbp_pos_llh_t *pos_llh, gnss_solution *soln, u8 flags)
+void sbp_make_pos_llh(msg_pos_llh_t *pos_llh, gnss_solution *soln, u8 flags)
 {
   pos_llh->tow = round(soln->time.tow * 1e3);
   pos_llh->lat = soln->pos_llh[0] * R2D;
@@ -43,7 +43,7 @@ void sbp_make_pos_llh(sbp_pos_llh_t *pos_llh, gnss_solution *soln, u8 flags)
   pos_llh->flags = flags;
 }
 
-void sbp_make_pos_llh_vect(sbp_pos_llh_t *pos_llh, double llh[3],
+void sbp_make_pos_llh_vect(msg_pos_llh_t *pos_llh, double llh[3],
                            gps_time_t *gps_t, u8 n_used, u8 flags)
 {
   pos_llh->tow = round(gps_t->tow * 1e3);
@@ -57,7 +57,7 @@ void sbp_make_pos_llh_vect(sbp_pos_llh_t *pos_llh, double llh[3],
   pos_llh->flags = flags;
 }
 
-void sbp_make_pos_ecef(sbp_pos_ecef_t *pos_ecef, gnss_solution *soln, u8 flags)
+void sbp_make_pos_ecef(msg_pos_ecef_t *pos_ecef, gnss_solution *soln, u8 flags)
 {
   pos_ecef->tow = round(soln->time.tow * 1e3);
   pos_ecef->x = soln->pos_ecef[0];
@@ -69,7 +69,7 @@ void sbp_make_pos_ecef(sbp_pos_ecef_t *pos_ecef, gnss_solution *soln, u8 flags)
   pos_ecef->flags = flags;
 }
 
-void sbp_make_pos_ecef_vect(sbp_pos_ecef_t *pos_ecef, double ecef[3],
+void sbp_make_pos_ecef_vect(msg_pos_ecef_t *pos_ecef, double ecef[3],
                             gps_time_t *gps_t, u8 n_used, u8 flags)
 {
   pos_ecef->tow = round(gps_t->tow * 1e3);
@@ -82,7 +82,7 @@ void sbp_make_pos_ecef_vect(sbp_pos_ecef_t *pos_ecef, double ecef[3],
   pos_ecef->flags = flags;
 }
 
-void sbp_make_vel_ned(sbp_vel_ned_t *vel_ned, gnss_solution *soln, u8 flags)
+void sbp_make_vel_ned(msg_vel_ned_t *vel_ned, gnss_solution *soln, u8 flags)
 {
   vel_ned->tow = round(soln->time.tow * 1e3);
   vel_ned->n = round(soln->vel_ned[0] * 1e3);
@@ -95,7 +95,7 @@ void sbp_make_vel_ned(sbp_vel_ned_t *vel_ned, gnss_solution *soln, u8 flags)
   vel_ned->flags = flags;
 }
 
-void sbp_make_vel_ecef(sbp_vel_ecef_t *vel_ecef, gnss_solution *soln, u8 flags)
+void sbp_make_vel_ecef(msg_vel_ecef_t *vel_ecef, gnss_solution *soln, u8 flags)
 {
   vel_ecef->tow = round(soln->time.tow * 1e3);
   vel_ecef->x = round(soln->vel_ecef[0] * 1e3);
@@ -107,7 +107,7 @@ void sbp_make_vel_ecef(sbp_vel_ecef_t *vel_ecef, gnss_solution *soln, u8 flags)
   vel_ecef->flags = flags;
 }
 
-void sbp_make_dops(sbp_dops_t *dops_out, dops_t *dops_in, gps_time_t *t)
+void sbp_make_dops(msg_dops_t *dops_out, dops_t *dops_in, gps_time_t *t)
 {
   dops_out->tow = round(t->tow * 1e3);
   dops_out->pdop = round(dops_in->pdop * 100);
@@ -117,7 +117,7 @@ void sbp_make_dops(sbp_dops_t *dops_out, dops_t *dops_in, gps_time_t *t)
   dops_out->vdop = round(dops_in->vdop * 100);
 }
 
-void sbp_make_baseline_ecef(sbp_baseline_ecef_t *baseline_ecef, gps_time_t *t,
+void sbp_make_baseline_ecef(msg_baseline_ecef_t *baseline_ecef, gps_time_t *t,
                             u8 n_sats, double b_ecef[3], u8 flags) {
   baseline_ecef->tow = round(t->tow * 1e3);
   baseline_ecef->x = round(1e3 * b_ecef[0]);
@@ -128,7 +128,7 @@ void sbp_make_baseline_ecef(sbp_baseline_ecef_t *baseline_ecef, gps_time_t *t,
   baseline_ecef->flags = flags;
 }
 
-void sbp_make_baseline_ned(sbp_baseline_ned_t *baseline_ned, gps_time_t *t,
+void sbp_make_baseline_ned(msg_baseline_ned_t *baseline_ned, gps_time_t *t,
                            u8 n_sats, double b_ned[3], u8 flags) {
   baseline_ned->tow = round(t->tow * 1e3);
   baseline_ned->n = round(1e3 * b_ned[0]);

--- a/src/sbp_utils.c
+++ b/src/sbp_utils.c
@@ -107,7 +107,7 @@ void sbp_make_vel_ecef(sbp_vel_ecef_t *vel_ecef, gnss_solution *soln, u8 flags)
   vel_ecef->flags = flags;
 }
 
-void sbp_make_dops(sbp_dops_t *dops_out, dops_t *dops_in)
+void sbp_make_dops(sbp_dops_t *dops_out, dops_t *dops_in, gps_time_t *t)
 {
   dops_out->tow = round(t->tow * 1e3);
   dops_out->pdop = round(dops_in->pdop * 100);

--- a/src/sbp_utils.c
+++ b/src/sbp_utils.c
@@ -109,6 +109,7 @@ void sbp_make_vel_ecef(sbp_vel_ecef_t *vel_ecef, gnss_solution *soln, u8 flags)
 
 void sbp_make_dops(sbp_dops_t *dops_out, dops_t *dops_in)
 {
+  dops_out->tow = round(t->tow * 1e3);
   dops_out->pdop = round(dops_in->pdop * 100);
   dops_out->gdop = round(dops_in->gdop * 100);
   dops_out->tdop = round(dops_in->tdop * 100);

--- a/src/sbp_utils.h
+++ b/src/sbp_utils.h
@@ -27,7 +27,7 @@ void sbp_make_pos_ecef_vect(sbp_pos_ecef_t *pos_ecef, double ecef[3],
                             gps_time_t *gps_t, u8 n_used, u8 flags);
 void sbp_make_vel_ned(sbp_vel_ned_t *vel_ned, gnss_solution *soln, u8 flags);
 void sbp_make_vel_ecef(sbp_vel_ecef_t *vel_ecef, gnss_solution *soln, u8 flags);
-void sbp_make_dops(sbp_dops_t *dops_out, dops_t *dops_in);
+void sbp_make_dops(sbp_dops_t *dops_out, dops_t *dops_in, gps_time_t *t);
 void sbp_make_baseline_ecef(sbp_baseline_ecef_t *baseline_ecef, gps_time_t *t,
                             u8 n_sats, double b_ecef[3], u8 flags);
 void sbp_make_baseline_ned(sbp_baseline_ned_t *baseline_ned, gps_time_t *t,

--- a/src/sbp_utils.h
+++ b/src/sbp_utils.h
@@ -14,23 +14,23 @@
 #define SWIFTNAV_SBP_UTILS_H
 
 #include <libsbp/common.h>
-#include <libsbp/sbp_messages.h>
+#include <libsbp/navigation.h>
 #include <libswiftnav/gpstime.h>
 #include <libswiftnav/pvt.h>
 
-void sbp_make_gps_time(sbp_gps_time_t *t_out, gps_time_t *t_in, u8 flags);
-void sbp_make_pos_llh(sbp_pos_llh_t *pos_llh, gnss_solution *soln, u8 flags);
-void sbp_make_pos_llh_vect(sbp_pos_llh_t *pos_llh, double llh[3],
+void sbp_make_gps_time(msg_gps_time_t *t_out, gps_time_t *t_in, u8 flags);
+void sbp_make_pos_llh(msg_pos_llh_t *pos_llh, gnss_solution *soln, u8 flags);
+void sbp_make_pos_llh_vect(msg_pos_llh_t *pos_llh, double llh[3],
                            gps_time_t *gps_t, u8 n_used, u8 flags);
-void sbp_make_pos_ecef(sbp_pos_ecef_t *pos_ecef, gnss_solution *soln, u8 flags);
-void sbp_make_pos_ecef_vect(sbp_pos_ecef_t *pos_ecef, double ecef[3],
+void sbp_make_pos_ecef(msg_pos_ecef_t *pos_ecef, gnss_solution *soln, u8 flags);
+void sbp_make_pos_ecef_vect(msg_pos_ecef_t *pos_ecef, double ecef[3],
                             gps_time_t *gps_t, u8 n_used, u8 flags);
-void sbp_make_vel_ned(sbp_vel_ned_t *vel_ned, gnss_solution *soln, u8 flags);
-void sbp_make_vel_ecef(sbp_vel_ecef_t *vel_ecef, gnss_solution *soln, u8 flags);
-void sbp_make_dops(sbp_dops_t *dops_out, dops_t *dops_in, gps_time_t *t);
-void sbp_make_baseline_ecef(sbp_baseline_ecef_t *baseline_ecef, gps_time_t *t,
+void sbp_make_vel_ned(msg_vel_ned_t *vel_ned, gnss_solution *soln, u8 flags);
+void sbp_make_vel_ecef(msg_vel_ecef_t *vel_ecef, gnss_solution *soln, u8 flags);
+void sbp_make_dops(msg_dops_t *dops_out, dops_t *dops_in, gps_time_t *t);
+void sbp_make_baseline_ecef(msg_baseline_ecef_t *baseline_ecef, gps_time_t *t,
                             u8 n_sats, double b_ecef[3], u8 flags);
-void sbp_make_baseline_ned(sbp_baseline_ned_t *baseline_ned, gps_time_t *t,
+void sbp_make_baseline_ned(msg_baseline_ned_t *baseline_ned, gps_time_t *t,
                            u8 n_sats, double b_ned[3], u8 flags);
 
 #endif /* SWIFTNAV_SBP_UTILS_H */

--- a/src/sbp_utils.h
+++ b/src/sbp_utils.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2014 Swift Navigation Inc.
+ * Contact: Fergus Noble <fergus@swift-nav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef SWIFTNAV_SBP_UTILS_H
+#define SWIFTNAV_SBP_UTILS_H
+
+#include <libsbp/common.h>
+#include <libsbp/sbp_messages.h>
+#include <libswiftnav/gpstime.h>
+#include <libswiftnav/pvt.h>
+
+void sbp_make_gps_time(sbp_gps_time_t *t_out, gps_time_t *t_in, u8 flags);
+void sbp_make_pos_llh(sbp_pos_llh_t *pos_llh, gnss_solution *soln, u8 flags);
+void sbp_make_pos_llh_vect(sbp_pos_llh_t *pos_llh, double llh[3],
+                           gps_time_t *gps_t, u8 n_used, u8 flags);
+void sbp_make_pos_ecef(sbp_pos_ecef_t *pos_ecef, gnss_solution *soln, u8 flags);
+void sbp_make_pos_ecef_vect(sbp_pos_ecef_t *pos_ecef, double ecef[3],
+                            gps_time_t *gps_t, u8 n_used, u8 flags);
+void sbp_make_vel_ned(sbp_vel_ned_t *vel_ned, gnss_solution *soln, u8 flags);
+void sbp_make_vel_ecef(sbp_vel_ecef_t *vel_ecef, gnss_solution *soln, u8 flags);
+void sbp_make_dops(sbp_dops_t *dops_out, dops_t *dops_in);
+void sbp_make_baseline_ecef(sbp_baseline_ecef_t *baseline_ecef, gps_time_t *t,
+                            u8 n_sats, double b_ecef[3], u8 flags);
+void sbp_make_baseline_ned(sbp_baseline_ned_t *baseline_ned, gps_time_t *t,
+                           u8 n_sats, double b_ned[3], u8 flags);
+
+#endif /* SWIFTNAV_SBP_UTILS_H */

--- a/src/solution.c
+++ b/src/solution.c
@@ -56,36 +56,36 @@ void solution_send_sbp(gnss_solution *soln, dops_t *dops)
 {
   if (soln) {
     /* Send GPS_TIME message first. */
-    sbp_gps_time_t gps_time;
+    msg_gps_time_t gps_time;
     sbp_make_gps_time(&gps_time, &soln->time, 0);
-    sbp_send_msg(SBP_GPS_TIME, sizeof(gps_time), (u8 *) &gps_time);
+    sbp_send_msg(SBP_MSG_GPS_TIME, sizeof(gps_time), (u8 *) &gps_time);
 
     /* Position in LLH. */
-    sbp_pos_llh_t pos_llh;
+    msg_pos_llh_t pos_llh;
     sbp_make_pos_llh(&pos_llh, soln, 0);
-    sbp_send_msg(SBP_POS_LLH, sizeof(pos_llh), (u8 *) &pos_llh);
+    sbp_send_msg(SBP_MSG_POS_LLH, sizeof(pos_llh), (u8 *) &pos_llh);
 
     /* Position in ECEF. */
-    sbp_pos_ecef_t pos_ecef;
+    msg_pos_ecef_t pos_ecef;
     sbp_make_pos_ecef(&pos_ecef, soln, 0);
-    sbp_send_msg(SBP_POS_ECEF, sizeof(pos_ecef), (u8 *) &pos_ecef);
+    sbp_send_msg(SBP_MSG_POS_ECEF, sizeof(pos_ecef), (u8 *) &pos_ecef);
 
     /* Velocity in NED. */
-    sbp_vel_ned_t vel_ned;
+    msg_vel_ned_t vel_ned;
     sbp_make_vel_ned(&vel_ned, soln, 0);
-    sbp_send_msg(SBP_VEL_NED, sizeof(vel_ned), (u8 *) &vel_ned);
+    sbp_send_msg(SBP_MSG_VEL_NED, sizeof(vel_ned), (u8 *) &vel_ned);
 
     /* Velocity in ECEF. */
-    sbp_vel_ecef_t vel_ecef;
+    msg_vel_ecef_t vel_ecef;
     sbp_make_vel_ecef(&vel_ecef, soln, 0);
-    sbp_send_msg(SBP_VEL_ECEF, sizeof(vel_ecef), (u8 *) &vel_ecef);
+    sbp_send_msg(SBP_MSG_VEL_ECEF, sizeof(vel_ecef), (u8 *) &vel_ecef);
   }
 
   if (dops) {
     DO_EVERY(10,
-      sbp_dops_t sbp_dops;
+      msg_dops_t sbp_dops;
       sbp_make_dops(&sbp_dops, dops, &(soln->time));
-      sbp_send_msg(SBP_DOPS, sizeof(sbp_dops_t), (u8 *) &sbp_dops);
+      sbp_send_msg(SBP_MSG_DOPS, sizeof(sbp_dops), (u8 *) &sbp_dops);
     );
   }
 }
@@ -125,16 +125,16 @@ void solution_send_baseline(gps_time_t *t, u8 n_sats, double b_ecef[3],
                             double ref_ecef[3], u8 flags)
 {
   double* base_station_pos;
-  sbp_baseline_ecef_t sbp_ecef;
+  msg_baseline_ecef_t sbp_ecef;
   sbp_make_baseline_ecef(&sbp_ecef, t, n_sats, b_ecef, flags);
-  sbp_send_msg(SBP_BASELINE_ECEF, sizeof(sbp_ecef), (u8 *)&sbp_ecef);
+  sbp_send_msg(SBP_MSG_BASELINE_ECEF, sizeof(sbp_ecef), (u8 *)&sbp_ecef);
 
   double b_ned[3];
   wgsecef2ned(b_ecef, ref_ecef, b_ned);
 
-  sbp_baseline_ned_t sbp_ned;
+  msg_baseline_ned_t sbp_ned;
   sbp_make_baseline_ned(&sbp_ned, t, n_sats, b_ned, flags);
-  sbp_send_msg(SBP_BASELINE_NED, sizeof(sbp_ned), (u8 *)&sbp_ned);
+  sbp_send_msg(SBP_MSG_BASELINE_NED, sizeof(sbp_ned), (u8 *)&sbp_ned);
 
   chMtxLock(&base_pos_lock);
   if (base_pos_known || (simulation_enabled_for(SIMULATION_MODE_FLOAT) ||
@@ -161,12 +161,12 @@ void solution_send_baseline(gps_time_t *t, u8 n_sats, double b_ecef[3],
     /* We defined the flags for the SBP protocol to be spp->0, fixed->1, float->2 */
     /* TODO: Define these flags from the yaml and remove hardcoding */
     u8 sbp_flags = (flags == 1) ? 1 : 2;
-    sbp_pos_llh_t pos_llh;
+    msg_pos_llh_t pos_llh;
     sbp_make_pos_llh_vect(&pos_llh, pseudo_absolute_llh, t, n_sats, sbp_flags);
-    sbp_send_msg(SBP_POS_LLH, sizeof(pos_llh), (u8 *) &pos_llh);
-    sbp_pos_ecef_t pos_ecef;
+    sbp_send_msg(SBP_MSG_POS_LLH, sizeof(pos_llh), (u8 *) &pos_llh);
+    msg_pos_ecef_t pos_ecef;
     sbp_make_pos_ecef_vect(&pos_ecef, pseudo_absolute_ecef, t, n_sats, sbp_flags);
-    sbp_send_msg(SBP_POS_ECEF, sizeof(pos_ecef), (u8 *) &pos_ecef);
+    sbp_send_msg(SBP_MSG_POS_ECEF, sizeof(pos_ecef), (u8 *) &pos_ecef);
   }
   chMtxUnlock();
 }

--- a/src/solution.c
+++ b/src/solution.c
@@ -12,8 +12,8 @@
 
 #include <string.h>
 
+#include <libsbp/sbp.h>
 #include <libswiftnav/logging.h>
-#include <libswiftnav/sbp_utils.h>
 #include <libswiftnav/pvt.h>
 #include <libswiftnav/constants.h>
 #include <libswiftnav/ephemeris.h>
@@ -29,6 +29,7 @@
 #include "position.h"
 #include "nmea.h"
 #include "sbp.h"
+#include "sbp_utils.h"
 #include "solution.h"
 #include "manage.h"
 #include "simulator.h"

--- a/src/system_monitor.c
+++ b/src/system_monitor.c
@@ -14,7 +14,7 @@
 
 #include <ch.h>
 
-#include <libsbp/sbp_messages.h>
+#include <libsbp/standard.h>
 #include <libswiftnav/logging.h>
 #include <libswiftnav/dgnss_management.h>
 
@@ -111,7 +111,7 @@ static msg_t system_monitor_thread(void *arg)
     chThdSleepMilliseconds(heartbeat_period_milliseconds);
 
     u32 status_flags = 0;
-    sbp_send_msg(SBP_HEARTBEAT, sizeof(status_flags), (u8 *)&status_flags);
+    sbp_send_msg(SBP_MSG_HEARTBEAT, sizeof(status_flags), (u8 *)&status_flags);
 
     /* If we are in base station mode then broadcast our known location. */
     if (base_station_mode) {

--- a/src/system_monitor.c
+++ b/src/system_monitor.c
@@ -14,8 +14,8 @@
 
 #include <ch.h>
 
+#include <libsbp/sbp_messages.h>
 #include <libswiftnav/logging.h>
-#include <libswiftnav/sbp_messages.h>
 #include <libswiftnav/dgnss_management.h>
 
 #include "board/nap/nap_common.h"

--- a/src/timing.c
+++ b/src/timing.c
@@ -14,9 +14,9 @@
 #include <string.h>
 #include <time.h>
 
+#include <libsbp/sbp.h>
 #include <libswiftnav/logging.h>
 #include <libswiftnav/linear_algebra.h>
-#include <libswiftnav/sbp.h>
 
 #include "board/nap/nap_common.h"
 #include "main.h"

--- a/stm32/Makefile.include
+++ b/stm32/Makefile.include
@@ -62,14 +62,16 @@ CFLAGS += -O0 -g -Wall -Wextra -Werror -std=gnu99 \
 
 CFLAGS += -I$(SWIFTNAV_ROOT)/src \
           -I$(SWIFTNAV_ROOT)/libopencm3/include \
+          -I$(SWIFTNAV_ROOT)/libsbp/c/include \
           -I$(SWIFTNAV_ROOT)/libswiftnav/include
 
 LDSCRIPT ?= $(SWIFTNAV_ROOT)/stm32/swiftnav.ld
 LDFLAGS += -T$(LDSCRIPT) -nostartfiles -Wl,--gc-sections \
            -mcpu=cortex-m4 -march=armv7e-m -mthumb \
            -mfloat-abi=hard -mfpu=fpv4-sp-d16 \
-           -lopencm3_stm32f4 -lswiftnav-static -llapacke -llapack -lcblas -lblas -lf2c -lm -lc -lnosys \
+           -lopencm3_stm32f4 -lsbp-static -lswiftnav-static -llapacke -llapack -lcblas -lblas -lf2c -lm -lc -lnosys \
            -L$(SWIFTNAV_ROOT)/libopencm3/lib \
+           -L$(SWIFTNAV_ROOT)/libsbp/c/build/src \
            -L$(SWIFTNAV_ROOT)/libswiftnav/build/lapacke \
            -L$(SWIFTNAV_ROOT)/libswiftnav/build/CBLAS/src \
            -L$(SWIFTNAV_ROOT)/libswiftnav/build/clapack-3.2.1-CMAKE/BLAS/SRC \


### PR DESCRIPTION
Integrate libsbp into the firmware:

1. Add libsbp submodule
2. Update Makefile machinery to build and link a static libsbp library
3. Bring in libswiftnav's sbp_utils to the firmware
4. Update from libswiftnav to libsbp based paths where applicable

The submodule branches supporting this request are:

https://github.com/swift-nav/libsbp/pull/40 -> [libsbp/mfine-remove-crc24q](https://github.com/swift-nav/libsbp/compare/mfine-remove-crc24q) 

https://github.com/swift-nav/libswiftnav/pull/96 -> [libswiftnav/mfine-remove-sbp](https://github.com/swift-nav/libswiftnav/compare/mfine-remove-sbp)

These changes should get some good time on the test bed!

/cc @mookerji @fnoble 
