### PR TITLE
Restricts flash.py queue size to 1.

### DIFF
--- a/scripts/flash.py
+++ b/scripts/flash.py
@@ -24,7 +24,7 @@ from sbp.piksi import *
 # 0.5 * ADDRS_PER_OP * MAX_QUEUED_OPS (plus SBP overhead) is how much each of
 # the STM32 TX/RX buffers will be filled by the program/read callback messages.
 ADDRS_PER_OP = 128
-MAX_QUEUED_OPS = 5
+MAX_QUEUED_OPS = 1
 
 M25_SR_SRWD = 1 << 7
 M25_SR_BP2  = 1 << 4


### PR DESCRIPTION
bootloader.py was observed to hang while programming in the HITL
setup. @gscmullin's thesis is that the UART RX handling overflows
because the unit under test is still receiving observations from its
partner.

Tested firmware installation across all the test rack units.

/cc @fnoble @gscmullin @cbeighley