### PR TITLE
Set default antenna selection to External

### DIFF
--- a/src/board/max2769.c
+++ b/src/board/max2769.c
@@ -143,7 +143,7 @@ void max2769_configure(void)
 
 }
 
-antenna_type_t antenna = AUTO;
+antenna_type_t antenna = EXTERNAL;
 
 bool antenna_changed(struct setting *s, const char *val)
 {


### PR DESCRIPTION
Customers have reported issues where the MAX's AUTO selection sometimes fails.  

The patch antenna shouldn't be used, so we default to EXTERNAL.

This should address: #372