### PR TITLE
Elevation mask and basic warm-start

### DIFF
--- a/src/manage.c
+++ b/src/manage.c
@@ -21,6 +21,7 @@
 #include <libswiftnav/almanac.h>
 #include <libswiftnav/constants.h>
 #include <libswiftnav/coord_system.h>
+#include <libswiftnav/linear_algebra.h>
 
 #include "main.h"
 #include "board/nap/track_channel.h"
@@ -46,10 +47,10 @@
 
 /** Different hints on satellite info to aid the acqusition */
 enum acq_hint {
-  ACQ_HINT_ALMANAC,  /**< Almanac information. */
-  ACQ_HINT_ACQ,      /**< Previous successful acqusition. */
-  ACQ_HINT_TRACK,    /**< Previously tracked satellite. */
-  ACQ_HINT_OBS,      /**< Observation from reference station. */
+  ACQ_HINT_WARMSTART,  /**< Information from almanac or ephemeris */
+  ACQ_HINT_PREV_ACQ,   /**< Previous successful acqusition. */
+  ACQ_HINT_PREV_TRACK, /**< Previously tracked satellite. */
+  ACQ_HINT_REMOTE_OBS, /**< Observation from reference station. */
 
   ACQ_HINT_NUM
 };
@@ -69,18 +70,21 @@ typedef struct {
 } acq_prn_t;
 acq_prn_t acq_prn_param[32];
 
-#define SCORE_DEFAULT 100
-#define SCORE_ALMANAC 200
-#define SCORE_ACQ     100
-#define SCORE_TRACK   200
-#define SCORE_OBS     200
+#define SCORE_COLDSTART     100
+#define SCORE_WARMSTART     200
+#define SCORE_BELOWMASK     0
+#define SCORE_ACQ           100
+#define SCORE_TRACK         200
+#define SCORE_OBS           200
 
-#define ALMANAC_DOPPLER_WINDOW 4000
+#define DOPP_UNCERT_ALMANAC 4000
+#define DOPP_UNCERT_EPHEM   500
 
 almanac_t almanac[32];
 extern ephemeris_t es[32];
 
-static float track_cn0_use_thres = 31.0;
+static float track_cn0_use_thres = 31.0; /* dBHz */
+float elevation_mask = 5.0; /* degrees */
 
 static u8 manage_track_new_acq(void);
 static void manage_acq(void);
@@ -194,42 +198,82 @@ void manage_acq_setup()
   );
 }
 
