### PR TITLE
Don't use a string setting for unknown serial number

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -190,11 +190,7 @@ int main(void)
   sbp_fileio_setup();
   ext_setup();
 
-  if (serial_number < 0) {
-    READ_ONLY_PARAMETER("system_info", "serial_number", "(unknown)", TYPE_STRING);
-  } else {
-    READ_ONLY_PARAMETER("system_info", "serial_number", serial_number, TYPE_INT);
-  }
+  READ_ONLY_PARAMETER("system_info", "serial_number", serial_number, TYPE_INT);
   READ_ONLY_PARAMETER("system_info", "firmware_version", GIT_VERSION,
                       TYPE_STRING);
   READ_ONLY_PARAMETER("system_info", "firmware_built", __DATE__ " " __TIME__,


### PR DESCRIPTION
serial_number is -1 when those bytes in the NAP flash are unwritten.  So this does what we discussed, without any special-casing.
Fixes #498 
cc @mfine @fnoble 