### PR TITLE
use_tracking_channel(): use libswiftnav ephemeris_good() to reject most bad TOWs

### DIFF
--- a/src/system_monitor.c
+++ b/src/system_monitor.c
@@ -80,7 +80,7 @@ void send_thread_states()
   g_ctime = 0;
 }
 
-static WORKING_AREA_CCM(wa_track_status_thread, 128);
+static WORKING_AREA_CCM(wa_track_status_thread, 256);
 static msg_t track_status_thread(void *arg)
 {
   (void)arg;


### PR DESCRIPTION
Bad tracking channel TOWs occasionally creep in.  I'm working on a separate overhaul of the nav bit parsing to take care of that, but it's also sensible to check that the TOW is within a few hours of the ephemeris TOE/TOC.  We were checking that already, but merely printing a warning if it were the case, and using the resulting bogus satellite state anyway.  With this check, we'll exclude a channel from the set of obs used for SPP and RTK if its TOW is too far out of whack wrt the ephemeris.

cc @fnoble @mookerji @denniszollo 

<!---
@huboard:{"order":469.0,"milestone_order":476,"custom_state":""}
-->
