### PR TITLE
New libsbp and new bootloader messages

### DIFF
--- a/src/board/nap/nap_common.c
+++ b/src/board/nap/nap_common.c
@@ -171,16 +171,21 @@ void nap_rd_dna_callback(u16 sender_id, u8 len, u8 msg[], void* context)
   (void)sender_id; (void)len; (void)msg; (void) context;
   u8 dna[8];
   nap_rd_dna(dna);
-  sbp_send_msg(SBP_MSG_NAP_DEVICE_DNA, 8, dna);
+
+  sbp_send_msg(SBP_MSG_NAP_DEVICE_DNA_DEVICE, 8, dna);
 }
 
 /** Setup NAP callbacks. */
 void nap_callbacks_setup(void)
 {
   static sbp_msg_callbacks_node_t nap_dna_node;
+  static sbp_msg_callbacks_node_t nap_dna_device_node;
 
-  sbp_register_cbk(SBP_MSG_NAP_DEVICE_DNA, &nap_rd_dna_callback,
+  sbp_register_cbk(SBP_MSG_NAP_DEVICE_DNA_HOST, &nap_rd_dna_callback,
                    &nap_dna_node);
+  /* TODO: This is deprecated. Replaced by above SBP_MSG_NAP_DEVICE_DNA_HOST. */
+  sbp_register_cbk(SBP_MSG_NAP_DEVICE_DNA_DEVICE, &nap_rd_dna_callback,
+                   &nap_dna_device_node);
 }
 
 /** Do an SPI transfer to/from one of the NAP's internal registers.

--- a/src/board/nap/nap_common.c
+++ b/src/board/nap/nap_common.c
@@ -179,13 +179,9 @@ void nap_rd_dna_callback(u16 sender_id, u8 len, u8 msg[], void* context)
 void nap_callbacks_setup(void)
 {
   static sbp_msg_callbacks_node_t nap_dna_node;
-  static sbp_msg_callbacks_node_t nap_dna_device_node;
 
   sbp_register_cbk(SBP_MSG_NAP_DEVICE_DNA_HOST, &nap_rd_dna_callback,
                    &nap_dna_node);
-  /* TODO: This is deprecated. Replaced by above SBP_MSG_NAP_DEVICE_DNA_HOST. */
-  sbp_register_cbk(SBP_MSG_NAP_DEVICE_DNA_DEVICE, &nap_rd_dna_callback,
-                   &nap_dna_device_node);
 }
 
 /** Do an SPI transfer to/from one of the NAP's internal registers.

--- a/src/flash_callbacks.c
+++ b/src/flash_callbacks.c
@@ -104,10 +104,10 @@ void flash_program_callback(u16 sender_id, u8 len, u8 msg[], void* context)
 }
 
 /** Callback to read a set of addresses of either the STM or M25 flash.
- * Replies with a SBP_MSG_FLASH_READ message containing the read data on success or
- * a SBP_MSG_FLASH_DONE message containing the return code FLASH_INVALID_LEN if the
- * maximum read size is exceeded or FLASH_INVALID_ADDR if the address is
- * outside of the allowed range.
+ * Replies with a SBP_MSG_FLASH_READ_DEVICE message containing the read data on
+ * success or a SBP_MSG_FLASH_DONE message containing the return code
+ * FLASH_INVALID_LEN if the maximum read size is exceeded or FLASH_INVALID_ADDR
+ * if the address is outside of the allowed range.
  *
  * \param buff Array of u8 (length 5) :
  *             - [0]   Flash to read (FLASH_STM or FLASH_M25)
@@ -161,7 +161,7 @@ void flash_read_callback(u16 sender_id, u8 len, u8 msg[], void* context)
   if (ret != 0)
     sbp_send_msg(SBP_MSG_FLASH_DONE, 1, &ret);
   else
-    sbp_send_msg(SBP_MSG_FLASH_READ, length + 5, callback_data);
+    sbp_send_msg(SBP_MSG_FLASH_READ_DEVICE, length + 5, callback_data);
 }
 
 /** Callback to write to the 8-bit M25 flash status register.
@@ -219,7 +219,9 @@ void flash_callbacks_register(void)
 {
   static sbp_msg_callbacks_node_t flash_erase_sector_node;
   static sbp_msg_callbacks_node_t flash_read_node;
+  static sbp_msg_callbacks_node_t flash_read_device_node;
   static sbp_msg_callbacks_node_t flash_program_node;
+  static sbp_msg_callbacks_node_t flash_done_node;
 
   static sbp_msg_callbacks_node_t stm_flash_lock_sector_node;
   static sbp_msg_callbacks_node_t stm_flash_unlock_sector_node;
@@ -229,12 +231,20 @@ void flash_callbacks_register(void)
   sbp_register_cbk(SBP_MSG_FLASH_ERASE,
                         &flash_erase_sector_callback,
                         &flash_erase_sector_node);
-  sbp_register_cbk(SBP_MSG_FLASH_READ,
+  sbp_register_cbk(SBP_MSG_FLASH_READ_HOST,
                         &flash_read_callback,
                         &flash_read_node);
+  /* TODO: This is deprecated. Replaced by above SBP_MSG_FLASH_READ_HOST. */
+  sbp_register_cbk(SBP_MSG_FLASH_READ_DEVICE,
+                        &flash_read_callback,
+                        &flash_read_device_node);
   sbp_register_cbk(SBP_MSG_FLASH_PROGRAM,
                         &flash_program_callback,
                         &flash_program_node);
