### PR TITLE
Bring into line with libswiftnav dgnss state refactor

### DIFF
--- a/src/STM32F405xG.ld
+++ b/src/STM32F405xG.ld
@@ -122,7 +122,6 @@ SECTIONS
 
     .ccmram (NOLOAD) : {
       *(.ccmram*)
-      *(.bss.nkf)
     } > ccmram
 
     .data :

--- a/src/solution.h
+++ b/src/solution.h
@@ -18,6 +18,7 @@
 #include <libswiftnav/pvt.h>
 #include <libswiftnav/track.h>
 #include <libswiftnav/gpstime.h>
+#include <libswiftnav/dgnss_management.h>
 
 typedef enum {
   SOLN_MODE_LOW_LATENCY,
@@ -42,6 +43,8 @@ typedef enum {
 
 extern double soln_freq;
 extern u32 obs_output_divisor;
+
+extern dgnss_state_t dgnss_state;
 
 void solution_send_sbp(gnss_solution *soln, dops_t *dops);
 void solution_send_nmea(gnss_solution *soln, dops_t *dops,

--- a/src/system_monitor.c
+++ b/src/system_monitor.c
@@ -24,6 +24,7 @@
 #include "main.h"
 #include "sbp.h"
 #include "manage.h"
+#include "solution.h"
 #include "simulator.h"
 #include "system_monitor.h"
 
@@ -155,7 +156,7 @@ static msg_t system_monitor_thread(void *arg)
     if (simulation_enabled_for(SIMULATION_MODE_RTK)) {
       iar_state.num_hyps = 1;
     } else {
-      iar_state.num_hyps = dgnss_iar_num_hyps();
+      iar_state.num_hyps = dgnss_iar_num_hyps(&dgnss_state);
     }
     sbp_send_msg(SBP_MSG_IAR_STATE, sizeof(msg_iar_state_t), (u8 *)&iar_state);
 


### PR DESCRIPTION
Untested!

It seems a little disingenuous to initalize the whole dgnss_state only on an as-needed basis when we gain > 4 sats.  I'd be inclined to do that in solution_setup() instead.  Thoughts?

/cc @fnoble @mookerji 

<!---
@huboard:{"order":1.6932288904314419e-13,"milestone_order":405,"custom_state":""}
-->
