### PR TITLE
ChibiOS thread support from GDB

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,3 +1,26 @@
+python
+import sys
+sys.path.append("./gdb_chibios")
+import coredump
+end
+
+break _screaming_death
+commands
+gcore
+cont
+end
+
+break debug_threads
+commands
+gcore
+cont
+end
+
+catch signal SIGSEGV
+command
+run
+end
+
 set mem inaccessible-by-default off
 target extended-remote /dev/ttyACM0
 mon jtag_scan 4 5 6

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+core-*
 ext/ext.c
 .DS_Store
 .gdbinit

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "libsbp"]
 	path = libsbp
 	url = https://github.com/swift-nav/libsbp.git
+[submodule "gdb_chibios"]
+	path = gdb_chibios
+	url = https://github.com/gsmcmullin/gdb_chibios.git


### PR DESCRIPTION
Python-Fu for GDB that allows switching between ChibiOS threads and generating core dumps.
Emulated GDB commands are `gcore`, `info threads` and `thread`.  See example below.
Includes hooks in `.gdbinit` to dump core on watchdog, screaming death and hard fault.

```
gareth@lmde:~/Projects/piksi_firmware$ arm-none-eabi-gdb-py3 build/piksi_firmware.elf 
GNU gdb (GDB) 7.9
Copyright (C) 2015 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "--host=x86_64-unknown-linux-gnu --target=arm-none-eabi".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from build/piksi_firmware.elf...done.
Breakpoint 1 at 0x800be10: file error.c, line 62.
Breakpoint 2 at 0x80110d0: file system_monitor.c, line 190.
Catchpoint 3 (signal SIGSEGV)
Target voltage: 0.0V
Device  IR Len  IDCODE      Description
0	4	0x4BA00477  ARM Limited: ADIv5 JTAG-DP port.
1	5	0x06413041  ST Microelectronics: STM32F4xx.
2	6	0x24004093  (null)

Available Targets:
No. Att Driver
 1      STM32F4xx
_idle_thread (p=0x0) at ../ChibiOS-RT/os/kernel/src/chsys.c:68
68	  }
[New thread 'main']
[New thread 'idle']
[New thread 'NAP ISR']
[New thread 'SBP']
[New thread 'manage acq']
[New thread 'manage track']
[New thread 'system monitor']
[New thread 'track status']
[New thread 'Watchdog']
[New thread 'solution']
[New thread 'time matched obs']
[New thread 'nav msg']
(gdb) bt
#0  _idle_thread (p=0x0) at ../ChibiOS-RT/os/kernel/src/chsys.c:68
#1  0x08005c70 in _port_thread_start () at ../ChibiOS-RT/os/ports/GCC/ARMCMx/chcore_v7m.c:262
#2  0x0800697c in chSemWaitS (sp=0x8005d41 <_idle_thread>) at ../ChibiOS-RT/os/kernel/src/chsem.c:197
#3  0x000702e8 in ?? ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
(gdb) info threads
  Id   Target Id            Frame
  1    main                 0x80062E5 in chSchGoSleepTimeoutS ()
* 2    idle                 0x8005D48 in _idle_thread ()
  3    NAP ISR              0x800697D in chSemWaitS ()
  4    SBP                  0x80062E5 in chSchGoSleepTimeoutS ()
  5    manage acq           0x80062E5 in chSchGoSleepTimeoutS ()
  6    manage track         0x80062E5 in chSchGoSleepTimeoutS ()
  7    system monitor       0x80062E5 in chSchGoSleepTimeoutS ()
  8    track status         0x80062E5 in chSchGoSleepTimeoutS ()
  9    Watchdog             0x80062E5 in chSchGoSleepTimeoutS ()
  10   solution             0x800697D in chSemWaitS ()
  11   time matched obs     0x800697D in chSemWaitS ()
  12   nav msg              0x80062E5 in chSchGoSleepTimeoutS ()
(gdb) thread 5
(gdb) bt
#0  chSchGoSleepTimeoutS (newstate=<optimized out>, time=1000) at ../ChibiOS-RT/os/kernel/src/chschd.c:198
#1  0x08006a68 in chSemWaitTimeout (sp=sp@entry=0x200097e8 <acq_pipeline_sem>, time=time@entry=1000)
    at ../ChibiOS-RT/os/kernel/src/chsem.c:226
#2  0x0800ce1c in acq_search (cf_min_=<optimized out>, cf_max_=1.46601547e+13, cf_bin_width=<optimized out>) at acq.c:152
#3  0x0800d184 in manage_acq () at manage.c:297
#4  manage_acq_thread (arg=<optimized out>) at manage.c:142
#5  0x08005c70 in _port_thread_start () at ../ChibiOS-RT/os/ports/GCC/ARMCMx/chcore_v7m.c:262
#6  0x080062e4 in chSchGoSleepTimeoutS (newstate=<optimized out>, time=16) at ../ChibiOS-RT/os/kernel/src/chschd.c:197
#7  0x00000000 in ?? ()
```