+  /* TODO: This is deprecated. Replaced by above SBP_MSG_FLASH_PROGRAM. */
+  sbp_register_cbk(SBP_MSG_FLASH_DONE,
+                        &flash_program_callback,
+                        &flash_done_node);
 
   sbp_register_cbk(SBP_MSG_STM_FLASH_LOCK_SECTOR,
                         &stm_flash_lock_sector_callback,
@@ -255,16 +265,21 @@ void stm_unique_id_callback(u16 sender_id, u8 len, u8 msg[], void* context)
 {
   (void)sender_id; (void)len; (void)msg; (void) context;
 
-  sbp_send_msg(SBP_MSG_STM_UNIQUE_ID, 12, (u8*)STM_UNIQUE_ID_ADDR);
+  sbp_send_msg(SBP_MSG_STM_UNIQUE_ID_DEVICE, 12, (u8*)STM_UNIQUE_ID_ADDR);
 }
 
 /** Register callback to read Device's Unique ID. */
 void stm_unique_id_callback_register(void)
 {
   static sbp_msg_callbacks_node_t stm_unique_id_node;
+  static sbp_msg_callbacks_node_t stm_unique_id_device_node;
 
-  sbp_register_cbk(SBP_MSG_STM_UNIQUE_ID,
+  sbp_register_cbk(SBP_MSG_STM_UNIQUE_ID_HOST,
                         &stm_unique_id_callback,
                         &stm_unique_id_node);
+  /* TODO: This is deprecated. Replaced by above SBP_MSG_STM_UNIQUE_ID_HOST. */
+  sbp_register_cbk(SBP_MSG_STM_UNIQUE_ID_DEVICE,
+                        &stm_unique_id_callback,
+                        &stm_unique_id_device_node);
 }
 

--- a/src/flash_callbacks.c
+++ b/src/flash_callbacks.c
@@ -219,9 +219,7 @@ void flash_callbacks_register(void)
 {
   static sbp_msg_callbacks_node_t flash_erase_sector_node;
   static sbp_msg_callbacks_node_t flash_read_node;
-  static sbp_msg_callbacks_node_t flash_read_device_node;
   static sbp_msg_callbacks_node_t flash_program_node;
-  static sbp_msg_callbacks_node_t flash_done_node;
 
   static sbp_msg_callbacks_node_t stm_flash_lock_sector_node;
   static sbp_msg_callbacks_node_t stm_flash_unlock_sector_node;
@@ -234,17 +232,9 @@ void flash_callbacks_register(void)
   sbp_register_cbk(SBP_MSG_FLASH_READ_HOST,
                         &flash_read_callback,
                         &flash_read_node);
-  /* TODO: This is deprecated. Replaced by above SBP_MSG_FLASH_READ_HOST. */
-  sbp_register_cbk(SBP_MSG_FLASH_READ_DEVICE,
-                        &flash_read_callback,
-                        &flash_read_device_node);
   sbp_register_cbk(SBP_MSG_FLASH_PROGRAM,
                         &flash_program_callback,
                         &flash_program_node);
-  /* TODO: This is deprecated. Replaced by above SBP_MSG_FLASH_PROGRAM. */
-  sbp_register_cbk(SBP_MSG_FLASH_DONE,
-                        &flash_program_callback,
-                        &flash_done_node);
 
   sbp_register_cbk(SBP_MSG_STM_FLASH_LOCK_SECTOR,
                         &stm_flash_lock_sector_callback,
@@ -272,14 +262,9 @@ void stm_unique_id_callback(u16 sender_id, u8 len, u8 msg[], void* context)
 void stm_unique_id_callback_register(void)
 {
   static sbp_msg_callbacks_node_t stm_unique_id_node;
-  static sbp_msg_callbacks_node_t stm_unique_id_device_node;
 
   sbp_register_cbk(SBP_MSG_STM_UNIQUE_ID_HOST,
                         &stm_unique_id_callback,
                         &stm_unique_id_node);
-  /* TODO: This is deprecated. Replaced by above SBP_MSG_STM_UNIQUE_ID_HOST. */
-  sbp_register_cbk(SBP_MSG_STM_UNIQUE_ID_DEVICE,
-                        &stm_unique_id_callback,
-                        &stm_unique_id_device_node);
 }
 

--- a/src/system_monitor.c
+++ b/src/system_monitor.c
@@ -15,6 +15,7 @@
 #include <ch.h>
 
 #include <libsbp/system.h>
+#include <libsbp/version.h>
 #include <libswiftnav/logging.h>
 #include <libswiftnav/dgnss_management.h>
 
@@ -143,7 +144,7 @@ static msg_t system_monitor_thread(void *arg)
   systime_t time = chTimeNow();
 
   while (TRUE) {
-    u32 status_flags = 0;
+    u32 status_flags = SBP_MAJOR_VERSION << 8 | SBP_MINOR_VERSION;
     sbp_send_msg(SBP_MSG_HEARTBEAT, sizeof(status_flags), (u8 *)&status_flags);
 
     /* If we are in base station mode then broadcast our known location. */


### PR DESCRIPTION
Bring in new sbp and begin supporting the new message paths with callbacks. Handled the following new pairs:

+ `FLASH_PROGRAM` / `FLASH_DONE`
+ `STM_UNIQUE_ID_HOST` / `STM_UNIQUE_ID_DEVICE`
+ `NAP_DEVICE_DNA_HOST` / `NAP_DEVICE_DNA_DEVICE`

But *NOT*:

+ `BOOTLOADER_HANDSHAKE_HOST` / `BOOTLOADER_HANDSHAKE_DEVICE`

pair - where is that callback/message?

Approach here is to support both new and old style messages until we're ready to remove the old style messages.

/cc @cbeighley 


<!---
@huboard:{"order":55.5}
-->
