### PR TITLE
Ephemeris changes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -127,6 +127,7 @@ CSRC := $(PORTSRC) \
         $(SWIFTNAV_ROOT)/src/nmea.o \
         $(SWIFTNAV_ROOT)/src/system_monitor.o \
         $(SWIFTNAV_ROOT)/src/flash_callbacks.o \
+        $(SWIFTNAV_ROOT)/src/ephemeris.o \
         main.c
 
 # C++ sources that can be compiled in ARM or THUMB mode depending on the global

--- a/src/base_obs.c
+++ b/src/base_obs.c
@@ -32,8 +32,7 @@
 #include "settings.h"
 #include "timing.h"
 #include "base_obs.h"
-
-extern ephemeris_t es[MAX_SATS];
+#include "ephemeris.h"
 
 /** \defgroup base_obs Base station observation handling
  * \{ */
@@ -278,6 +277,7 @@ static void obs_callback(u16 sender_id, u8 len, u8 msg[], void* context)
     }
     /* Check if we have an ephemeris for this satellite, we will need this to
      * fill in satellite position etc. parameters. */
+    chMtxLock(&es_mutex);
     if (ephemeris_good(&es[obs[i].prn], t)) {
       /* Unpack the observation into a navigation_measurement_t. */
       unpack_obs_content(
@@ -304,6 +304,7 @@ static void obs_callback(u16 sender_id, u8 len, u8 msg[], void* context)
       base_obss_rx.nm[base_obss_rx.n].tot = t;
       base_obss_rx.n++;
     }
+    chMtxUnlock();
   }
 
   /* If we can, and all the obs have been received, update to using the new

--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -146,3 +146,19 @@ void ephemeris_setup(void)
                     NORMALPRIO-1, nav_msg_thread, NULL);
 }
 
+/* This is called if the solution failed to converge.  We'll look for a
+ * suspect ephemeris, and revert to the last one we had if found.
+ */
+void ephemeris_check_fix(void)
+{
+  for (u8 i = 0; i < MAX_SATS; i++) {
+    if (es_confidence[i] || !es_old[i].valid)
+      continue;
+
+    log_warn("Reverting to old ephemeris for PRN%d\n", i+1);
+    chMtxLock(&es_mutex);
+    es[i] = es_old[i];
+    chMtxUnlock();
+  }
+}
+

--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2011-2015 Swift Navigation Inc.
+ * Contact: Fergus Noble <fergus@swift-nav.com>
+ *          Gareth McMullin <gareth@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <string.h>
+#include <libswiftnav/ephemeris.h>
+#include <libswiftnav/logging.h>
+#include <ch.h>
+
+#include "sbp.h"
+#include "track.h"
+#include "ephemeris.h"
+
+/* TODO: Think about thread safety when updating ephemerides. */
+ephemeris_t es[MAX_SATS] _CCM;
+ephemeris_t es_old[MAX_SATS] _CCM;
+
+static WORKING_AREA_CCM(wa_nav_msg_thread, 3000);
+static msg_t nav_msg_thread(void *arg)
+{
+  (void)arg;
+  chRegSetThreadName("nav msg");
+
+  memset(es, 0, sizeof(es));
+  for (u8 i=0; i<32; i++) {
+    es[i].prn = i;
+  }
+
+  while (TRUE) {
+
+    /* TODO: This should be trigged by a semaphore from the tracking loop, not
+     * just ran periodically. */
+
+
+    for (u8 i=0; i<nap_track_n_channels; i++) {
+      chThdSleepMilliseconds(100);
+      /* Check if there is a new nav msg subframe to process.
+       * TODO: move this into a function */
+      if (tracking_channel[i].state == TRACKING_RUNNING &&
+          tracking_channel[i].nav_msg.subframe_start_index) {
+
+        /* Save old ephemeris before potentially updating. */
+        memcpy(&es_old[tracking_channel[i].prn],
+               &es[tracking_channel[i].prn],
+               sizeof(ephemeris_t));
+
+        __asm__("CPSID i;");
+        s8 ret = process_subframe(&tracking_channel[i].nav_msg,
+                                  &es[tracking_channel[i].prn]);
+        __asm__("CPSIE i;");
+
+        if (ret < 0) {
+          log_info("PRN %02d ret %d\n", tracking_channel[i].prn+1, ret);
+        } else if (ret == 1) {
+          /* Decoded a new ephemeris. */
+
+          if (memcmp(&es[tracking_channel[i].prn],
+                     &es_old[tracking_channel[i].prn],
+                     sizeof(ephemeris_t))) {
+            log_info("New ephemeris for PRN %02d\n", tracking_channel[i].prn+1);
+          }
+
+          if (!es[tracking_channel[i].prn].healthy) {
+            log_info("PRN %02d unhealthy\n", tracking_channel[i].prn+1);
+          } else {
+            sbp_send_msg(SBP_MSG_EPHEMERIS,
+                         sizeof(ephemeris_t),
+                         (u8 *)&es[tracking_channel[i].prn]);
+          }
+        }
+      }
+    }
+  }
+
+  return 0;
+}
+
+void ephemeris_setup(void)
+{
+  chThdCreateStatic(wa_nav_msg_thread, sizeof(wa_nav_msg_thread),
+                    NORMALPRIO-1, nav_msg_thread, NULL);
+}
+

--- a/src/ephemeris.h
+++ b/src/ephemeris.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2015 Swift Navigation Inc.
+ * Contact: Fergus Noble <fergus@swift-nav.com>
+ *          Gareth McMullin <gareth@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+#ifndef SWIFTNAV_EPHEMERIS_H
+#define SWIFTNAV_EPHEMERIS_H
+
+#include <libswiftnav/constants.h>
+#include <libswiftnav/ephemeris.h>
+
+extern ephemeris_t es[MAX_SATS];
+
+void ephemeris_setup(void);
+
+#endif
+

