### PR TITLE
Update assert() to use screaming death

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -92,6 +92,17 @@ void _screaming_death(const char *pos, const char *msg)
 
 /* OS syscall implementations related to error conditions */
 
+/** Custom assert() failure function. Calls screaming_death(). */
+void __assert_func(const char *_file, int _line, const char *_func,
+                   const char *_expr)
+{
+  char pos[255];
+  char msg[255];
+  sprintf(pos, "%s:%s():%d", _file, _func, _line);
+  sprintf(msg, "assertion '%s' failed", _expr);
+  _screaming_death(pos, msg);
+}
+
 /** Required by exit() which is (hopefully not) called from BLAS/LAPACK. */
 void _fini(void)
 {

--- a/src/sbp.c
+++ b/src/sbp.c
@@ -303,14 +303,6 @@ void sbp_process_messages()
   }
 }
 
-void __assert_func(const char *_file, int _line, const char *_func,
-                   const char *_expr)
-{
-  log_error("assertion '%s' failed: file '%s', line %d, function: %s\n",
-            _expr, _file, _line, _func);
-  abort();
-}
-
 /** Directs printf's output to the SBP interface */
 int _write(int file, char *ptr, int len)
 {


### PR DESCRIPTION
Calls to `assert()` weren't being properly output previously. Now we direct the output to `_screaming_death()`.

Tested on the bench, doesn't need HITL.

cc: @cbeighley