### PR TITLE
Reset ambiguity when SNR falls below threshold

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -345,8 +345,14 @@ void manage_track()
       }
 
       if (tracking_channel_snr(i) < TRACK_THRESHOLD) {
+        /* SNR has dropped below threshold, indicate that the carrier phase
+         * ambiguity is now unknown as cycle slips are likely. */
+        tracking_channel_ambiguity_unknown(i);
+        /* Update the latest time we were below the threshold. */
         tracking_channel[i].snr_below_threshold_count =
           tracking_channel[i].update_count;
+        /* Have we have been below the threshold for longer than
+         * `TRACK_SNR_THRES_COUNT`? */
         if (tracking_channel[i].update_count > TRACK_SNR_INIT_COUNT &&
             tracking_channel[i].update_count -
               tracking_channel[i].snr_above_threshold_count >
@@ -357,9 +363,11 @@ void manage_track()
           acq_prn_param[tracking_channel[i].prn].state = ACQ_PRN_TRIED;
         }
       } else {
+        /* SNR is good. */
         tracking_channel[i].snr_above_threshold_count =
           tracking_channel[i].update_count;
       }
+
     }
   }
 }

--- a/src/manage.c
+++ b/src/manage.c
@@ -380,7 +380,7 @@ s8 use_tracking_channel(u8 i)
       && (tracking_channel[i].update_count
             - tracking_channel[i].snr_below_threshold_count
             > TRACK_SNR_THRES_COUNT)
-      && (tracking_channel[i].TOW_ms > 0);
+      && (tracking_channel[i].TOW_ms >= 0);
 }
 
 u8 tracking_channels_ready()

--- a/src/track.c
+++ b/src/track.c
@@ -295,12 +295,29 @@ void tracking_channel_update(u8 channel)
  * Change tracking channel state to TRACKING_DISABLED and write 0 to SwiftNAP
  * tracking channel code / carrier frequencies to stop channel from raising
  * interrupts.
+ *
  * \param channel Tracking channel to disable.
  */
 void tracking_channel_disable(u8 channel)
 {
   nap_track_update_wr_blocking(channel, 0, 0, 0, 0);
   tracking_channel[channel].state = TRACKING_DISABLED;
+}
+
+/** Sets a channel's carrier phase ambiguity to unknown.
+ * Changes the lock counter to indicate to the consumer of the tracking channel
+ * observations that the carrier phase ambiguity may have changed. Also
+ * invalidates the time of week to indicate that the half cycle ambiguity must
+ * be resolved again by the navigation message processing. Should be called if
+ * a cycle slip is suspected.
+ *
+ * \param channel Tracking channel to disable.
+ */
+void tracking_channel_ambiguity_unknown(u8 channel)
+{
+  u8 prn = tracking_channel[channel].prn;
+  tracking_channel[channel].TOW_ms = TOW_INVALID;
+  tracking_channel[channel].lock_counter = ++tracking_lock_counters[prn];
 }
 
 /** Update channel measurement for a tracking channel.

--- a/src/track.c
+++ b/src/track.c
@@ -119,10 +119,10 @@ void tracking_channel_init(u8 channel, u8 prn, float carrier_freq,
   tracking_channel[channel].state = TRACKING_RUNNING;
   tracking_channel[channel].prn = prn;
   tracking_channel[channel].update_count = 0;
-  tracking_channel[channel].lock_counter = ++tracking_lock_counters[prn];
 
-  /* Use -1 to indicate an uninitialised value. */
-  tracking_channel[channel].TOW_ms = -1;
+  /* Initialize TOW_ms and lock_count. */
+  tracking_channel_ambiguity_unknown(channel);
+
   tracking_channel[channel].snr_above_threshold_count = 0;
   tracking_channel[channel].snr_below_threshold_count = 0;
 

--- a/src/track.h
+++ b/src/track.h
@@ -76,6 +76,7 @@ void tracking_channel_init(u8 channel, u8 prn, float carrier_freq,
 void tracking_channel_get_corrs(u8 channel);
 void tracking_channel_update(u8 channel);
 void tracking_channel_disable(u8 channel);
+void tracking_channel_ambiguity_unknown(u8 channel);
 void tracking_update_measurement(u8 channel, channel_measurement_t *meas);
 float tracking_channel_snr(u8 channel);
 void tracking_send_state(void);


### PR DESCRIPTION
Hopefully fixes issues with frequent half cycle slips seen in double difference observations when SNR falls below the threshold and then picks up again.

cc @gsmcmullin @henryhallam @imh

<!---
@huboard:{"custom_state":"","order":179.0,"milestone_order":356}
-->
