### PR TITLE
Widen the PRN field

### DIFF
--- a/src/acq.c
+++ b/src/acq.c
@@ -48,7 +48,7 @@ void acq_send_result(u8 prn, float snr, float cp, float cf)
 {
   msg_acq_result_t acq_result_msg;
 
-  acq_result_msg.prn = prn;
+  acq_result_msg.sid = prn; /* TODO prn -> sid */
   acq_result_msg.snr = snr;
   acq_result_msg.cp = cp;
   acq_result_msg.cf = cf;

--- a/src/base_obs.c
+++ b/src/base_obs.c
@@ -272,17 +272,17 @@ static void obs_callback(u16 sender_id, u8 len, u8 msg[], void* context)
   for (u8 i=0; i<obs_in_msg; i++) {
     /* Check the PRN is valid. e.g. simulation mode outputs test observations
      * with PRNs >200. */
-    if (obs[i].prn > 31) {
+    if (obs[i].sid > 31) { /* TODO prn - sid; assume everything below is 0x1F masked! */
       continue;
     }
 
     /* Flag this as visible/viable to acquisition/search */
-    manage_set_obs_hint(obs[i].prn);
+    manage_set_obs_hint(obs[i].sid);
 
     /* Check if we have an ephemeris for this satellite, we will need this to
      * fill in satellite position etc. parameters. */
     chMtxLock(&es_mutex);
-    if (ephemeris_good(&es[obs[i].prn], t)) {
+    if (ephemeris_good(&es[obs[i].sid], t)) {
       /* Unpack the observation into a navigation_measurement_t. */
       unpack_obs_content(
         &obs[i],
@@ -295,7 +295,7 @@ static void obs_callback(u16 sender_id, u8 len, u8 msg[], void* context)
       double clock_err;
       double clock_rate_err;
       /* Calculate satellite parameters using the ephemeris. */
-      calc_sat_state(&es[obs[i].prn], t,
+      calc_sat_state(&es[obs[i].sid], t,
                      base_obss_rx.nm[base_obss_rx.n].sat_pos,
                      base_obss_rx.nm[base_obss_rx.n].sat_vel,
                      &clock_err, &clock_rate_err);

--- a/src/base_obs.c
+++ b/src/base_obs.c
@@ -318,6 +318,14 @@ static void obs_callback(u16 sender_id, u8 len, u8 msg[], void* context)
   }
 }
 
+/** SBP callback for the old style observation messages.
+ * Just logs a deprecation warning. */
+static void deprecated_callback(u16 sender_id, u8 len, u8 msg[], void* context)
+{
+  (void) context; (void) len; (void) msg; (void) sender_id;
+  log_error("Receiving an old deprecated observation message.\n");
+}
+
 /** Setup the base station observation handling subsystem. */
 void base_obs_setup()
 {
@@ -340,6 +348,13 @@ void base_obs_setup()
     SBP_MSG_OBS,
     &obs_callback,
     &obs_packed_node
+  );
+
+  static sbp_msg_callbacks_node_t deprecated_node;
+  sbp_register_cbk(
+    SBP_MSG_OBS_DEP_A,
+    &deprecated_callback,
+    &deprecated_node
   );
 }
 

--- a/src/board/nap/nap_common.c
+++ b/src/board/nap/nap_common.c
@@ -172,7 +172,7 @@ void nap_rd_dna_callback(u16 sender_id, u8 len, u8 msg[], void* context)
   u8 dna[8];
   nap_rd_dna(dna);
 
-  sbp_send_msg(SBP_MSG_NAP_DEVICE_DNA_RESPONSE, 8, dna);
+  sbp_send_msg(SBP_MSG_NAP_DEVICE_DNA_RESP, 8, dna);
 }
 
 /** Setup NAP callbacks. */
@@ -180,7 +180,7 @@ void nap_callbacks_setup(void)
 {
   static sbp_msg_callbacks_node_t nap_dna_node;
 
-  sbp_register_cbk(SBP_MSG_NAP_DEVICE_DNA_REQUEST, &nap_rd_dna_callback,
+  sbp_register_cbk(SBP_MSG_NAP_DEVICE_DNA_REQ, &nap_rd_dna_callback,
                    &nap_dna_node);
 }
 

--- a/src/init.c
+++ b/src/init.c
@@ -80,7 +80,7 @@ static void stm_unique_id_callback(u16 sender_id, u8 len, u8 msg[], void* contex
 {
   (void)sender_id; (void)len; (void)msg; (void) context;
 
-  sbp_send_msg(SBP_MSG_STM_UNIQUE_ID_RESPONSE, 12, (u8*)STM_UNIQUE_ID_ADDR);
+  sbp_send_msg(SBP_MSG_STM_UNIQUE_ID_RESP, 12, (u8*)STM_UNIQUE_ID_ADDR);
 }
 
 /** Register callback to read Device's Unique ID. */
@@ -88,7 +88,7 @@ static void stm_unique_id_callback_register(void)
 {
   static sbp_msg_callbacks_node_t stm_unique_id_node;
 
-  sbp_register_cbk(SBP_MSG_STM_UNIQUE_ID_REQUEST,
+  sbp_register_cbk(SBP_MSG_STM_UNIQUE_ID_REQ,
                    &stm_unique_id_callback,
                    &stm_unique_id_node);
 }

--- a/src/manage.c
+++ b/src/manage.c
@@ -120,14 +120,16 @@ static void mask_sat_callback(u16 sender_id, u8 len, u8 msg[], void* context)
 
   msg_mask_satellite_t *m = (msg_mask_satellite_t *)msg;
 
-  log_info("Mask for PRN %02d = 0x%02x\n", m->prn+1, m->mask);
+  u8 prn = m->sid & 0x1F; /* TODO prn -> sid */
+
+  log_info("Mask for PRN %02d = 0x%02x\n", prn+1, m->mask);
   if (m->mask & MASK_ACQUISITION) {
-    acq_prn_param[m->prn].masked = true;
+    acq_prn_param[prn].masked = true;
   } else {
-    acq_prn_param[m->prn].masked = false;
+    acq_prn_param[prn].masked = false;
   }
   if (m->mask & MASK_TRACKING) {
-    tracking_drop_satellite(m->prn);
+    tracking_drop_satellite(prn);
   }
 }
 

--- a/src/sbp_fileio.c
+++ b/src/sbp_fileio.c
@@ -32,13 +32,13 @@ void sbp_fileio_setup(void)
 {
   static sbp_msg_callbacks_node_t read_node;
   sbp_register_cbk(
-    SBP_MSG_FILEIO_READ_REQUEST,
+    SBP_MSG_FILEIO_READ_REQ,
     &read_cb,
     &read_node
   );
   static sbp_msg_callbacks_node_t read_dir_node;
   sbp_register_cbk(
-    SBP_MSG_FILEIO_READ_DIR_REQUEST,
+    SBP_MSG_FILEIO_READ_DIR_REQ,
     &read_dir_cb,
     &read_dir_node
   );
@@ -50,17 +50,17 @@ void sbp_fileio_setup(void)
   );
   static sbp_msg_callbacks_node_t write_node;
   sbp_register_cbk(
-    SBP_MSG_FILEIO_WRITE_REQUEST,
+    SBP_MSG_FILEIO_WRITE_REQ,
     &write_cb,
     &write_node
   );
 }
 
 /** File read callback.
- * Responds to a SBP_MSG_FILEIO_READ_REQUEST message.
+ * Responds to a SBP_MSG_FILEIO_READ_REQ message.
  *
  * Reads a certain length (up to 255 bytes) from a given offset. Returns the
- * data in a SBP_MSG_FILEIO_READ_RESPONSE message where the message length field
+ * data in a SBP_MSG_FILEIO_READ_RESP message where the message length field
  * indicates how many bytes were succesfully read.
  */
 static void read_cb(u16 sender_id, u8 len, u8 msg[], void* context)
@@ -86,16 +86,16 @@ static void read_cb(u16 sender_id, u8 len, u8 msg[], void* context)
   len += cfs_read(f, buf + len, readlen);
   cfs_close(f);
 
-  sbp_send_msg(SBP_MSG_FILEIO_READ_RESPONSE, len, buf);
+  sbp_send_msg(SBP_MSG_FILEIO_READ_RESP, len, buf);
 }
 
 /** Directory listing callback.
- * Responds to a SBP_MSG_FILEIO_READ_DIR_REQUEST message.
+ * Responds to a SBP_MSG_FILEIO_READ_DIR_REQ message.
  *
  * The offset parameter can be used to skip the first n elements of the file
  * list.
  *
- * Returns a SBP_MSG_FILEIO_READ_DIR_RESPONSE message containing the directory
+ * Returns a SBP_MSG_FILEIO_READ_DIR_RESP message containing the directory
  * listings as a NULL delimited list. The listing is chunked over multiple SBP
  * packets and the end of the list is identified by an entry containing just
  * the character 0xFF.
@@ -133,7 +133,7 @@ static void read_dir_cb(u16 sender_id, u8 len, u8 msg[], void* context)
 
   cfs_closedir(&dir);
 
-  sbp_send_msg(SBP_MSG_FILEIO_READ_DIR_RESPONSE, len, buf);
+  sbp_send_msg(SBP_MSG_FILEIO_READ_DIR_RESP, len, buf);
 }
 
 /* Remove file callback.
@@ -157,10 +157,10 @@ static void remove_cb(u16 sender_id, u8 len, u8 msg[], void* context)
 }
 
 /* Write to file callback.
- * Responds to a SBP_MSG_FILEIO_WRITE_REQUEST message.
+ * Responds to a SBP_MSG_FILEIO_WRITE_REQ message.
  *
  * Writes a certain length (up to 255 bytes) at a given offset. Returns a copy
- * of the original SBP_MSG_FILEIO_WRITE_RESPONSE message to check integrity of
+ * of the original SBP_MSG_FILEIO_WRITE_RESP message to check integrity of
  * the write.
  */
 static void write_cb(u16 sender_id, u8 len, u8 msg[], void* context)
@@ -184,5 +184,5 @@ static void write_cb(u16 sender_id, u8 len, u8 msg[], void* context)
   cfs_write(f, msg + headerlen, len - headerlen);
   cfs_close(f);
 
-  sbp_send_msg(SBP_MSG_FILEIO_WRITE_RESPONSE, headerlen, msg);
+  sbp_send_msg(SBP_MSG_FILEIO_WRITE_RESP, headerlen, msg);
 }

--- a/src/sbp_utils.c
+++ b/src/sbp_utils.c
@@ -222,5 +222,69 @@ s8 pack_obs_content(double P, double L, double snr, u16 lock_counter, u8 prn,
   return 0;
 }
 
+void unpack_ephemeris(const msg_ephemeris_t *msg, ephemeris_t *e)
+{
+   e->tgd       =  msg->tgd;
+   e->crs       =  msg->c_rs;
+   e->crc       =  msg->c_rc;
+   e->cuc       =  msg->c_uc;
+   e->cus       =  msg->c_us;
+   e->cic       =  msg->c_ic;
+   e->cis       =  msg->c_is;
+   e->dn        =  msg->dn;
+   e->m0        =  msg->m0;
+   e->ecc       =  msg->ecc;
+   e->sqrta     =  msg->sqrta;
+   e->omega0    =  msg->omega0;
+   e->omegadot  =  msg->omegadot;
+   e->w         =  msg->w;
+   e->inc       =  msg->inc;
+   e->inc_dot   =  msg->inc_dot;
+   e->af0       =  msg->af0;
+   e->af1       =  msg->af1;
+   e->af2       =  msg->af2;
+   e->toe.tow   =  msg->toe_tow;
+   e->toe.wn    =  msg->toe_wn;
+   e->toc.tow   =  msg->toc_tow;
+   e->toc.wn    =  msg->toe_wn;
+   e->valid     =  msg->valid;
+   e->healthy   =  msg->healthy;
+   e->prn       =  msg->sid & 0x1F; /* TODO prn -> sid */
+   e->iode      =  msg->iode;
+}
+
+void pack_ephemeris(const ephemeris_t *e, msg_ephemeris_t *msg)
+{
+  gps_time_t toe = e->toe;
+  gps_time_t toc = e->toc;
+  msg->tgd       = e->tgd;
+  msg->c_rs      = e->crs;
+  msg->c_rc      = e->crc;
+  msg->c_uc      = e->cuc;
+  msg->c_us      = e->cus;
+  msg->c_ic      = e->cic;
+  msg->c_is      = e->cis;
+  msg->dn        = e->dn;
+  msg->m0        = e->m0;
+  msg->ecc       = e->ecc;
+  msg->sqrta     = e->sqrta;
+  msg->omega0    = e->omega0;
+  msg->omegadot  = e->omegadot;
+  msg->w         = e->w;
+  msg->inc       = e->inc;
+  msg->inc_dot   = e->inc_dot;
+  msg->af0       = e->af0;
+  msg->af1       = e->af1;
+  msg->af2       = e->af2;
+  msg->toe_tow   = toe.tow;
+  msg->toe_wn    = toe.wn;
+  msg->toc_tow   = toc.tow;
+  msg->toe_wn    = toc.wn;
+  msg->valid     = e->valid;
+  msg->healthy   = e->healthy;
+  msg->sid       = e->prn; /* TODO: prn -> sid */
+  msg->iode      = e->iode;
+}
+
 /** \} */
 /** \} */

--- a/src/sbp_utils.c
+++ b/src/sbp_utils.c
@@ -169,7 +169,7 @@ void unpack_obs_content(const packed_obs_content_t *msg, double *P, double *L,
   *L   = ((double)msg->L.i) + (((double)msg->L.f) / MSG_OSB_LF_MULTIPLIER);
   *snr = ((double)msg->cn0) / MSG_OBS_SNR_MULTIPLIER;
   *lock_counter = ((u16)msg->lock);
-  *prn = msg->prn;
+  *prn = msg->sid & 0x1F; /* TODO: prn -> sid */
 }
 
 /** Pack GPS observables into a `msg_obs_content_t` struct.
@@ -217,7 +217,7 @@ s8 pack_obs_content(double P, double L, double snr, u16 lock_counter, u8 prn,
 
   msg->lock = lock_counter;
 
-  msg->prn = prn;
+  msg->sid = prn; /* TODO prn -> sid */
 
   return 0;
 }

--- a/src/sbp_utils.h
+++ b/src/sbp_utils.h
@@ -55,6 +55,10 @@ void unpack_obs_content(const packed_obs_content_t *msg, double *P, double *L,
 s8 pack_obs_content(double P, double L, double snr, u16 lock_counter, u8 prn,
                     packed_obs_content_t *msg);
 
+void unpack_ephemeris(const msg_ephemeris_t *msg, ephemeris_t *e);
+
+void pack_ephemeris(const ephemeris_t *e, msg_ephemeris_t *msg);
+
 /** Value specifying the size of the SBP framing */
 #define SBP_FRAMING_SIZE_BYTES 8
 /** Value defining maximum SBP packet size */

--- a/src/settings.c
+++ b/src/settings.c
@@ -198,13 +198,13 @@ void settings_setup(void)
   );
   static sbp_msg_callbacks_node_t settings_read_node;
   sbp_register_cbk(
-    SBP_MSG_SETTINGS_READ_REQUEST,
+    SBP_MSG_SETTINGS_READ_REQ,
     &settings_read_callback,
     &settings_read_node
   );
   static sbp_msg_callbacks_node_t settings_read_by_index_node;
   sbp_register_cbk(
-    SBP_MSG_SETTINGS_READ_BY_INDEX_REQUEST,
+    SBP_MSG_SETTINGS_READ_BY_INDEX_REQ,
     &settings_read_by_index_callback,
     &settings_read_by_index_node
   );
@@ -401,7 +401,7 @@ static void settings_read_callback(u16 sender_id, u8 len, u8 msg[], void* contex
   }
 
   buflen = settings_format_setting(s, buf, sizeof(buf));
-  sbp_send_msg(SBP_MSG_SETTINGS_READ_RESPONSE, buflen, (void*)buf);
+  sbp_send_msg(SBP_MSG_SETTINGS_READ_RESP, buflen, (void*)buf);
   return;
 }
 
