### PR TITLE
Reduce false-positives in acquisition

### DIFF
--- a/src/acq.c
+++ b/src/acq.c
@@ -190,6 +190,11 @@ void acq_get_results(float* cp, float* cf, float* cn0)
   *cp = 1023.0 - (float)(acq_state.best_cp % (1023 * NAP_ACQ_CODE_PHASE_UNITS_PER_CHIP))
                   / NAP_ACQ_CODE_PHASE_UNITS_PER_CHIP;
   *cf = (float)acq_state.best_cf / NAP_ACQ_CARRIER_FREQ_UNITS_PER_HZ;
+  /* Only should occur if the the power returned from the HDL is exactly zero in any of the runs 
+   * Actual powers here are in the range of 5-10 */
+  if ((acq_state.power_acc / acq_state.count) > 100000) {
+    log_error("acq: Acquisition power out of range\n");
+  }
   /* "SNR" estimated by peak power over mean power. */
   float snr = (float)acq_state.best_power / (acq_state.power_acc / acq_state.count);
   if (snr == 0 || snr != snr) {

--- a/src/acq.c
+++ b/src/acq.c
@@ -102,7 +102,7 @@ static struct {
   u8 p_head;
   u8 p_tail;
 
-  u64 power_acc;      /**< Sum of powers of all acquisition set points. */
+  float power_acc;      /**< Sum of powers of all acquisition set points. */
   u64 best_power;     /**< Highest power of all acquisition set points. */
   s16 best_cf;        /**< Carrier freq corresponding to highest power. */
   u16 best_cp;        /**< Code phase corresponding to highest power. */
@@ -163,7 +163,7 @@ void acq_service_irq(void)
 
   u16 index_max;
   u16 corr_max;
-  u16 ave;
+  float ave;
 
   nap_acq_corr_rd_blocking(&index_max, &corr_max, &ave);
   acq_state.power_acc += ave;

--- a/src/acq.c
+++ b/src/acq.c
@@ -192,7 +192,7 @@ void acq_get_results(float* cp, float* cf, float* cn0)
   *cf = (float)acq_state.best_cf / NAP_ACQ_CARRIER_FREQ_UNITS_PER_HZ;
   /* Only should occur if the the power returned from the HDL is exactly zero in any of the runs 
    * Actual powers here are in the range of 5-10 */
-  if ((acq_state.power_acc / acq_state.count) > 100000) {
+  if ((acq_state.power_acc / acq_state.count) > 1000) {
     log_error("acq: Acquisition power out of range\n");
   }
   /* "SNR" estimated by peak power over mean power. */

--- a/src/acq.c
+++ b/src/acq.c
@@ -190,11 +190,6 @@ void acq_get_results(float* cp, float* cf, float* cn0)
   *cp = 1023.0 - (float)(acq_state.best_cp % (1023 * NAP_ACQ_CODE_PHASE_UNITS_PER_CHIP))
                   / NAP_ACQ_CODE_PHASE_UNITS_PER_CHIP;
   *cf = (float)acq_state.best_cf / NAP_ACQ_CARRIER_FREQ_UNITS_PER_HZ;
-  /* Only should occur if the the power returned from the HDL is exactly zero in any of the runs 
-   * Actual powers here are in the range of 5-10 */
-  if ((acq_state.power_acc / acq_state.count) > 1000) {
-    log_error("acq: Acquisition power out of range\n");
-  }
   /* "SNR" estimated by peak power over mean power. */
   float snr = (float)acq_state.best_power / (acq_state.power_acc / acq_state.count);
   if (snr == 0 || snr != snr) {

--- a/src/acq.c
+++ b/src/acq.c
@@ -193,7 +193,8 @@ void acq_get_results(float* cp, float* cf, float* cn0)
   /* "SNR" estimated by peak power over mean power. */
   float snr = (float)acq_state.best_power / (acq_state.power_acc / acq_state.count);
   if (snr == 0 || snr != snr) {
-    log_error("Acq: bad SNR (%f)\n", snr);
+    log_error("acq: SNR is NaN (best=%" PRIu64 ", acc=%" PRIu64 ", count=%" PRIu32 ")\n",
+              acq_state.best_power, acq_state.power_acc, acq_state.count);
     *cn0 = 0;
   } else {
   *cn0 = 10 * log10(snr)

--- a/src/acq.c
+++ b/src/acq.c
@@ -102,7 +102,7 @@ static struct {
   u8 p_head;
   u8 p_tail;
 
-  float power_acc;      /**< Sum of powers of all acquisition set points. */
+  float power_acc;    /**< Sum of powers of all acquisition set points. */
   u64 best_power;     /**< Highest power of all acquisition set points. */
   s16 best_cf;        /**< Carrier freq corresponding to highest power. */
   u16 best_cp;        /**< Code phase corresponding to highest power. */
@@ -192,8 +192,9 @@ void acq_get_results(float* cp, float* cf, float* cn0)
   *cf = (float)acq_state.best_cf / NAP_ACQ_CARRIER_FREQ_UNITS_PER_HZ;
   /* "SNR" estimated by peak power over mean power. */
   float snr = (float)acq_state.best_power / (acq_state.power_acc / acq_state.count);
-  if (snr == 0 || snr != snr) {
-    log_error("acq: SNR is NaN (best=%" PRIu64 ", acc=%" PRIu64 ", count=%" PRIu32 ")\n",
+  if (acq_state.power_acc == 0) {
+    log_error("acq: Power accumulator is 0, will cause SNR to be NaN. "
+              "(best=%" PRIu64 ", acc=%f, count=%" PRIu32 ")\n",
               acq_state.best_power, acq_state.power_acc, acq_state.count);
     *cn0 = 0;
   } else {

--- a/src/board/nap/acq_channel.c
+++ b/src/board/nap/acq_channel.c
@@ -100,11 +100,11 @@ void nap_acq_init_wr_disable_blocking()
  * \param corr   Maximum tap correlation from last cycle.
  * \param acc    Accumulation of all tap final correlations from last cycle.
  */
-static void nap_acq_corr_unpack(u8 packed[], u16 *index, u16 *max, u16 *ave)
+static void nap_acq_corr_unpack(u8 packed[], u16 *index, u16 *max, float *ave)
 {
   *max = (packed[0] << 8) | packed[1];
-  *ave = (packed[2] << 8) | packed[3];
-  *index = ((packed[4] << 8) | packed[5]) >> (16 - nap_acq_fft_index_bits);
+  *ave = ((packed[2] << 16) | (packed[3] << 8) | packed[4]) / 256.0;
+  *index = ((packed[5] << 8) | packed[6]) >> (16 - nap_acq_fft_index_bits);
 }
 
 /** Read correlations from acquisition channel.
@@ -115,9 +115,9 @@ static void nap_acq_corr_unpack(u8 packed[], u16 *index, u16 *max, u16 *ave)
  * \param corr   Maximum tap correlation from last cycle.
  * \param acc    Accumulation of all tap final correlations from last cycle.
  */
-void nap_acq_corr_rd_blocking(u16 *index, u16 *max, u16 *ave)
+void nap_acq_corr_rd_blocking(u16 *index, u16 *max, float *ave)
 {
-  u8 temp[6];
+  u8 temp[7];
 
   nap_xfer_blocking(NAP_REG_ACQ_CORR, sizeof(temp), temp, temp);
   nap_acq_corr_unpack(temp, index, max, ave);

--- a/src/board/nap/acq_channel.h
+++ b/src/board/nap/acq_channel.h
@@ -50,7 +50,7 @@ void nap_acq_load_wr_enable_blocking(void);
 void nap_acq_load_wr_disable_blocking(void);
 void nap_acq_init_wr_params_blocking(s16 carrier_freq);
 void nap_acq_init_wr_disable_blocking(void);
-void nap_acq_corr_rd_blocking(u16 *index, u16 *max, u16 *ave);
+void nap_acq_corr_rd_blocking(u16 *index, u16 *max, float *ave);
 void nap_acq_code_wr_blocking(u8 prn);
 
 #endif  /* SWIFTNAV_ACQ_CHANNEL_H */

--- a/src/main.c
+++ b/src/main.c
@@ -159,7 +159,7 @@ int main(void)
   log_info("NAP firmware version: %s\n", nap_version_string);
 
   /* Check we are running a compatible version of the NAP firmware. */
-  const char *required_nap_version = "v0.14";
+  const char *required_nap_version = "v0.16";
   if (compare_version(nap_version_string, required_nap_version) < 0) {
     while (1) {
       log_error("NAP firmware version >= %s required, please update!\n"


### PR DESCRIPTION
Tied to the HDL change of the same name, but this treats the incoming average power as a fixed point number.  Unintended side effect of reducing the number of false positives in acquisition.

Includes @gsmcmullin stop-gap if SNR is NaN.  HDL now returns an obscenely large number for the average power if it's zero, so an error is now 

/cc @fnoble @gsmcmullin @cbeighley 

<!---
@huboard:{"order":469.5,"milestone_order":487,"custom_state":""}
-->
