### PR TITLE
Complain repeatedly if the NAP firmware version is incompatible

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -160,11 +160,11 @@ int main(void)
   /* Check we are running a compatible version of the NAP firmware. */
   const char *required_nap_version = "v0.12";
   if (compare_version(nap_version_string, required_nap_version) < 0) {
-    log_error("NAP firmware version newer than %s required, please update!\n"
+    while (1) {
+      log_error("NAP firmware version newer than %s required, please update!\n"
               "(instructions can be found at http://docs.swift-nav.com/)\n",
               required_nap_version);
-    while (1) {
-      chThdSleepSeconds(60);
+      chThdSleepSeconds(2);
     }
   }
 

--- a/src/main.c
+++ b/src/main.c
@@ -158,12 +158,12 @@ int main(void)
   log_info("NAP firmware version: %s\n", nap_version_string);
 
   /* Check we are running a compatible version of the NAP firmware. */
-  const char *required_nap_version = "v0.12";
+  const char *required_nap_version = "v0.14";
   if (compare_version(nap_version_string, required_nap_version) < 0) {
     while (1) {
       log_error("NAP firmware version newer than %s required, please update!\n"
-              "(instructions can be found at http://docs.swift-nav.com/)\n",
-              required_nap_version);
+                "(instructions can be found at http://docs.swift-nav.com/)\n",
+                required_nap_version);
       chThdSleepSeconds(2);
     }
   }


### PR DESCRIPTION
cc @denniszollo 
Unfortunately getting the heartbeat message to send at this point is a bit tricky.  Is that necessary so that host software knows the SBP protocol version?  We could probably send a precanned heartbeat msg (separate from the usual heartbeat thread) if that would work.