### PR TITLE
V0.19 branch

### DIFF
--- a/src/acq.c
+++ b/src/acq.c
@@ -183,15 +183,17 @@ void acq_service_irq(void)
  *
  * \param cp  Code phase of the acquisition result
  * \param cf  Carrier frequency of the acquisition result
- * \param snr SNR of the acquisition result
+ * \param cn0 Estimated CN0 of the acquisition result
  */
-void acq_get_results(float* cp, float* cf, float* snr)
+void acq_get_results(float* cp, float* cf, float* cn0)
 {
   *cp = 1023.0 - (float)(acq_state.best_cp % (1023 * NAP_ACQ_CODE_PHASE_UNITS_PER_CHIP))
                   / NAP_ACQ_CODE_PHASE_UNITS_PER_CHIP;
   *cf = (float)acq_state.best_cf / NAP_ACQ_CARRIER_FREQ_UNITS_PER_HZ;
   /* "SNR" estimated by peak power over mean power. */
-  *snr = (float)acq_state.best_power / (acq_state.power_acc / acq_state.count);
+  float snr = (float)acq_state.best_power / (acq_state.power_acc / acq_state.count);
+  *cn0 = 10 * log10(snr)
+       + 10 * log10(1.0 / NAP_ACQ_CARRIER_FREQ_UNITS_PER_HZ); /* Bandwidth */
 }
 
 /** \} */

--- a/src/acq.c
+++ b/src/acq.c
@@ -139,7 +139,7 @@ void acq_search(float cf_min_, float cf_max_, float cf_bin_width)
   s16 cf_max = cf_step*ceil(cf_max_*NAP_ACQ_CARRIER_FREQ_UNITS_PER_HZ /
     (float)cf_step);
 
