### PR TITLE
check dimensionality properly before pvt or baseline solution

### DIFF
--- a/src/solution.c
+++ b/src/solution.c
@@ -398,7 +398,7 @@ static msg_t solution_thread(void *arg)
     memcpy(nav_meas_old, nav_meas, sizeof(nav_meas));
     n_ready_old = n_ready;
 
-    if (n_ready_tdcp == 0) {
+    if (n_ready_tdcp < 4) {
       /* Not enough sats to compute PVT */
       continue;
     }
@@ -446,7 +446,9 @@ static msg_t solution_thread(void *arg)
                                     es, position_solution.time,
                                     sdiffs);
             chMtxUnlock();
-            output_baseline(num_sdiffs, sdiffs, &position_solution.time);
+            if (num_sdiffs >= 4) {
+              output_baseline(num_sdiffs, sdiffs, &position_solution.time);
+            }
           }
 
         }


### PR DESCRIPTION
should reduce the incidence of

"WARNING: dgnss_baseline returned error: -1"

and

"WARNING: PVT solver: Not enough measurements for solution (< 4) (code -7)"