@@ -436,7 +436,7 @@ static void settings_read_by_index_callback(u16 sender_id, u8 len, u8 msg[], voi
   buf[buflen++] = msg[0];
   buf[buflen++] = msg[1];
   buflen += settings_format_setting(s, buf + buflen, sizeof(buf) - buflen);
-  sbp_send_msg(SBP_MSG_SETTINGS_READ_BY_INDEX_RESPONSE, buflen, (void*)buf);
+  sbp_send_msg(SBP_MSG_SETTINGS_READ_BY_INDEX_RESP, buflen, (void*)buf);
 }
 
 static void settings_save_callback(u16 sender_id, u8 len, u8 msg[], void* context)

--- a/src/simulator.c
+++ b/src/simulator.c
@@ -313,7 +313,7 @@ void simulation_step_tracking_and_observations(double elapsed)
       /* As for tracking, we just set each sat consecutively in each channel. */
       /* This will cause weird jumps when a satellite rises or sets. */
       sim_state.tracking_channel[num_sats_selected].state = TRACKING_RUNNING;
-      sim_state.tracking_channel[num_sats_selected].prn = simulation_almanacs[i].prn  + SIM_PRN_OFFSET;
+      sim_state.tracking_channel[num_sats_selected].sid = simulation_almanacs[i].prn  + SIM_PRN_OFFSET;
       sim_state.tracking_channel[num_sats_selected].cn0 = sim_state.nav_meas[num_sats_selected].snr;
 
       num_sats_selected++;

