### PR TITLE
Verify that loaded almanac is valid (within a certain week number range)

### DIFF
--- a/src/manage.h
+++ b/src/manage.h
@@ -55,6 +55,10 @@
 #define MANAGE_TRACK_THREAD_PRIORITY (NORMALPRIO-2)
 #define MANAGE_TRACK_THREAD_STACK   1400
 
+/** The age of an almanac in weeks
+    before it is no longer valid. */
+#define MAX_ALM_WEEK_DIFF 6
+
 /** \} */
 
 void manage_acq_setup(void);


### PR DESCRIPTION
Invalidate almanac in memory if invalid for a particular PRN when discovered.

This is a check that is most relevant in the future when we are decoding the almanac or sending it to the device.  It may affect people who haven't used Piksi for a long time but used it last when we used to send the almanac to the device through the console.