-static void manage_calc_almanac_scores(void)
-{
-  double az, el;
-  gps_time_t t = get_current_time();
 
-  for (u8 prn=0; prn<32; prn++) {
-    if (!almanac[prn].valid ||
-        time_quality == TIME_UNKNOWN ||
-        position_quality == POSITION_UNKNOWN) {
-      /* No almanac or position/time information, give it the benefit of the
-       * doubt. */
-      acq_prn_param[prn].score[ACQ_HINT_ALMANAC] = 0;
+/** Using available almanac and ephemeris information, determine
+ * whether a satellite is in view and the range of doppler frequencies
+ * in which we expect to find it.
+ *
+ * \param prn 0-indexed PRN
+ * \param t Time at which to evaluate ephemeris and almanac (typically system's
+ *  estimate of current time)
+ * \param dopp_hint_low, dopp_hint_high Pointers to store doppler search range
+ *  from ephemeris or almanac, if available and elevation > mask
+ * \return Score (higher is better)
+ */
+static u16 manage_warm_start(u8 prn, gps_time_t t,
+                             float *dopp_hint_low, float *dopp_hint_high)
+{
+    /* Do we have any idea where/when we are?  If not, no score. */
+    /* TODO: Stricter requirement on time and position uncertainty?
+       We ought to keep track of a quantitative uncertainty estimate. */
+    if (time_quality < TIME_GUESS &&
+        position_quality < POSITION_GUESS)
+      return SCORE_COLDSTART;
+
+    float el = 0;
+    double el_d, _, dopp_hint = 0, dopp_uncertainty = DOPP_UNCERT_ALMANAC;
+
+    /* Do we have a suitable ephemeris for this sat?  If so, use
+       that in preference to the almanac. */
+    if (ephemeris_good(&es[prn], t)) {
+      double sat_pos[3], sat_vel[3], el_d;
+      calc_sat_state(&es[prn], t, sat_pos, sat_vel, &_, &_);
+      wgsecef2azel(sat_pos, position_solution.pos_ecef, &_, &el_d);
+      el = (float)(el_d) * R2D;
+      if (el < elevation_mask)
+        return SCORE_BELOWMASK;
+      vector_subtract(3, sat_pos, position_solution.pos_ecef, sat_pos);
+      vector_normalize(3, sat_pos);
+      /* sat_pos now holds unit vector from us to satellite */
+      vector_subtract(3, sat_vel, position_solution.vel_ecef, sat_vel);
+      /* sat_vel now holds velocity of sat relative to us */
+      dopp_hint = -GPS_L1_HZ * (vector_dot(3, sat_pos, sat_vel) / GPS_C
+                                + position_solution.clock_bias);
+      /* TODO: Check sign of receiver frequency offset correction */
+      if (time_quality >= TIME_FINE)
+        dopp_uncertainty = DOPP_UNCERT_EPHEM;
+    } else if (almanac[prn].valid) {
+      calc_sat_az_el_almanac(&almanac[prn], t.tow, t.wn-1024,
+                             position_solution.pos_ecef, &_, &el_d);
+      el = (float)(el_d) * R2D;
+      if (el < elevation_mask)
+        return SCORE_BELOWMASK;
+      dopp_hint = -calc_sat_doppler_almanac(&almanac[prn], t.tow, t.wn,
+                                            position_solution.pos_ecef);
     } else {
-      calc_sat_az_el_almanac(&almanac[prn], t.tow, t.wn-1024, position_solution.pos_ecef, &az, &el);
-      float dopp = -calc_sat_doppler_almanac(&almanac[prn], t.tow, t.wn,
-                                             position_solution.pos_ecef);
-      acq_prn_param[prn].score[ACQ_HINT_ALMANAC] =
-            el > 0 ? (u16)(SCORE_ALMANAC * 2 * el / M_PI) : 0;
-      acq_prn_param[prn].dopp_hint_low = dopp - ALMANAC_DOPPLER_WINDOW;
-      acq_prn_param[prn].dopp_hint_high = dopp + ALMANAC_DOPPLER_WINDOW;
+      return SCORE_COLDSTART; /* Couldn't determine satellite state. */
     }
-  }
+    /* Return the doppler hints and a score proportional to elevation */
+    *dopp_hint_low = dopp_hint - dopp_uncertainty;
+    *dopp_hint_high = dopp_hint + dopp_uncertainty;
+    return SCORE_COLDSTART + SCORE_WARMSTART * el / 90.f;
 }
 
 static u8 choose_prn(void)
 {
   u32 total_score = 0;
-
-  manage_calc_almanac_scores();
+  gps_time_t t = get_current_time();
 
   for (u8 prn=0; prn<32; prn++) {
     if ((acq_prn_param[prn].state != ACQ_PRN_ACQUIRING) ||
          acq_prn_param[prn].masked)
       continue;
 
-    total_score += SCORE_DEFAULT;
+    acq_prn_param[prn].score[ACQ_HINT_WARMSTART] =
+      manage_warm_start(prn, t,
+                        &acq_prn_param[prn].dopp_hint_low,
+                        &acq_prn_param[prn].dopp_hint_high);
+
     for (enum acq_hint hint = 0; hint < ACQ_HINT_NUM; hint++) {
       total_score += acq_prn_param[prn].score[hint];
     }
@@ -242,7 +286,7 @@ static u8 choose_prn(void)
          acq_prn_param[prn].masked)
       continue;
 
-    u32 sat_score = SCORE_DEFAULT;
+    u32 sat_score = 0;
     for (enum acq_hint hint = 0; hint < ACQ_HINT_NUM; hint++)
       sat_score += acq_prn_param[prn].score[hint];
     if (pick < sat_score) {
@@ -272,7 +316,7 @@ void manage_set_obs_hint(u8 prn)
   if (prn >= 32) /* check range */
     return;
 
-  acq_prn_param[prn].score[ACQ_HINT_OBS] = SCORE_OBS;
+  acq_prn_param[prn].score[ACQ_HINT_REMOTE_OBS] = SCORE_OBS;
 }
 
 /** Manages acquisition searches and starts tracking channels after successful acquisitions. */
@@ -331,7 +375,7 @@ static void manage_acq()
     for (u8 i = 0; i < ACQ_HINT_NUM; i++)
       acq_prn_param[prn].score[i] = (acq_prn_param[prn].score[i] * 3) / 4;
     /* Reset hint score for acquisition. */
-    acq_prn_param[prn].score[ACQ_HINT_ACQ] = 0;
+    acq_prn_param[prn].score[ACQ_HINT_PREV_ACQ] = 0;
     return;
   }
 
@@ -342,7 +386,8 @@ static void manage_acq()
      * later using another fine acq.
      */
     if (cn0 > ACQ_RETRY_THRESHOLD) {
-      acq_prn_param[prn].score[ACQ_HINT_ACQ] = SCORE_ACQ + (cn0 - ACQ_THRESHOLD);
+      acq_prn_param[prn].score[ACQ_HINT_PREV_ACQ] =
+        SCORE_ACQ + (cn0 - ACQ_THRESHOLD);
       acq_prn_param[prn].dopp_hint_low = cf - ACQ_FULL_CF_STEP;
       acq_prn_param[prn].dopp_hint_high = cf + ACQ_FULL_CF_STEP;
     }
@@ -355,7 +400,11 @@ static void manage_acq()
   // Contrive for the timing strobe to occur at or close to a PRN edge (code phase = 0)
   track_count += 16*(1023.0-cp)*(1.0 + cf / GPS_L1_HZ);
 
-  tracking_channel_init(chan, prn, cf, track_count, cn0);
+  /* Start the tracking channel */
+  tracking_channel_init(chan, prn, cf, track_count, cn0,
+                        TRACKING_ELEVATION_UNKNOWN);
+  /* TODO: Initialize elevation from ephemeris if we know it precisely */
+
   acq_prn_param[prn].state = ACQ_PRN_TRACKING;
   nap_timing_strobe_wait(100);
 }
@@ -419,6 +468,7 @@ void manage_track_setup()
   initialize_lock_counters();
 
   SETTING("track", "cn0_use", track_cn0_use_thres, TYPE_FLOAT);
+  SETTING("solution", "elevation_mask", elevation_mask, TYPE_FLOAT);
 
   chThdCreateStatic(
       wa_manage_track_thread,
@@ -432,7 +482,7 @@ static void drop_channel(u8 channel_id) {
   tracking_channel_disable(channel_id);
   const tracking_channel_t *ch = &tracking_channel[channel_id];
   if (ch->update_count > TRACK_REACQ_T) {
-    acq_prn_param[ch->prn].score[ACQ_HINT_TRACK] = SCORE_TRACK;
+    acq_prn_param[ch->prn].score[ACQ_HINT_PREV_TRACK] = SCORE_TRACK;
     acq_prn_param[ch->prn].dopp_hint_low = ch->carrier_freq - ACQ_FULL_CF_STEP;
     acq_prn_param[ch->prn].dopp_hint_high = ch->carrier_freq + ACQ_FULL_CF_STEP;
   }
@@ -482,6 +532,16 @@ static void manage_track()
       drop_channel(i);
       continue;
     }
+
+    /* Is satellite below our elevation mask? */
+    if (ch->elevation < elevation_mask) {
+      log_info("PRN%d below elevation mask, dropping\n", ch->prn+1);
+      drop_channel(i);
+      /* Erase the tracking hint score, and any others it might have */
+      memset(&acq_prn_param[ch->prn].score, 0,
+             sizeof(acq_prn_param[ch->prn].score));
+      continue;
+    }
   }
 }
 