--- a/src/track.c
+++ b/src/track.c
@@ -464,7 +464,7 @@ void tracking_send_state()
     if (num_sats < nap_track_n_channels) {
       for (u8 i = num_sats; i < nap_track_n_channels; i++) {
         states[i].state = TRACKING_DISABLED;
-        states[i].prn   = 0;
+        states[i].sid   = 0;
         states[i].cn0   = -1;
       }
     }
@@ -473,7 +473,7 @@ void tracking_send_state()
 
     for (u8 i=0; i<nap_track_n_channels; i++) {
       states[i].state = tracking_channel[i].state;
-      states[i].prn = tracking_channel[i].prn;
+      states[i].sid = tracking_channel[i].prn; /* TODO prn -> sid */
       if (tracking_channel[i].state == TRACKING_RUNNING)
         states[i].cn0 = tracking_channel_snr(i);
       else


### PR DESCRIPTION
Move the PRN field over to the SID field. https://github.com/swift-nav/libsbp/pull/185.

Incoming SID values are masked off with 0x1F where applicable (this is probably unnecessary as I think normal truncation will cover it - but just to be explicit) - outbound values are not masked. Note, this doesn't actually do any of the widening in the firmware, just supports widening around the messaging.

Are there other areas that are not covered here? Like, hand rolled messages?

/cc @henryhallam @gsmcmullin @fnoble 
