### PR TITLE
Support masking satellites for acquisition and tracking.

### DIFF
--- a/src/track.c
+++ b/src/track.c
@@ -209,6 +209,21 @@ void tracking_channel_get_corrs(u8 channel)
   }
 }
 
+/** Force a satellite to drop.
+ * This function is used for testing.  It clobbers the code frequency in the
+ * loop filter which destroys the correlations.  The satellite is dropped
+ * by manage.c which checks the SNR.
+ */
+void tracking_drop_satellite(u8 prn)
+{
+  for (u8 i=0; i<nap_track_n_channels; i++) {
+    if (tracking_channel[i].prn != prn)
+      continue;
+
+    tracking_channel[i].tl_state.code_filt.y += 500;
+  }
+}
+
 /** Update tracking channels after the end of an integration period.
  * Update update_count, sample_count, TOW, run loop filters and update
  * SwiftNAP tracking channel frequencies.

--- a/src/track.h
+++ b/src/track.h
@@ -83,5 +83,6 @@ void tracking_channel_ambiguity_unknown(u8 channel);
 void tracking_update_measurement(u8 channel, channel_measurement_t *meas);
 float tracking_channel_snr(u8 channel);
 void tracking_send_state(void);
+void tracking_drop_satellite(u8 prn);
 
 #endif


### PR DESCRIPTION
This adds support for a new SBP message MSG_MASK_SATELLITE which allows a mask to be set preventing a satellite from being acquired, and forcing a tracked satellite to be dropped.