### PR TITLE
Tack on a newline at the end of settings

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -279,6 +279,7 @@ static int settings_format_setting(struct setting *s, char *buf, int len)
   if (s->type->format_type != NULL)
     buflen += s->type->format_type(s->type->priv, buf + buflen, len - buflen);
 
+  buf[buflen++] = '\n';
   return buflen;
 }
 


### PR DESCRIPTION
Add a newline at the end of settings. Our protocol has defined strings to be newline terminated. Conform to that. By a couple orders of magnitude, this is the least path to resistance to getting stuff working. Post release, we can consider other formats, but let's go with this for now.

/cc @fnoble @denniszollo @mookerji 