### PR TITLE
Wait for 5s after mode changes for transients to stabilize

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -456,6 +456,11 @@ s8 use_tracking_channel(u8 i)
       && (tracking_channel[i].update_count
             - tracking_channel[i].snr_below_threshold_count
             > TRACK_SNR_THRES_COUNT)
+      /* Check that a minimum time has elapsed since the last tracking channel
+       * mode change, to allow any transients to stabilize. */
+      && (tracking_channel[i].update_count
+            - tracking_channel[i].mode_change_count
+            > TRACK_STABILIZATION_COUNT)
       /* Check the channel time of week has been decoded. */
       && (tracking_channel[i].TOW_ms >= 0)
       /* Check the current SNR.

--- a/src/manage.h
+++ b/src/manage.h
@@ -25,6 +25,9 @@
 #define TRACK_THRESHOLD 33.0
 #define TRACK_SNR_INIT_COUNT 1000
 #define TRACK_SNR_THRES_COUNT 2000
+/** How many milliseconds to wait for the tracking loops to
+ * stabilize after any mode change. */
+#define TRACK_STABILIZATION_COUNT 5000
 
 #define ACQ_FULL_CF_MIN  -8500
 #define ACQ_FULL_CF_MAX   8500

--- a/src/track.c
+++ b/src/track.c
@@ -119,6 +119,7 @@ void tracking_channel_init(u8 channel, u8 prn, float carrier_freq,
   chan->state = TRACKING_RUNNING;
   chan->prn = prn;
   chan->update_count = 0;
+  chan->mode_change_count = 0;
 
   /* Initialize TOW_ms and lock_count. */
   tracking_channel_ambiguity_unknown(channel);
@@ -305,6 +306,10 @@ void tracking_channel_update(u8 channel)
         float err = alias_detect_second(&chan->alias_detect, I, Q);
         if (fabs(err) > 10) {
           log_warn("False phase lock detect PRN%d: err=%f\n", chan->prn+1, err);
+
+          /* Indicate that a mode change has ocurred. */
+          chan->mode_change_count = chan->update_count;
+
           chan->tl_state.carr_freq += err;
           chan->tl_state.carr_filt.y = chan->tl_state.carr_freq;
         }
@@ -324,6 +329,9 @@ void tracking_channel_update(u8 channel)
                       chan->tl_state.code_freq, 1, 0.7, 1,
                       chan->tl_state.carr_freq, 10, 0.7, 1,
                       0);
+
+        /* Indicate that a mode change has ocurred. */
+        chan->mode_change_count = chan->update_count;
       }
 
       nap_track_update_wr_blocking(

--- a/src/track.h
+++ b/src/track.h
@@ -34,6 +34,7 @@ typedef struct {
   u8 state;                    /**< Tracking channel state. */
   /* TODO : u32's big enough? */
   u32 update_count;            /**< Total number of tracking channel ms updates. */
+  u32 mode_change_count;       /**< update_count at last mode change. */
   s32 TOW_ms;                  /**< TOW in ms. */
   u32 snr_above_threshold_count;     /**< update_count value when SNR was last above a certain margin. */
   u32 snr_below_threshold_count;     /**< update_count value when SNR was last below a certain margin. */


### PR DESCRIPTION
**Why:** We have observed strange things happening when satellites first start outputting observations. Often we will see a half-cycle slip within a few data points of the beginning and sometimes we will get only a few data points for a satellite that appears not to have phase lock. These effects are causing serious mischief in the filters.

It is hypothesized that this is because we transition to 20ms tracking right at the instant we start outputting observations.

**How:** Wait for a while (5s) after "mode changes" to allow the tracking loops time to stabilize and ride over any strange transients that occur at these events. This also gives time for the alias detection to do its job.

Mode changes right now are:
 - Changes to integration length
 - Frequency adjustments for alias lock correction

This is implemented by adding a field `mode_change_count` to the state struct that is set equal to `update_count` on any events expected to cause transients. In `use_tracking_channel()` we now compute the different between `mode_change_count` and `update_count` to check sufficient time has elapsed since the mode change.

**Testing:** HITL

cc: @gsmcmullin @imh @mookerji @cbeighley 