--- a/src/ephemeris.h
+++ b/src/ephemeris.h
@@ -16,6 +16,7 @@
 #include <libswiftnav/constants.h>
 #include <libswiftnav/ephemeris.h>
 
+extern Mutex es_mutex;
 extern ephemeris_t es[MAX_SATS];
 
 void ephemeris_setup(void);

--- a/src/ephemeris.h
+++ b/src/ephemeris.h
@@ -20,7 +20,6 @@ extern Mutex es_mutex;
 extern ephemeris_t es[MAX_SATS];
 
 void ephemeris_setup(void);
-void ephemeris_check_fix(void);
 
 #endif
 

--- a/src/ephemeris.h
+++ b/src/ephemeris.h
@@ -20,6 +20,7 @@ extern Mutex es_mutex;
 extern ephemeris_t es[MAX_SATS];
 
 void ephemeris_setup(void);
+void ephemeris_check_fix(void);
 
 #endif
 

--- a/src/main.c
+++ b/src/main.c
@@ -35,6 +35,7 @@
 #include "simulator.h"
 #include "settings.h"
 #include "sbp_fileio.h"
+#include "ephemeris.h"
 
 extern void ext_setup(void);
 
@@ -42,74 +43,10 @@ extern void ext_setup(void);
 #define SYSTEM_CLOCK 130944000
 #endif
 
-/* TODO: Think about thread safety when updating ephemerides. */
-ephemeris_t es[32] _CCM;
-ephemeris_t es_old[32] _CCM;
-
 /* Required by exit() which is called from BLAS/LAPACK. */
 void _fini(void)
 {
   return;
-}
-
-static WORKING_AREA_CCM(wa_nav_msg_thread, 3000);
-static msg_t nav_msg_thread(void *arg)
-{
-  (void)arg;
-  chRegSetThreadName("nav msg");
-
-  memset(es, 0, sizeof(es));
-  for (u8 i=0; i<32; i++) {
-    es[i].prn = i;
-  }
-
-  while (TRUE) {
-
-    /* TODO: This should be trigged by a semaphore from the tracking loop, not
-     * just ran periodically. */
-
-
-    for (u8 i=0; i<nap_track_n_channels; i++) {
-      chThdSleepMilliseconds(100);
-      /* Check if there is a new nav msg subframe to process.
-       * TODO: move this into a function */
-      if (tracking_channel[i].state == TRACKING_RUNNING &&
-          tracking_channel[i].nav_msg.subframe_start_index) {
-
-        /* Save old ephemeris before potentially updating. */
-        memcpy(&es_old[tracking_channel[i].prn],
-               &es[tracking_channel[i].prn],
-               sizeof(ephemeris_t));
-
-        __asm__("CPSID i;");
-        s8 ret = process_subframe(&tracking_channel[i].nav_msg,
-                                  &es[tracking_channel[i].prn]);
-        __asm__("CPSIE i;");
-
-        if (ret < 0) {
-          log_info("PRN %02d ret %d\n", tracking_channel[i].prn+1, ret);
-        } else if (ret == 1) {
-          /* Decoded a new ephemeris. */
-
-          if (memcmp(&es[tracking_channel[i].prn],
-                     &es_old[tracking_channel[i].prn],
-                     sizeof(ephemeris_t))) {
-            log_info("New ephemeris for PRN %02d\n", tracking_channel[i].prn+1);
-          }
-
-          if (!es[tracking_channel[i].prn].healthy) {
-            log_info("PRN %02d unhealthy\n", tracking_channel[i].prn+1);
-          } else {
-            sbp_send_msg(SBP_MSG_EPHEMERIS,
-                         sizeof(ephemeris_t),
-                         (u8 *)&es[tracking_channel[i].prn]);
-          }
-        }
-      }
-    }
-  }
-
-  return 0;
 }
 
 /** Compare version strings.
@@ -279,8 +216,7 @@ int main(void)
                       TYPE_INT);
   READ_ONLY_PARAMETER("system_info", "nap_fft_index_bits", nap_acq_fft_index_bits, TYPE_INT);
 
-  chThdCreateStatic(wa_nav_msg_thread, sizeof(wa_nav_msg_thread),
-                    NORMALPRIO-1, nav_msg_thread, NULL);
+  ephemeris_setup();
 
   /* Send message to inform host we are up and running. */
   u32 startup_flags = 0;

--- a/src/solution.c
+++ b/src/solution.c
@@ -456,9 +456,6 @@ static msg_t solution_thread(void *arg)
           log_warn("PVT solver: %s (%d)\n", err_msg[-ret-1], ret);
         );
 
-        /* Revert to old ephemeris if any are suspect. */
-        ephemeris_check_fix();
-
         /* Send just the DOPs */
         solution_send_sbp(0, &dops);
       }

--- a/src/solution.c
+++ b/src/solution.c
@@ -456,6 +456,9 @@ static msg_t solution_thread(void *arg)
           log_warn("PVT solver: %s (%d)\n", err_msg[-ret-1], ret);
         );
 
+        /* Revert to old ephemeris if any are suspect. */
+        ephemeris_check_fix();
+
         /* Send just the DOPs */
         solution_send_sbp(0, &dops);
       }


### PR DESCRIPTION
- Move ephemeris routines to a new file.
- Protect ephemeris structures with a mutex
- Keep confidence flags, set when the same ephemeris is decoded for a second time.
- Use peer's ephemeris if received over SBP.
- Revert to previous ephemeris if solution fails to converge.

<!---
@huboard:{"order":304.0,"milestone_order":309,"custom_state":"ready"}
-->