-  for (s16 cf = cf_min; cf < cf_max; cf += cf_step) {
+  for (s16 cf = cf_min; cf <= cf_max; cf += cf_step) {
     if (chSemWaitTimeout(&acq_pipeline_sem, 1000) == RDY_TIMEOUT) {
       log_error("acq: Search timeout (cf = %d)!\n", cf);
     }

--- a/src/acq.h
+++ b/src/acq.h
@@ -22,7 +22,7 @@ void acq_service_load_done(void);
 
 void acq_search(float cf_min, float cf_max, float cf_bin_width);
 void acq_service_irq(void);
-void acq_get_results(float* cp, float* cf, float* snr);
+void acq_get_results(float* cp, float* cf, float* cn0);
 void acq_send_result(u8 prn, float snr, float cp, float cf);
 
 #endif

--- a/src/board/nap/track_channel.h
+++ b/src/board/nap/track_channel.h
@@ -32,7 +32,7 @@
 #define NAP_REG_TRACK_CODE_OFFSET    0x04
 
 /** Max number of tracking channels NAP configuration will be built with. */
-#define NAP_MAX_N_TRACK_CHANNELS     14
+#define NAP_MAX_N_TRACK_CHANNELS     12
 
 extern u8 nap_track_n_channels;
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -332,15 +332,12 @@ static void manage_acq()
     return;
   }
 
-  log_info("acq: PRN %d found @ %d Hz, %.1f C/N0\n", prn + 1, (int)cf, cn0);
-
   u8 chan = manage_track_new_acq();
   if (chan == MANAGE_NO_CHANNELS_FREE) {
     /* No channels are free to accept our new satellite :( */
     /* TODO: Perhaps we can try to warm start this one
      * later using another fine acq.
      */
-    log_info("All channels in use\n");
     if (cn0 > ACQ_RETRY_THRESHOLD) {
       acq_prn_param[prn].score[ACQ_HINT_ACQ] = SCORE_ACQ + (cn0 - ACQ_THRESHOLD);
       acq_prn_param[prn].dopp_hint_low = cf - ACQ_FULL_CF_STEP;
@@ -471,9 +468,9 @@ static void manage_track()
           ch->update_count - ch->snr_above_threshold_count >
             TRACK_SNR_THRES_COUNT) {
         /* This tracking channel has lost its satellite. */
-        log_info("Disabling channel %d (PRN %02d)\n", i, ch->prn+1);
         tracking_channel_disable(i);
         if (ch->snr_above_threshold_count > TRACK_SNR_THRES_COUNT) {
+          log_info("Disabling channel %d (PRN %02d)\n", i, ch->prn+1);
           acq_prn_param[ch->prn].score[ACQ_HINT_TRACK] = SCORE_TRACK;
           float cf = ch->carrier_freq;
           acq_prn_param[ch->prn].dopp_hint_low = cf - ACQ_FULL_CF_STEP;

--- a/src/manage.c
+++ b/src/manage.c
@@ -294,6 +294,15 @@ static void manage_acq()
     /* acq_load could timeout if we're preempted and miss the timing strobe */
   } while (!acq_load(timer_count));
 
+  /* Check for NaNs in dopp hints, or low > high */
+  if (!(acq_prn_param[prn].dopp_hint_low
+        <= acq_prn_param[prn].dopp_hint_high)) {
+    log_error("Acq: caught bogus dopp_hints (%f, %f)\n",
+              acq_prn_param[prn].dopp_hint_low,
+              acq_prn_param[prn].dopp_hint_high);
+    acq_prn_param[prn].dopp_hint_high = ACQ_FULL_CF_MAX;
+    acq_prn_param[prn].dopp_hint_low = ACQ_FULL_CF_MIN;
+  }
   acq_search(acq_prn_param[prn].dopp_hint_low,
              acq_prn_param[prn].dopp_hint_high,
              ACQ_FULL_CF_STEP);

--- a/src/manage.h
+++ b/src/manage.h
@@ -20,8 +20,8 @@
 /** \addtogroup manage
  * \{ */
 
-#define ACQ_THRESHOLD 20.0
-#define ACQ_RETRY_THRESHOLD 25.0
+#define ACQ_THRESHOLD 37.0
+#define ACQ_RETRY_THRESHOLD 38.0
 
 #define TRACK_SNR_INIT_COUNT 1000
 #define TRACK_SNR_THRES_COUNT 2000

--- a/src/nmea.c
+++ b/src/nmea.c
@@ -163,7 +163,7 @@ void nmea_gpgga(const double pos_llh[3], const gps_time_t *gps_t, u8 n_used,
   char lat_dir = pos_llh[0] < 0 ? 'S' : 'N';
   char lon_dir = pos_llh[1] < 0 ? 'W' : 'E';
 
-  NMEA_SENTENCE_START(80);
+  NMEA_SENTENCE_START(120);
   NMEA_SENTENCE_PRINTF("$GPGGA,%02d%02d%06.3f,"
                        "%02d%010.7f,%c,%03d%010.7f,%c,"
                        "%01d,%02d,%.1f,%.2f,M,,M,,",
@@ -182,7 +182,7 @@ void nmea_gpgga(const double pos_llh[3], const gps_time_t *gps_t, u8 n_used,
  */
 void nmea_gpgsa(const tracking_channel_t *chans, const dops_t *dops)
 {
-  NMEA_SENTENCE_START(80);
+  NMEA_SENTENCE_START(120);
   NMEA_SENTENCE_PRINTF("$GPGSA,A,3,");
 
   for (u8 i = 0; i < 12; i++) {
@@ -220,7 +220,7 @@ void nmea_gpgsv(u8 n_used, const navigation_measurement_t *nav_meas,
   double az, el;
 
   for (u8 i = 0; i < n_mess; i++) {
-    NMEA_SENTENCE_START(80);
+    NMEA_SENTENCE_START(120);
     NMEA_SENTENCE_PRINTF("$GPGSV,%d,%d,%d", n_mess, i+1, n_used);
 
     for (u8 j = 0; j < 4; j++) {
@@ -294,7 +294,7 @@ void nmea_gprmc(const navigation_measurement_t *nav_meas,
   double az, el;
   wgsecef2azel(nav_meas[0].sat_pos, soln->pos_ecef, &az, &el);
 
-  NMEA_SENTENCE_START(100);
+  NMEA_SENTENCE_START(140);
   NMEA_SENTENCE_PRINTF(
                 "$GPRMC,%02d%02d%06.3f,A," /* Command, Time (UTC), Valid */
                 "%02d%010.7f,%c,%03d%010.7f,%c," /* Lat/Lon */
@@ -341,7 +341,7 @@ void nmea_gpvtg(const navigation_measurement_t *nav_meas,
   /* Conversion to magnitue km/hr */
   vkmhr = MS2KMHR(x,y,z);
 
-  NMEA_SENTENCE_START(80);
+  NMEA_SENTENCE_START(120);
   NMEA_SENTENCE_PRINTF(
                   "$GPVTG,%05.1f,T," /* Command, course, */
                   ",M," /* Magnetic Course (omitted) */
@@ -383,7 +383,7 @@ void nmea_gpgll(const gnss_solution *soln, const gps_time_t *gps_t)
   char lat_dir = soln->pos_llh[0] < 0 ? 'S' : 'N';
   char lon_dir = soln->pos_llh[1] < 0 ? 'W' : 'E';
 
-  NMEA_SENTENCE_START(80);
+  NMEA_SENTENCE_START(120);
   NMEA_SENTENCE_PRINTF("$GPGLL,"
                 "%02d%010.7f,%c,%03d%010.7f,%c," /* Lat/Lon */
                 "%02d%02d%06.3f,A", /* Time (UTC), Valid */

--- a/src/nmea.c
+++ b/src/nmea.c
@@ -207,7 +207,7 @@ void nmea_gpgsa(const tracking_channel_t *chans, const dops_t *dops)
  * NMEA GPGSV message contains GPS satellites in view.
  *
  * \param n_used   Number of satellites currently being tracked.
- * \param nav_meas Pointer to navigation_measurement struct.
+ * \param nav_meas Array of navigation_measurement structs.
  * \param soln     Pointer to gnss_solution struct.
  */
 void nmea_gpgsv(u8 n_used, const navigation_measurement_t *nav_meas,
@@ -249,7 +249,6 @@ void nmea_gpgsv(u8 n_used, const navigation_measurement_t *nav_meas,
 /** Assemble an NMEA GPRMC message and send it out NMEA USARTs.
  * NMEA RMC contains minimum GPS data 
  *
- * \param nav_meas Pointer to navigation_measurement struct.
  * \param soln Pointer to gnss_solution struct
  * \param gps_t Pointer to the current GPS Time
  */
@@ -385,6 +384,17 @@ void nmea_gpgll(const gnss_solution *soln, const gps_time_t *gps_t)
                 t.tm_hour, t.tm_min, t.tm_sec + frac_s);
   NMEA_SENTENCE_DONE();
 }
+
+
+/** Generate and send periodic NMEA GPGSV, GPRMC, GPVTG, GPGLL
+ * (but not GPGGA) messages.
+ *
+ * Called from solution thread.
+ *
+ * \param soln     Pointer to gnss_solution struct.
+ * \param n        Number of satellites in use
+ * \param nav_meas Array of n navigation_measurement structs.
+ */
 void nmea_send_msgs(gnss_solution *soln, u8 n, 
                     navigation_measurement_t *nm)
 {

--- a/src/nmea.c
+++ b/src/nmea.c
@@ -253,8 +253,7 @@ void nmea_gpgsv(u8 n_used, const navigation_measurement_t *nav_meas,
  * \param soln Pointer to gnss_solution struct
  * \param gps_t Pointer to the current GPS Time
  */
-void nmea_gprmc(const navigation_measurement_t *nav_meas,
-                const gnss_solution *soln, const gps_time_t *gps_t)
+void nmea_gprmc(const gnss_solution *soln, const gps_time_t *gps_t)
 {
   
   /* NMEA Parameters
@@ -294,9 +293,6 @@ void nmea_gprmc(const navigation_measurement_t *nav_meas,
   /* Conversion to magnitue knots */
   velocity = MS2KNOTTS(x,y,z);
 
-  double az, el;
-  wgsecef2azel(nav_meas[0].sat_pos, soln->pos_ecef, &az, &el);
-
   NMEA_SENTENCE_START(140);
   NMEA_SENTENCE_PRINTF(
                 "$GPRMC,%02d%02d%06.3f,A," /* Command, Time (UTC), Valid */
@@ -314,11 +310,9 @@ void nmea_gprmc(const navigation_measurement_t *nav_meas,
 /** Assemble an NMEA GPVTG message and send it out NMEA USARTs.
  * NMEA VTG contains course and speed
  *
- * \param nav_meas Pointer to navigation_measurement struct.
  * \param soln Pointer to gnss_solution struct
  */
-void nmea_gpvtg(const navigation_measurement_t *nav_meas,
-                const gnss_solution *soln)
+void nmea_gpvtg(const gnss_solution *soln)
 {
   /* NMEA Parameters for GPVTG
    * Ex.
@@ -328,9 +322,6 @@ void nmea_gpvtg(const navigation_measurement_t *nav_meas,
    *     True Course   |  Speed (K)   |
    *               Mag. course     Speed (km/hr)
    */
-
-  double az, el;
-  wgsecef2azel(nav_meas[0].sat_pos, soln->pos_ecef, &az, &el);
 
   float vknots, vkmhr;
   float x,y,z;
@@ -413,10 +404,10 @@ void nmea_send_msgs(gnss_solution *soln, u8 n,
     nmea_gpgsv(n, nm, soln);
   );
   DO_EVERY(gprmc_msg_rate,
-    nmea_gprmc(nm, soln, &soln->time);
+    nmea_gprmc(soln, &soln->time);
   );
   DO_EVERY(gpvtg_msg_rate,
-    nmea_gpvtg(nm, soln);
+    nmea_gpvtg(soln);
   );
   DO_EVERY(gpgll_msg_rate,
     nmea_gpgll(soln, &soln->time);

--- a/src/nmea.c
+++ b/src/nmea.c
@@ -307,7 +307,7 @@ void nmea_gprmc(const navigation_measurement_t *nav_meas,
                 t.tm_hour, t.tm_min, t.tm_sec + frac_s,
                 lat_deg, lat_min, lat_dir, lon_deg, lon_min, lon_dir,
                 velocity, course * R2D, 
-                t.tm_mday, t.tm_mon, t.tm_year-100);
+                t.tm_mday, t.tm_mon + 1, t.tm_year % 100);
   NMEA_SENTENCE_DONE();
 }
 

--- a/src/nmea.h
+++ b/src/nmea.h
@@ -63,7 +63,7 @@ void nmea_send_msgs(gnss_solution *soln, u8 n,
 
 /** \cond */
 struct nmea_dispatcher {
-  void (*send)(const char *msg);
+  void (*send)(const char *msg, size_t msg_size);
   struct nmea_dispatcher *next;
 };
 

--- a/src/nmea.h
+++ b/src/nmea.h
@@ -43,10 +43,8 @@ void nmea_gpgga(const double pos_llh[3], const gps_time_t *gps_t, u8 n_used,
 void nmea_gpgsa(const tracking_channel_t *chans, const dops_t *dops);
 void nmea_gpgsv(u8 n_used, const navigation_measurement_t *nav_meas,
                 const gnss_solution *soln);
-void nmea_gprmc(const navigation_measurement_t *nav_meas,
-                const gnss_solution *soln, const gps_time_t *gps_t);
-void nmea_gpvtg(const navigation_measurement_t *nav_meas,
-                const gnss_solution *soln);
+void nmea_gprmc(const gnss_solution *soln, const gps_time_t *gps_t);
+void nmea_gpvtg(const gnss_solution *soln);
 void nmea_gpgll(const gnss_solution *soln, const gps_time_t *gps_t);
 void nmea_send_msgs(gnss_solution *soln, u8 n, 
                     navigation_measurement_t *nm);

--- a/src/solution.c
+++ b/src/solution.c
@@ -210,6 +210,8 @@ static void output_baseline(u8 num_sdiffs, const sdiff_t *sdiffs,
                    &amb_state.float_ambs, &num_used, b,
                    disable_raim, DEFAULT_RAIM_THRESHOLD);
     chMtxUnlock();
+    if (ret == 1)
+      log_warn("output_baseline: Float baseline RAIM repair\n");
     if (ret < 0) {
       log_warn("dgnss_float_baseline returned error: %d\n", ret);
       return;
@@ -406,6 +408,9 @@ static msg_t solution_thread(void *arg)
     /* disable_raim controlled by external setting. Defaults to false. */
     if ((ret = calc_PVT(n_ready_tdcp, nav_meas_tdcp, disable_raim,
                         &position_solution, &dops)) >= 0) {
+
+      if (ret == 1)
+        log_warn("calc_PVT: RAIM repair\n");
 
       /* Update global position solution state. */
       position_updated();

--- a/src/track.c
+++ b/src/track.c
@@ -104,9 +104,10 @@ float propagate_code_phase(float code_phase, float carrier_freq, u32 n_samples)
  * \param channel            Tracking channel number on the Swift NAP.
  * \param carrier_freq       Carrier frequency (Doppler) at start of tracking in Hz.
  * \param start_sample_count Sample count on which to start tracking.
+ * \param cn0_init           Estimated C/N0 from acquisition
  */
 void tracking_channel_init(u8 channel, u8 prn, float carrier_freq,
-                           u32 start_sample_count, float snr)
+                           u32 start_sample_count, float cn0_init)
 {
   /* Calculate code phase rate with carrier aiding. */
   float code_phase_rate = (1 + carrier_freq/GPS_L1_HZ) * GPS_CA_CHIPPING_RATE;
@@ -161,9 +162,7 @@ void tracking_channel_init(u8 channel, u8 prn, float carrier_freq,
   chan->short_cycle = true;
 
   /* Initialise C/N0 estimator */
-  float cn0 = 10 * log10(snr);
-  cn0 += 10 * log10(1000); /* Bandwidth */
-  cn0_est_init(&chan->cn0_est, 1e3, cn0, 5, 1e3);
+  cn0_est_init(&chan->cn0_est, 1e3/l->coherent_ms, cn0_init, 5, 1e3/l->coherent_ms);
 
   /* TODO: Reconfigure alias detection between stages */
   alias_detect_init(&chan->alias_detect, 500/loop_params_stage[1].coherent_ms,

--- a/src/track.c
+++ b/src/track.c
@@ -360,10 +360,8 @@ void tracking_channel_update(u8 channel)
       if ((chan->stage == 0) &&
           (chan->int_ms == 1) &&
           (chan->nav_msg.bit_phase == chan->nav_msg.bit_phase_ref)) {
-        /* This means we have nav bit sync, and just finished a nav bit.
-           So, we can transition to longer integration and/or tighter NBW. */
-        log_info("PRN %d entering second-stage tracking after %u ms\n",
-                 chan->prn+1, (unsigned int)chan->update_count);
+        log_info("PRN %d synced @ %u ms, %.1f dBHz\n",
+                 chan->prn+1, (unsigned int)chan->update_count, chan->cn0);
         chan->stage = 1;
         struct loop_params *l = &loop_params_stage[1];
         chan->int_ms = l->coherent_ms;

--- a/src/track.c
+++ b/src/track.c
@@ -515,15 +515,17 @@ static bool parse_loop_params(struct setting *s, const char *val)
     struct loop_params *l = &loop_params_parse[stage];
 
     int n_chars_read = 0;
-    if (sscanf(str, "( %hhu ms , ( %f , %f , %f , %f ) , ( %f , %f , %f , %f ) ) , %n",
-               &l->coherent_ms,
+    unsigned int tmp; /* newlib's sscanf doesn't support hh size modifier */
+    
+    if (sscanf(str, "( %u ms , ( %f , %f , %f , %f ) , ( %f , %f , %f , %f ) ) , %n",
+               &tmp,
                &l->code_bw, &l->code_zeta, &l->code_k, &l->carr_to_code,
                &l->carr_bw, &l->carr_zeta, &l->carr_k, &l->carr_fll_aid_gain,
                &n_chars_read) < 9) {
       log_error("Ill-formatted tracking loop param string.\n");
       return false;
     }
-
+    l->coherent_ms = tmp;
     /* If string omits second-stage parameters, then after the first
        stage has been parsed, n_chars_read == 0 because of missing
        comma and we'll parse the string again into loop_params_parse[1]. */

--- a/src/track.h
+++ b/src/track.h
@@ -78,7 +78,7 @@ void initialize_lock_counters(void);
 
 float propagate_code_phase(float code_phase, float carrier_freq, u32 n_samples);
 void tracking_channel_init(u8 channel, u8 prn, float carrier_freq,
-                           u32 start_sample_count, float snr);
+                           u32 start_sample_count, float cn0_init);
 
 void tracking_channel_get_corrs(u8 channel);
 void tracking_channel_update(u8 channel);


### PR DESCRIPTION
@cbeighley @denniszollo  here you go.  Includes the following fixes:

NMEA prevent buffer overruns
NMEA fix wrong month in GPRMC
Acq prevent zero dopp span search (leading to SNR=0 spins)
Sscanf doesn't support %hhu
libswiftnav: fix occasional incorrect TOW extraction from nav msg
libswiftnav: fix incorrect DOPs
libswiftnav: report RAIM repairs
Drop max tracking channels supported by STM to 12, giving a little more breathing room on the heap
Silence a lot of the spammy INFO messages
Report acq results as C/N0 rather than SNR