### PR TITLE
Changed simulation almanacs to const.

### DIFF
--- a/src/simulator_data.c
+++ b/src/simulator_data.c
@@ -11,7 +11,7 @@ u32 simulation_fake_carrier_bias[31];
 
 u8 simulation_num_almanacs = 31;
 
-almanac_t simulation_almanacs[31] = {
+const almanac_t simulation_almanacs[31] = {
 { 
   .ecc       = 0.002888,
   .toa       = 233472.000000,

--- a/src/simulator_data.h
+++ b/src/simulator_data.h
@@ -21,6 +21,6 @@ extern u8 simulation_num_almanacs;
 extern double simulation_sats_pos[][3];
 extern double simulation_sats_vel[][3];
 extern u32 simulation_fake_carrier_bias[];
-extern almanac_t simulation_almanacs[];
+extern const almanac_t simulation_almanacs[];
 
 #endif /* SWIFTNAV_SIMULATOR_DATA_H */


### PR DESCRIPTION
Freeing up ~3Kb. libswiftnav PR: https://github.com/swift-nav/libswiftnav/pull/202

Signed-off-by: Vlad Ungureanu <vvu@vdev.ro>

/cc: @gsmcmullin @henryhallam 