### PR TITLE
Observations output below CN0 threshold

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -448,12 +448,21 @@ static void manage_track()
 s8 use_tracking_channel(u8 i)
 {
   return (tracking_channel[i].state == TRACKING_RUNNING)
+      /* Check ephemeris is useable. */
+      /* TODO: Use libswiftnav function here. */
       && (es[tracking_channel[i].prn].valid == 1)
       && (es[tracking_channel[i].prn].healthy == 1)
+      /* Check SNR has been above threshold for the minimum time. */
       && (tracking_channel[i].update_count
             - tracking_channel[i].snr_below_threshold_count
             > TRACK_SNR_THRES_COUNT)
-      && (tracking_channel[i].TOW_ms >= 0);
+      /* Check the channel time of week has been decoded. */
+      && (tracking_channel[i].TOW_ms >= 0)
+      /* Check the current SNR.
+       * NOTE: `snr_below_threshold_count` will not be reset immediately if the
+       * SNR drops, only once `manage_track()` is called, so this additional
+       * test is required here. */
+      && (tracking_channel_snr(i) >= TRACK_THRESHOLD);
 }
 
 u8 tracking_channels_ready()


### PR DESCRIPTION
**Why:** We have observed observations being generated with CN0 values below the tracking threshold specified in the firmware. These observations also frequently contain cycle slips (as may be expected given the low SNR). It is hypothesized that these observations are one of the main causes of fixed -> float transitions.

**How:** Right now we don't directly test the SNR when checking if we should filter out an observation, we only check the hysteresis counter. I think that what we are seeing is somehow the `manage_track()` thread is not getting called in time to update and hence we are outputting bad measurements. The easiest fix is to just directly check the SNR each time in addition to looking at the hysteresis counter.

**Testing:** HITL test has been created to check for this effect, see `TrackingTest_observations_obs_cn0_below_thres` and `TrackingTest_observations_obs_cn0_min`.

Hopefully helps with #81.