### PR TITLE
random: better checks and thread safety on RNG.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -18,6 +18,7 @@
 
 #include <ch.h>
 
+#include "peripherals/random.h"
 #include "board/leds.h"
 #include "board/max2769.h"
 #include "board/nap/nap_conf.h"
@@ -176,6 +177,8 @@ int main(void)
   ext_event_setup();
   position_setup();
   tracking_setup();
+
+  rng_setup();
   manage_acq_setup();
   manage_track_setup();
   system_monitor_setup();

--- a/src/peripherals/random.c
+++ b/src/peripherals/random.c
@@ -13,8 +13,16 @@
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/f4/rng.h>
 
+#include <ch.h>
+
 #include "libswiftnav/common.h"
+#include "libswiftnav/logging.h"
 #include "random.h"
+
+
+#define RANDOM_MAX_TRIES 100
+
+static MUTEX_DECL(rng_mutex);
 
 /* These two methods copied from:
  * https://raw.githubusercontent.com/libopencm3/libopencm3-examples/058298fd78c23639a1a135871e6c363c9d6153f6/examples/stm32/f4/stm32f4-discovery/random/random.c
@@ -34,17 +42,38 @@ void rng_setup(void)
 
 u32 random_int(void)
 {
+  chMtxLock(&rng_mutex);
+
   static u32 last_value;
-  static u32 new_value;
-  u32 error_bits = 0;
-  error_bits = RNG_SR_SEIS | RNG_SR_CEIS;
-  while (new_value == last_value) {
-    /* Check for error flags and if data is ready. */
-    if (((RNG_SR & error_bits) == 0) &&
-        ((RNG_SR & RNG_SR_DRDY) == 1)) {
-      new_value = RNG_DR;
+  u32 new_value = last_value;
+  int tries = 0;
+  do {
+    u32 sr;
+    /* Check for error flags. */
+    if ((sr = RNG_SR)) {
+      if (sr & RNG_SR_SEIS) {
+        /* Seed error, we must reinitialise */
+        log_warn("random: Seed error, restarting RNG 0x%"PRIx32"\n", sr);
+        RNG_CR &= ~RNG_CR_RNGEN;
+        RNG_CR |= RNG_CR_RNGEN;
+      }
+      /* Write back as zero to clear */
+      RNG_SR = ~(sr & (RNG_SR_SEIS | RNG_SR_CEIS));
     }
+    /* Check if data is ready. */
+    if ((RNG_SR & RNG_SR_DRDY) == 0)
+      continue;
+
+    tries++;
+    new_value = RNG_DR;
+  } while ((new_value == last_value) && (tries < RANDOM_MAX_TRIES));
+
+  if (new_value == last_value) {
+    log_error("random: Gave up waiting for random number!\n");
+    new_value = last_value + 1;
   }
   last_value = new_value;
+
+  chMtxUnlock();
   return new_value;
 }

--- a/src/track.c
+++ b/src/track.c
@@ -55,8 +55,8 @@ static u16 tracking_lock_counters[MAX_SATS];
 
 /* Initialize the lock counters to random numbers
  */
-void initialize_lock_counters(void) {
-  rng_setup();
+void initialize_lock_counters(void)
+{
   for (u8 i=0; i < MAX_SATS; i++) {
     tracking_lock_counters[i] = random_int();
   }


### PR DESCRIPTION
Check and clear error flags from RNG, restarting RNG in the case of seed error.
Report seed error and too many iterations.
Protect RNG access with a mutex.