@@ -491,6 +551,8 @@ s8 use_tracking_channel(u8 i)
   /* To use a channel's measurements in an SPP or RTK solution, we
      require the following conditions: */
   if ((ch->state == TRACKING_RUNNING)
+      /* Satellite elevation is above the mask. */
+      && (ch->elevation >= elevation_mask)
       /* Pessimistic phase lock detector = "locked". */
       && (ch->lock_detect.outp)
       /* Some time has elapsed since the last tracking channel mode

--- a/src/solution.c
+++ b/src/solution.c
@@ -342,6 +342,26 @@ static void solution_simulation()
   }
 }
 
+/** Update the tracking channel states with satellite elevation angles
+ * \param nav_meas Navigation measurements with .sat_pos populated
+ * \param n_meas Number of navigation measurements
+ * \param pos_ecef Receiver position
+ */
+static void update_sat_elevations(const navigation_measurement_t nav_meas[],
+                                  u8 n_meas, const double pos_ecef[3])
+{
+  double _, el;
+  for (int i = 0; i < n_meas; i++) {
+    wgsecef2azel(nav_meas[i].sat_pos, pos_ecef, &_, &el);
+    for (int j = 0; j < nap_track_n_channels; j++) {
+      if (tracking_channel[j].prn == nav_meas[i].prn) {
+        tracking_channel[j].elevation = (float)el * R2D;
+        break;
+      }
+    }
+  }
+}
+
 static WORKING_AREA_CCM(wa_solution_thread, 12004);
 static msg_t solution_thread(void *arg)
 {
@@ -415,6 +435,11 @@ static msg_t solution_thread(void *arg)
       /* Update global position solution state. */
       position_updated();
       set_time_fine(nav_tc, position_solution.time);
+
+      /* Save elevation angles every so often */
+      DO_EVERY((u32)soln_freq,
+               update_sat_elevations(nav_meas_tdcp, n_ready_tdcp,
+                                     position_solution.pos_ecef));
 
       if (!simulation_enabled()) {
         /* Output solution. */

--- a/src/track.c
+++ b/src/track.c
@@ -139,9 +139,11 @@ float propagate_code_phase(float code_phase, float carrier_freq, u32 n_samples)
  * \param carrier_freq       Carrier frequency (Doppler) at start of tracking in Hz.
  * \param start_sample_count Sample count on which to start tracking.
  * \param cn0_init           Estimated C/N0 from acquisition
+ * \param elevation          Satellite elevation in degrees, or
+ *                           TRACKING_ELEVATION_UNKNOWN
  */
 void tracking_channel_init(u8 channel, u8 prn, float carrier_freq,
-                           u32 start_sample_count, float cn0_init)
+                           u32 start_sample_count, float cn0_init, s8 elevation)
 {
   tracking_channel_t *chan = &tracking_channel[channel];
 
@@ -158,6 +160,7 @@ void tracking_channel_init(u8 channel, u8 prn, float carrier_freq,
   /* Setup tracking_channel struct. */
   chan->state = TRACKING_RUNNING;
   chan->prn = prn;
+  chan->elevation = elevation;
 
   /* Initialize TOW_ms and lock_count. */
   tracking_channel_ambiguity_unknown(channel);

--- a/src/track.h
+++ b/src/track.h
@@ -26,7 +26,7 @@
 
 #define TRACKING_DISABLED 0 /**< Tracking channel disabled state. */
 #define TRACKING_RUNNING  1 /**< Tracking channel running state. */
-
+#define TRACKING_ELEVATION_UNKNOWN 100 /* Ensure it will be above elev. mask */
 extern u8 n_rollovers;
 
 /** Tracking channel parameters as of end of last correlation period. */
@@ -66,6 +66,7 @@ typedef struct {
                                     1 = Second-stage. After nav bit sync,
                                     retune loop filters and typically (but
                                     not necessarily) use longer integration. */
+  s8 elevation;                /**< Elevation angle, degrees */
   alias_detect_t alias_detect; /**< Alias lock detector. */
   lock_detect_t lock_detect;   /**< Phase-lock detector state. */
 } tracking_channel_t;
@@ -82,7 +83,7 @@ void initialize_lock_counters(void);
 
 float propagate_code_phase(float code_phase, float carrier_freq, u32 n_samples);
 void tracking_channel_init(u8 channel, u8 prn, float carrier_freq,
-                           u32 start_sample_count, float cn0_init);
+                           u32 start_sample_count, float cn0_init, s8 elevation);
 
 void tracking_channel_get_corrs(u8 channel);
 void tracking_channel_update(u8 channel);


### PR DESCRIPTION
I accidentally the whole[1] warmstart...
@mookerji how do you like them apples?
Works on bench, ready for review. Will HITL test overnight.
cc @fnoble @cbeighley @gsmcmullin 

     - New setting 'solution.elevation_mask'
     - New tracking channel state field 'elevation'
     - After calc_pvt in solution_thread, calc the el and save it in that field
     - Check 'elevation' against the mask in use_tracking_channel()
     - Drop satellites that are below the mask in manage_track()
     - manage_cal_almanac_scores() expanded into manage_warm_start()
       - Uses ephemeris instead of almanac if we have it
       - Gives sats below el mask a minimum score
       - Narrow doppler search window if we have good position and time.

[1] not really.  Other warmstart stuff includes preseeding the TOW etc.
