### PR TITLE
Remove newlines from logs

### DIFF
--- a/src/acq.c
+++ b/src/acq.c
@@ -33,7 +33,7 @@ void acq_set_prn(u8 prn)
   chBSemInit(&load_wait_sem, TRUE);
   nap_acq_code_wr_blocking(prn);
   if (chBSemWaitTimeout(&load_wait_sem, 1000) == RDY_TIMEOUT) {
-    log_error("acq: Timeout waiting for code load!\n");
+    log_error("acq: Timeout waiting for code load!");
   }
 }
 
@@ -76,7 +76,7 @@ bool acq_load(u32 count)
   nap_acq_load_wr_enable_blocking();
   nap_timing_strobe(count);
   if (chBSemWaitTimeout(&load_wait_sem, 1000) == RDY_TIMEOUT) {
-    log_info("acq: Sample load timeout. Probably set timing strobe in the past.\n");
+    log_info("acq: Sample load timeout. Probably set timing strobe in the past.");
     return false;
   }
   return true;
@@ -141,7 +141,7 @@ void acq_search(float cf_min_, float cf_max_, float cf_bin_width)
 
   for (s16 cf = cf_min; cf <= cf_max; cf += cf_step) {
     if (chSemWaitTimeout(&acq_pipeline_sem, 1000) == RDY_TIMEOUT) {
-      log_error("acq: Search timeout (cf = %d)!\n", cf);
+      log_error("acq: Search timeout (cf = %d)!", cf);
     }
     acq_state.pipeline[acq_state.p_head].cf = cf;
     acq_state.p_head = (acq_state.p_head + 1) % NAP_ACQ_PIPELINE_STAGES;
@@ -150,7 +150,7 @@ void acq_search(float cf_min_, float cf_max_, float cf_bin_width)
 
   for (int i = 0; i < NAP_ACQ_PIPELINE_STAGES; i++) {
     if (chSemWaitTimeout(&acq_pipeline_sem, 1000) == RDY_TIMEOUT) {
-      log_error("acq: Search timeout!\n");
+      log_error("acq: Search timeout!");
     }
   }
 }
@@ -202,7 +202,7 @@ void acq_get_results(float* cp, float* cf, float* cn0)
    * this condition so we don't propagate NaN up through the stack */
   if ((acq_state.power_acc == 0) || (acq_state.count == 0)) {
     log_error("acq: Power or frequency bin count is 0, causing SNR to be NaN. "
-              "(best=%" PRIu64 ", acc=%f, count=%" PRIu32 ")\n",
+              "(best=%" PRIu64 ", acc=%f, count=%" PRIu32 ")",
               acq_state.best_power, acq_state.power_acc, acq_state.count);
     *cn0 = 0;
   } else {

--- a/src/base_obs.c
+++ b/src/base_obs.c
@@ -161,7 +161,7 @@ static void update_obss(obss_t *new_obss)
     } else {
       /* TODO(dsk) check for repair failure */
       /* There was an error calculating the position solution. */
-      log_warn("Error calculating base station position: (%s).\n", pvt_err_msg[-ret-1]);
+      log_warn("Error calculating base station position: (%s).", pvt_err_msg[-ret-1]);
     }
   }
   /* If the base station position is known then calculate the satellite ranges.
@@ -235,7 +235,7 @@ static void obs_callback(u16 sender_id, u8 len, u8 msg[], void* context)
   double dt = fabs(epoch_count - round(epoch_count)) / obs_freq;
   if (dt > TIME_MATCH_THRESHOLD) {
     log_warn("Unaligned observation from base station ignored, "
-             "tow = %.3f, dt = %.3f\n", t.tow, dt);
+             "tow = %.3f, dt = %.3f", t.tow, dt);
     return;
   }
 
@@ -253,7 +253,7 @@ static void obs_callback(u16 sender_id, u8 len, u8 msg[], void* context)
   } else if (prev_t.tow != t.tow ||
              prev_t.wn != t.wn ||
              prev_count + 1 != count) {
-    log_info("Dropped one of the observation packets! Skipping this sequence.\n");
+    log_info("Dropped one of the observation packets! Skipping this sequence.");
     prev_count = -1;
     return;
   } else {
@@ -327,7 +327,7 @@ static void obs_callback(u16 sender_id, u8 len, u8 msg[], void* context)
 static void deprecated_callback(u16 sender_id, u8 len, u8 msg[], void* context)
 {
   (void) context; (void) len; (void) msg; (void) sender_id;
-  log_error("Receiving an old deprecated observation message.\n");
+  log_error("Receiving an old deprecated observation message.");
 }
 
 /** Setup the base station observation handling subsystem. */

--- a/src/board/max2769.c
+++ b/src/board/max2769.c
@@ -162,14 +162,14 @@ bool antenna_changed(struct setting *s, const char *val)
       max2769_conf1 |= MAX2769_CONF1_LNAMODE_LNA1 | MAX2769_CONF1_ANTEN;
       if (ant_status) {
         log_warn("Patch antenna selected, but an external "
-                 "antenna appears to be connected.\n"); 
+                 "antenna appears to be connected."); 
       }
       break;
     case EXTERNAL:
       max2769_conf1 |= MAX2769_CONF1_LNAMODE_LNA2 | MAX2769_CONF1_ANTEN;
       if (!ant_status) { 
         log_warn("External antenna selected, but no external " 
-                 "antenna appears to be connected.\n"); 
+                 "antenna appears to be connected."); 
       }
       break;
     case EXTERNAL_AC:
@@ -177,7 +177,7 @@ bool antenna_changed(struct setting *s, const char *val)
       break;
     }
     max2769_write(MAX2769_CONF1, max2769_conf1);
-    log_info("Antenna changed to: %s\n", val);
+    log_info("Antenna changed to: %s", val);
 
     return true;
   }

--- a/src/ephemeris.c
+++ b/src/ephemeris.c
@@ -31,21 +31,21 @@ static void ephemeris_new(ephemeris_t *e)
   gps_time_t t = get_current_time();
   if (!ephemeris_good(&es[e->prn], t)) {
     /* Our currently used ephemeris is bad, so we assume this is better. */
-    log_info("New untrusted ephemeris for PRN %02d\n", e->prn+1);
+    log_info("New untrusted ephemeris for PRN %02d", e->prn+1);
     chMtxLock(&es_mutex);
     es[e->prn] = es_candidate[e->prn] = *e;
     chMtxUnlock();
 
   } else if (ephemeris_equal(&es_candidate[e->prn], e)) {
     /* The received ephemeris matches our candidate, so we trust it. */
-    log_info("New trusted ephemeris for PRN %02d\n", e->prn+1);
+    log_info("New trusted ephemeris for PRN %02d", e->prn+1);
     chMtxLock(&es_mutex);
     es[e->prn] = *e;
     chMtxUnlock();
   } else {
     /* This is our first reception of this new ephemeris, so treat it with
      * suspicion and call it the new candidate. */
-    log_info("New ephemeris candidate for PRN %02d\n", e->prn+1);
+    log_info("New ephemeris candidate for PRN %02d", e->prn+1);
     chMtxLock(&es_mutex);
     es_candidate[e->prn] = *e;
     chMtxUnlock();
@@ -87,7 +87,7 @@ static msg_t nav_msg_thread(void *arg)
       ephemeris_new(&e);
 
       if (!es[ch->prn].healthy) {
-        log_info("PRN %02d unhealthy\n", ch->prn+1);
+        log_info("PRN %02d unhealthy", ch->prn+1);
       } else {
         msg_ephemeris_t msg;
         pack_ephemeris(&es[ch->prn], &msg);
@@ -104,14 +104,14 @@ static void ephemeris_msg_callback(u16 sender_id, u8 len, u8 msg[], void* contex
   (void)sender_id; (void)context;
 
   if (len != sizeof(msg_ephemeris_t)) {
-    log_warn("Received bad ephemeris from peer\n");
+    log_warn("Received bad ephemeris from peer");
     return;
   }
 
   ephemeris_t e;
   unpack_ephemeris((msg_ephemeris_t *)msg, &e);
   if (e.prn >= MAX_SATS) {
-    log_warn("Ignoring ephemeris for invalid sat\n");
+    log_warn("Ignoring ephemeris for invalid sat");
     return;
   }
 

--- a/src/init.c
+++ b/src/init.c
@@ -132,7 +132,7 @@ void check_nap_auth(void)
     led_off(LED_RED);
     while (1) {
       DO_EVERY(10000000,
-        log_error("NAP Verification Failed\n");
+        log_error("NAP Verification Failed");
         led_toggle(LED_GREEN);
         led_toggle(LED_RED);
       );

--- a/src/main.c
+++ b/src/main.c
@@ -156,14 +156,14 @@ int main(void)
 
   static char nap_version_string[64] = {0};
   nap_conf_rd_version_string(nap_version_string);
-  log_info("NAP firmware version: %s\n", nap_version_string);
+  log_info("NAP firmware version: %s", nap_version_string);
 
   /* Check we are running a compatible version of the NAP firmware. */
   const char *required_nap_version = "v0.16";
   if (compare_version(nap_version_string, required_nap_version) < 0) {
     while (1) {
-      log_error("NAP firmware version >= %s required, please update!\n"
-                "(instructions can be found at http://docs.swift-nav.com/)\n",
+      log_error("NAP firmware version >= %s required, please update!"
+                "(instructions can be found at http://docs.swift-nav.com/)",
                 required_nap_version);
       chThdSleepSeconds(2);
     }

--- a/src/manage.c
+++ b/src/manage.c
@@ -97,20 +97,20 @@ static void almanac_callback(u16 sender_id, u8 len, u8 msg[], void* context)
 
   almanac_t *new_almanac = (almanac_t*)msg;
 
-  log_info("Received alamanc for PRN %02d\n", new_almanac->prn);
+  log_info("Received alamanc for PRN %02d", new_almanac->prn);
   memcpy(&almanac[new_almanac->prn-1], new_almanac, sizeof(almanac_t));
 
   int fd = cfs_open("almanac", CFS_WRITE);
   if (fd != -1) {
     cfs_seek(fd, (new_almanac->prn-1)*sizeof(almanac_t), CFS_SEEK_SET);
     if (cfs_write(fd, new_almanac, sizeof(almanac_t)) != sizeof(almanac_t)) {
-      log_error("Error writing to almanac file\n");
+      log_error("Error writing to almanac file");
     } else {
-      log_info("Saved almanac to flash\n");
+      log_info("Saved almanac to flash");
     }
     cfs_close(fd);
   } else {
-    log_error("Error opening almanac file\n");
+    log_error("Error opening almanac file");
   }
 }
 
@@ -127,7 +127,7 @@ static void mask_sat_callback(u16 sender_id, u8 len, u8 msg[], void* context)
 
   u8 prn = m->sid & 0x1F; /* TODO prn -> sid */
 
-  log_info("Mask for PRN %02d = 0x%02x\n", prn+1, m->mask);
+  log_info("Mask for PRN %02d = 0x%02x", prn+1, m->mask);
   if (m->mask & MASK_ACQUISITION) {
     acq_prn_param[prn].masked = true;
   } else {
@@ -166,10 +166,10 @@ void manage_acq_setup()
   int fd = cfs_open("almanac", CFS_READ);
   if (fd != -1) {
     cfs_read(fd, almanac, 32*sizeof(almanac_t));
-    log_info("Loaded almanac from flash\n");
+    log_info("Loaded almanac from flash");
     cfs_close(fd);
   } else {
-    log_info("No almanac file present in flash, create an empty one\n");
+    log_info("No almanac file present in flash, create an empty one");
     cfs_coffee_reserve("almanac", 32*sizeof(almanac_t));
     cfs_coffee_configure_log("almanac", 256, sizeof(almanac_t));
 
@@ -296,7 +296,7 @@ static u8 choose_prn(void)
     }
   }
 
-  log_error("Failed to pick a sat for acquisition!\n");
+  log_error("Failed to pick a sat for acquisition!");
 
   return -1;
 }
@@ -344,7 +344,7 @@ static void manage_acq()
   /* Check for NaNs in dopp hints, or low > high */
   if (!(acq_prn_param[prn].dopp_hint_low
         <= acq_prn_param[prn].dopp_hint_high)) {
-    log_error("Acq: caught bogus dopp_hints (%f, %f)\n",
+    log_error("Acq: caught bogus dopp_hints (%f, %f)",
               acq_prn_param[prn].dopp_hint_low,
               acq_prn_param[prn].dopp_hint_high);
     acq_prn_param[prn].dopp_hint_high = ACQ_FULL_CF_MAX;
@@ -504,7 +504,7 @@ static void manage_track()
 
     /* Is ephemeris marked unhealthy? */
     if (es[ch->prn].valid && !es[ch->prn].healthy) {
-      log_info("PRN%d unhealthy, dropping\n", ch->prn+1);
+      log_info("PRN%d unhealthy, dropping", ch->prn+1);
       drop_channel(i);
       acq_prn_param[ch->prn].state = ACQ_PRN_UNHEALTHY;
       continue;
@@ -521,21 +521,21 @@ static void manage_track()
     /* Optimistic phase lock detector "unlocked" for a while? */
     /* TODO: This isn't doing much.  Use the pessimistic detector instead? */
     if ((int)(uc - ch->ld_opti_locked_count) > TRACK_DROP_UNLOCKED_T) {
-      log_info("PRN%d PLL unlocked too long, dropping\n", ch->prn+1);
+      log_info("PRN%d PLL unlocked too long, dropping", ch->prn+1);
       drop_channel(i);
       continue;
     }
 
     /* CN0 below threshold for a while? */
     if ((int)(uc - ch->cn0_above_drop_thres_count) > TRACK_DROP_CN0_T) {
-      log_info("PRN%d low CN0 too long, dropping\n", ch->prn+1);
+      log_info("PRN%d low CN0 too long, dropping", ch->prn+1);
       drop_channel(i);
       continue;
     }
 
     /* Is satellite below our elevation mask? */
     if (ch->elevation < elevation_mask) {
-      log_info("PRN%d below elevation mask, dropping\n", ch->prn+1);
+      log_info("PRN%d below elevation mask, dropping", ch->prn+1);
       drop_channel(i);
       /* Erase the tracking hint score, and any others it might have */
       memset(&acq_prn_param[ch->prn].score, 0,

--- a/src/nmea.c
+++ b/src/nmea.c
@@ -63,7 +63,7 @@ static struct nmea_dispatcher *nmea_dispatchers_head;
 /** NMEA_SENTENCE_DONE: append checksum and dispatch. */
 #define NMEA_SENTENCE_DONE() do { \
     if (sentence_bufp == sentence_buf_end) \
-      log_warn("NMEA %.6s cut off\n", sentence_buf); \
+      log_warn("NMEA %.6s cut off", sentence_buf); \
     nmea_append_checksum(sentence_buf, sizeof(sentence_buf)); \
     nmea_output(sentence_buf, sentence_bufp - sentence_buf + NMEA_SUFFIX_LEN); \
   } while (0)

--- a/src/peripherals/3drradio.c
+++ b/src/peripherals/3drradio.c
@@ -162,7 +162,7 @@ void radio_preconfigure_hook(u32 usart, u32 default_baud, char* uart_name)
     busy_wait_for_str(usart, "\x00", WAIT_BETWEEN_COMMANDS);
 
   } else {
-    log_info("No telemetry radio found on %s, skipping configuration.\n",
+    log_info("No telemetry radio found on %s, skipping configuration.",
              uart_name);
   }
 

--- a/src/peripherals/random.c
+++ b/src/peripherals/random.c
@@ -53,7 +53,7 @@ u32 random_int(void)
     if ((sr = RNG_SR)) {
       if (sr & RNG_SR_SEIS) {
         /* Seed error, we must reinitialise */
-        log_warn("random: Seed error, restarting RNG 0x%"PRIx32"\n", sr);
+        log_warn("random: Seed error, restarting RNG 0x%"PRIx32"", sr);
         RNG_CR &= ~RNG_CR_RNGEN;
         RNG_CR |= RNG_CR_RNGEN;
       }
@@ -69,7 +69,7 @@ u32 random_int(void)
   } while ((new_value == last_value) && (tries < RANDOM_MAX_TRIES));
 
   if (new_value == last_value) {
-    log_error("random: Gave up waiting for random number!\n");
+    log_error("random: Gave up waiting for random number!");
     new_value = last_value + 1;
   }
   last_value = new_value;

--- a/src/peripherals/usart.c
+++ b/src/peripherals/usart.c
@@ -187,17 +187,17 @@ void usarts_enable(u32 ftdi_baud, u32 uarta_baud, u32 uartb_baud, bool do_precon
     /* TODO: Should this really be here? */
     if ((RCC_CSR & 0xFF000000) != RCC_CSR_PINRSTF) {
       if (RCC_CSR & RCC_CSR_IWDGRSTF)
-        log_error("Piksi has reset due to a watchdog timeout.\n");
+        log_error("Piksi has reset due to a watchdog timeout.");
       if (RCC_CSR & RCC_CSR_LPWRRSTF)
-        log_error("Low power reset detected.\n");
+        log_error("Low power reset detected.");
       if (RCC_CSR & RCC_CSR_SFTRSTF)
-        log_info("Software reset detected.\n");
-      log_info("Reset reason: %02X\n", (unsigned int)(RCC_CSR >> 24));
+        log_info("Software reset detected.");
+      log_info("Reset reason: %02X", (unsigned int)(RCC_CSR >> 24));
     }
-    log_info("Piksi Starting...\n");
+    log_info("Piksi Starting...");
     RCC_CSR |= RCC_CSR_RMVF;
-    log_info("Firmware Version: " GIT_VERSION "\n");
-    log_info("Built: " __DATE__ " " __TIME__ "\n");
+    log_info("Firmware Version: " GIT_VERSION "");
+    log_info("Built: " __DATE__ " " __TIME__ "");
 
     if (uarta_usart.configure_telemetry_radio_on_boot) {
       radio_preconfigure_hook(USART1, uarta_baud, "UARTA");

--- a/src/peripherals/usart_chat.c
+++ b/src/peripherals/usart_chat.c
@@ -65,7 +65,7 @@ bool usart_sendwait(enum uart u, const char *send, const char *wait, u32 timeout
     for (i = 0; send[i]; i++) {
       usart_read_dma_timeout(&uart_state(u)->rx, &c, 1, TIMEOUT_CHAR);
       if (c != send[i]) {
-        log_debug("No echo: '%s'\n", send);
+        log_debug("No echo: '%s'", send);
         return false;
       }
     }

--- a/src/peripherals/usart_rx.c
+++ b/src/peripherals/usart_rx.c
@@ -200,7 +200,7 @@ u32 usart_n_read_dma(usart_rx_dma_state* s)
     n_available = 0;
   else if (n_available > USART_RX_BUFFER_LEN) {
     /* If greater than a whole buffer then we have had an overflow. */
-    log_error("DMA RX buffer overrun\n");
+    log_error("DMA RX buffer overrun");
     n_available = 0;
     s->errors++;
     /* Disable and re-enable the DMA channel to get back to a known good

--- a/src/position.c
+++ b/src/position.c
@@ -43,7 +43,7 @@ void position_setup(void)
   if (fd != -1) {
     cfs_read(fd, &position_solution, sizeof(gnss_solution));
     if (position_solution.valid) {
-      log_info("Loaded last position solution from file: %.4f %.4f %.1f\n",
+      log_info("Loaded last position solution from file: %.4f %.4f %.1f",
                position_solution.pos_llh[0] * (180 / M_PI),
                position_solution.pos_llh[1] * (180 / M_PI),
                position_solution.pos_llh[2]);
@@ -52,11 +52,11 @@ void position_setup(void)
       last_time = position_solution.time;
       memcpy(last_ecef, position_solution.pos_ecef, sizeof(last_ecef));
     } else {
-      log_warn("Loaded position solution from file invalid\n");
+      log_warn("Loaded position solution from file invalid");
     }
     cfs_close(fd);
   } else {
-    log_info("No position file present in flash, create an empty one\n");
+    log_info("No position file present in flash, create an empty one");
     cfs_coffee_reserve("posn", sizeof(gnss_solution));
     cfs_coffee_configure_log("posn", 256, sizeof(gnss_solution));
   }
@@ -77,13 +77,13 @@ void position_updated(void)
     if (fd != -1) {
       if (cfs_write(fd, (void *)&position_solution,
                     sizeof(position_solution)) != sizeof(position_solution)) {
-        log_error("Error writing to position file\n");
+        log_error("Error writing to position file");
       } else {
-        log_info("Saved position to flash\n");
+        log_info("Saved position to flash");
       }
       cfs_close(fd);
     } else {
-      log_error("Error opening position file\n");
+      log_error("Error opening position file");
     }
     last_time = position_solution.time;
     memcpy(last_ecef, position_solution.pos_ecef, sizeof(last_ecef));

--- a/src/sbp_fileio.c
+++ b/src/sbp_fileio.c
@@ -71,12 +71,12 @@ static void read_cb(u16 sender_id, u8 len, u8 msg_[], void* context)
   msg_fileio_read_req_t *msg = (msg_fileio_read_req_t *)msg_;
 
   if (sender_id != SBP_SENDER_ID) {
-    log_error("Invalid sender!\n");
+    log_error("Invalid sender!");
     return;
   }
 
   if ((len <= sizeof(*msg)) || (len == SBP_FRAMING_MAX_PAYLOAD_SIZE)) {
-    log_error("Invalid fileio read message!\n");
+    log_error("Invalid fileio read message!");
     return;
   }
 
@@ -113,12 +113,12 @@ static void read_dir_cb(u16 sender_id, u8 len, u8 msg_[], void* context)
   msg_fileio_read_dir_req_t *msg = (msg_fileio_read_dir_req_t *)msg_;
 
   if (sender_id != SBP_SENDER_ID) {
-    log_error("Invalid sender!\n");
+    log_error("Invalid sender!");
     return;
   }
 
   if ((len <= sizeof(*msg)) || (len == SBP_FRAMING_MAX_PAYLOAD_SIZE)) {
-    log_error("Invalid fileio read dir message!\n");
+    log_error("Invalid fileio read dir message!");
     return;
   }
 
@@ -157,12 +157,12 @@ static void remove_cb(u16 sender_id, u8 len, u8 msg[], void* context)
   (void)context;
 
   if (sender_id != SBP_SENDER_ID) {
-    log_error("Invalid sender!\n");
+    log_error("Invalid sender!");
     return;
   }
 
   if ((len < 1) || (len == SBP_FRAMING_MAX_PAYLOAD_SIZE)) {
-    log_error("Invalid fileio remove message!\n");
+    log_error("Invalid fileio remove message!");
     return;
   }
 
@@ -185,14 +185,14 @@ static void write_cb(u16 sender_id, u8 len, u8 msg_[], void* context)
   msg_fileio_write_req_t *msg = (msg_fileio_write_req_t *)msg_;
 
   if (sender_id != SBP_SENDER_ID) {
-    log_error("Invalid sender!\n");
+    log_error("Invalid sender!");
     return;
   }
 
   if ((len <= sizeof(*msg) + 2) ||
       (strnlen(msg->filename, SBP_FRAMING_MAX_PAYLOAD_SIZE - sizeof(*msg)) ==
                               SBP_FRAMING_MAX_PAYLOAD_SIZE - sizeof(*msg))) {
-    log_error("Invalid fileio write message!\n");
+    log_error("Invalid fileio write message!");
     return;
   }
 

--- a/src/sbp_utils.c
+++ b/src/sbp_utils.c
@@ -190,7 +190,7 @@ s8 pack_obs_content(double P, double L, double snr, u16 lock_counter, u8 prn,
 
   s64 P_fp = llround(P * MSG_OBS_P_MULTIPLIER);
   if (P < 0 || P_fp > UINT32_MAX) {
-    log_error("observation message packing: P integer overflow (%f)\n", P);
+    log_error("observation message packing: P integer overflow (%f)", P);
     return -1;
   }
 
@@ -198,7 +198,7 @@ s8 pack_obs_content(double P, double L, double snr, u16 lock_counter, u8 prn,
 
   double Li = floor(L);
   if (Li < INT32_MIN || Li > INT32_MAX) {
-    log_error("observation message packing: L integer overflow (%f)\n", L);
+    log_error("observation message packing: L integer overflow (%f)", L);
     return -1;
   }
 
@@ -209,7 +209,7 @@ s8 pack_obs_content(double P, double L, double snr, u16 lock_counter, u8 prn,
 
   s32 snr_fp = lround(snr * MSG_OBS_SNR_MULTIPLIER);
   if (snr < 0 || snr_fp > UINT8_MAX) {
-    log_error("observation message packing: SNR integer overflow (%f)\n", snr);
+    log_error("observation message packing: SNR integer overflow (%f)", snr);
     return -1;
   }
 

--- a/src/settings.c
+++ b/src/settings.c
@@ -287,7 +287,7 @@ static void settings_write_callback(u16 sender_id, u8 len, u8 msg[], void* conte
   (void) context;
 
   if (sender_id != SBP_SENDER_ID) {
-    log_error("Invalid sender\n");
+    log_error("Invalid sender");
     return;
   }
 
@@ -295,12 +295,12 @@ static void settings_write_callback(u16 sender_id, u8 len, u8 msg[], void* conte
   const char *section = NULL, *setting = NULL, *value = NULL;
 
   if (len == 0) {
-    log_error("Error in settings write message\n");
+    log_error("Error in settings write message");
     return;
   }
 
   if (msg[len-1] != '\0') {
-    log_error("Error in settings write message\n");
+    log_error("Error in settings write message");
     return;
   }
 
@@ -323,26 +323,26 @@ static void settings_write_callback(u16 sender_id, u8 len, u8 msg[], void* conte
         if (i == len-1)
           break;
       default:
-        log_error("Error in settings write message\n");
+        log_error("Error in settings write message");
         return;
       }
     }
   }
 
   if (value == NULL) {
-    log_error("Error in settings write message\n");
+    log_error("Error in settings write message");
     return;
   }
 
   s = settings_lookup(section, setting);
   if (s == NULL) {
-    log_error("Error in settings write message\n");
+    log_error("Error in settings write message");
     return;
   }
 
   /* This is an assignment, call notify function */
   if (!s->notify(s, value)) {
-    log_error("Error in settings write message\n");
+    log_error("Error in settings write message");
     return;
   }
   s->dirty = true;
@@ -354,7 +354,7 @@ static void settings_read_callback(u16 sender_id, u8 len, u8 msg[], void* contex
   (void) context;
 
   if (sender_id != SBP_SENDER_ID) {
-    log_error("Invalid sender\n");
+    log_error("Invalid sender");
     return;
   }
 
@@ -364,12 +364,12 @@ static void settings_read_callback(u16 sender_id, u8 len, u8 msg[], void* contex
   u8 buflen;
 
   if (len == 0) {
-    log_error("Error in settings read message\n");
+    log_error("Error in settings read message");
     return;
   }
 
   if (msg[len-1] != '\0') {
-    log_error("Error in settings read message\n");
+    log_error("Error in settings read message");
     return;
   }
 
@@ -388,7 +388,7 @@ static void settings_read_callback(u16 sender_id, u8 len, u8 msg[], void* contex
         if (i == len-1)
           break;
       default:
-        log_error("Error in settings read message\n");
+        log_error("Error in settings read message");
         return;
       }
     }
@@ -396,7 +396,7 @@ static void settings_read_callback(u16 sender_id, u8 len, u8 msg[], void* contex
 
   s = settings_lookup(section, setting);
   if (s == NULL) {
-    log_error("Error in settings read message\n");
+    log_error("Error in settings read message");
     return;
   }
 
@@ -410,7 +410,7 @@ static void settings_read_by_index_callback(u16 sender_id, u8 len, u8 msg[], voi
   (void) context;
 
   if (sender_id != SBP_SENDER_ID) {
-    log_error("Invalid sender\n");
+    log_error("Invalid sender");
     return;
   }
 
@@ -449,7 +449,7 @@ static void settings_save_callback(u16 sender_id, u8 len, u8 msg[], void* contex
   (void)sender_id; (void) context; (void)len; (void)msg;
 
   if (f == -1) {
-    log_error("Error opening config file!\n");
+    log_error("Error opening config file!");
     return;
   }
 
@@ -463,7 +463,7 @@ static void settings_save_callback(u16 sender_id, u8 len, u8 msg[], void* contex
       sec = s->section;
       i = snprintf(buf, sizeof(buf), "[%s]\n", sec);
       if (cfs_write(f, buf, i) != i) {
-        log_error("Error writing to config file!\n");
+        log_error("Error writing to config file!");
       }
     }
 
@@ -472,11 +472,11 @@ static void settings_save_callback(u16 sender_id, u8 len, u8 msg[], void* contex
     i += s->type->to_string(s->type->priv, &buf[i], sizeof(buf) - i - 1, s->addr, s->len);
     buf[i++] = '\n';
     if (cfs_write(f, buf, i) != i) {
-      log_error("Error writing to config file!\n");
+      log_error("Error writing to config file!");
     }
   }
 
   cfs_close(f);
-  log_info("Wrote settings to config file.\n");
+  log_info("Wrote settings to config file.");
 }
 

--- a/src/solution.c
+++ b/src/solution.c
@@ -198,7 +198,7 @@ static void output_baseline(u8 num_sdiffs, const sdiff_t *sdiffs,
       /* ret is <0 on error, 2 if float, 1 if fixed */
       flags = (ret == 1) ? 1 : 0;
     } else {
-      log_warn("dgnss_baseline returned error: %d\n", ret);
+      log_warn("dgnss_baseline returned error: %d", ret);
       return;
     }
     break;
@@ -211,9 +211,9 @@ static void output_baseline(u8 num_sdiffs, const sdiff_t *sdiffs,
                    disable_raim, DEFAULT_RAIM_THRESHOLD);
     chMtxUnlock();
     if (ret == 1)
-      log_warn("output_baseline: Float baseline RAIM repair\n");
+      log_warn("output_baseline: Float baseline RAIM repair");
     if (ret < 0) {
-      log_warn("dgnss_float_baseline returned error: %d\n", ret);
+      log_warn("dgnss_float_baseline returned error: %d", ret);
       return;
     }
     break;
@@ -293,7 +293,7 @@ static void timer_set_period_check(uint32_t timer_peripheral, uint32_t period)
   if (tmp > period) {
     TIM_CNT(timer_peripheral) = period;
     log_warn("Solution thread missed deadline, "
-             "TIM counter = %lu, period = %lu\n", tmp, period);
+             "TIM counter = %lu, period = %lu", tmp, period);
   }
   __asm__("CPSIE i;");
 }
@@ -430,7 +430,7 @@ static msg_t solution_thread(void *arg)
                         &position_solution, &dops)) >= 0) {
 
       if (ret == 1)
-        log_warn("calc_PVT: RAIM repair\n");
+        log_warn("calc_PVT: RAIM repair");
 
       /* Update global position solution state. */
       position_updated();
@@ -521,7 +521,7 @@ static msg_t solution_thread(void *arg)
            * overwrite the oldest item in the queue. */
           ret = chMBFetch(&obs_mailbox, (msg_t *)&obs, TIME_IMMEDIATE);
           if (ret != RDY_OK) {
-            log_error("Pool full and mailbox empty!\n");
+            log_error("Pool full and mailbox empty!");
           }
         }
         obs->t = new_obs_time;
@@ -534,7 +534,7 @@ static msg_t solution_thread(void *arg)
            * are equal then we should have already handled the case where the
            * mailbox is full when we handled the case that the pool was full.
            * */
-          log_error("Mailbox should have space!\n");
+          log_error("Mailbox should have space!");
         }
       }
 
@@ -556,7 +556,7 @@ static msg_t solution_thread(void *arg)
        * count. */
       /* pvt_err_msg defined in libswiftnav/pvt.c */
       DO_EVERY((u32)soln_freq,
-        log_warn("PVT solver: %s (code %d)\n", pvt_err_msg[-ret-1], ret);
+        log_warn("PVT solver: %s (code %d)", pvt_err_msg[-ret-1], ret);
       );
 
       /* Send just the DOPs */
@@ -575,7 +575,7 @@ void process_matched_obs(u8 n_sds, gps_time_t *t, sdiff_t *sds)
   if (init_known_base) {
     if (n_sds > 4) {
       /* Calculate ambiguities from known baseline. */
-      log_info("Initializing using known baseline\n");
+      log_info("Initializing using known baseline");
       double known_baseline_ecef[3];
       wgsned2ecef(known_baseline, position_solution.pos_ecef,
                   known_baseline_ecef);
@@ -583,13 +583,13 @@ void process_matched_obs(u8 n_sds, gps_time_t *t, sdiff_t *sds)
                                 known_baseline_ecef);
       init_known_base = false;
     } else {
-      log_warn("> 4 satellites required for known baseline init.\n");
+      log_warn("> 4 satellites required for known baseline init.");
     }
   }
   if (!init_done) {
     if (n_sds > 4) {
       /* Initialize filters. */
-      log_info("Initializing DGNSS filters\n");
+      log_info("Initializing DGNSS filters");
       dgnss_init(n_sds, sds, position_solution.pos_ecef);
       /* Initialize ambiguity states. */
       ambiguities_init(&amb_state.fixed_ambs);
@@ -670,7 +670,7 @@ static msg_t time_matched_obs_thread(void *arg)
           /* In practice this should basically never happen so lets make a note
            * if it does. */
           log_warn("Obs Matching: t_base < t_rover "
-                   "(dt=%f obss.t={%d,%f} base_obss.t={%d,%f})\n", dt,
+                   "(dt=%f obss.t={%d,%f} base_obss.t={%d,%f})", dt,
                    obss->t.wn, obss->t.tow,
                    base_obss.t.wn, base_obss.t.tow
           );
@@ -679,7 +679,7 @@ static msg_t time_matched_obs_thread(void *arg)
           if (ret != RDY_OK) {
             /* Something went wrong with returning it to the buffer, better just
              * free it and carry on. */
-            log_warn("Obs Matching: mailbox full, discarding observation!\n");
+            log_warn("Obs Matching: mailbox full, discarding observation!");
             chPoolFree(&obs_buff_pool, obss);
           }
           break;
@@ -707,11 +707,11 @@ void reset_filters_callback(u16 sender_id, u8 len, u8 msg[], void* context)
   (void)sender_id; (void)len; (void)context;
   switch (msg[0]) {
   case 0:
-    log_info("Filter reset requested\n");
+    log_info("Filter reset requested");
     init_done = false;
     break;
   case 1:
-    log_info("IAR reset requested\n");
+    log_info("IAR reset requested");
     reset_iar = true;
     break;
   default:

--- a/src/system_monitor.c
+++ b/src/system_monitor.c
@@ -151,10 +151,10 @@ static msg_t system_monitor_thread(void *arg)
     if (ant_status != max2769_ant_status()) {
       ant_status = max2769_ant_status();
       if (ant_status && max2769_ant_setting() == AUTO) {
-        log_info("Now using external antenna.\n");
+        log_info("Now using external antenna.");
       }
       else if (max2769_ant_setting() == AUTO) {
-        log_info("Now using patch antenna.\n");
+        log_info("Now using patch antenna.");
       }
     }
     u32 status_flags = ant_status << 31 | SBP_MAJOR_VERSION << 16 | SBP_MINOR_VERSION << 8;
@@ -177,7 +177,7 @@ static msg_t system_monitor_thread(void *arg)
 
     u32 err = nap_error_rd_blocking();
     if (err) {
-      log_error("SwiftNAP Error: 0x%08X\n", (unsigned int)err);
+      log_error("SwiftNAP Error: 0x%08X", (unsigned int)err);
     }
 
     sleep_until(&time, MS2ST(heartbeat_period_milliseconds));
@@ -206,7 +206,7 @@ static void debug_threads()
   };
   Thread *tp = chRegFirstThread();
   while (tp) {
-  log_info("%s (%u: %s): prio: %lu, flags: %u, wtobjp: %p\n",
+  log_info("%s (%u: %s): prio: %lu, flags: %u, wtobjp: %p",
            tp->p_name, tp->p_state, state[tp->p_state], tp->p_prio,
            tp->p_flags, tp->p_u.wtobjp);
     tp = chRegNextThread(tp);
@@ -235,7 +235,7 @@ static msg_t watchdog_thread(void *arg)
     if (threads_dead) {
       /* TODO: ChibiOS thread state dump */
       log_error("One or more threads appear to be dead: 0x%08X. "
-                "Watchdog reset %s.\n",
+                "Watchdog reset %s.",
                 (unsigned int)threads_dead,
                 use_wdt ? "imminent" : "disabled");
       debug_threads();

--- a/src/timing.c
+++ b/src/timing.c
@@ -57,7 +57,7 @@ void set_time(time_quality_t quality, gps_time_t t)
 
     time_quality = quality;
     time_t unix_t = gps2time(t);
-    log_info("Time set to: %s (quality=%d)\n", ctime(&unix_t), quality);
+    log_info("Time set to: %s (quality=%d)", ctime(&unix_t), quality);
   }
 }
 

--- a/src/track.c
+++ b/src/track.c
@@ -333,7 +333,7 @@ void tracking_channel_update(u8 channel)
 
       if ((TOW_ms >= 0) && chan->TOW_ms != TOW_ms) {
         if (chan->TOW_ms != TOW_INVALID) {
-          log_error("PRN %d TOW mismatch: %ld, %lu\n",
+          log_error("PRN %d TOW mismatch: %ld, %lu",
                     chan->prn+1, chan->TOW_ms, TOW_ms);
         }
         chan->TOW_ms = TOW_ms;
@@ -357,7 +357,7 @@ void tracking_channel_update(u8 channel)
       /* Reset carrier phase ambiguity if there's doubt as to our phase lock */
       if (last_outp && !chan->lock_detect.outp) {
         if (chan->stage > 0)
-          log_info("PRN %d PLL stress\n", chan->prn+1);
+          log_info("PRN %d PLL stress", chan->prn+1);
         tracking_channel_ambiguity_unknown(channel);
       }
 
@@ -404,7 +404,7 @@ void tracking_channel_update(u8 channel)
         float err = alias_detect_second(&chan->alias_detect, I, Q);
         if (fabs(err) > (250 / chan->int_ms)) {
           if (chan->lock_detect.outp)
-            log_warn("False phase lock detect PRN%d: err=%f\n", chan->prn+1, err);
+            log_warn("False phase lock detect PRN%d: err=%f", chan->prn+1, err);
 
           tracking_channel_ambiguity_unknown(channel);
           /* Indicate that a mode change has occurred. */
@@ -421,7 +421,7 @@ void tracking_channel_update(u8 channel)
           (chan->lock_detect.outo) &&
           /* Must have nav bit sync, and be correctly aligned */
           (chan->nav_msg.bit_phase == chan->nav_msg.bit_phase_ref)) {
-        log_info("PRN %d synced @ %u ms, %.1f dBHz\n",
+        log_info("PRN %d synced @ %u ms, %.1f dBHz",
                  chan->prn+1, (unsigned int)chan->update_count, chan->cn0);
         chan->stage = 1;
         struct loop_params *l = &loop_params_stage[1];
@@ -463,7 +463,7 @@ void tracking_channel_update(u8 channel)
       tracking_channel_disable(channel);
       break;
     default:
-      log_error("CH%d (PRN%02d) invalid state %d\n", channel, chan->prn+1, chan->state);
+      log_error("CH%d (PRN%02d) invalid state %d", channel, chan->prn+1, chan->state);
       tracking_channel_disable(channel);
       break;
   }
@@ -581,7 +581,7 @@ static bool parse_loop_params(struct setting *s, const char *val)
                &l->code_bw, &l->code_zeta, &l->code_k, &l->carr_to_code,
                &l->carr_bw, &l->carr_zeta, &l->carr_k, &l->carr_fll_aid_gain,
                &n_chars_read) < 9) {
-      log_error("Ill-formatted tracking loop param string.\n");
+      log_error("Ill-formatted tracking loop param string.");
       return false;
     }
     l->coherent_ms = tmp;
@@ -593,7 +593,7 @@ static bool parse_loop_params(struct setting *s, const char *val)
     if ((l->coherent_ms == 0)
         || ((20 % l->coherent_ms) != 0) /* i.e. not 1, 2, 4, 5, 10 or 20 */
         || (stage == 0 && l->coherent_ms != 1)) {
-      log_error("Invalid coherent integration length.\n");
+      log_error("Invalid coherent integration length.");
       return false;
     }
   }
@@ -611,7 +611,7 @@ static bool parse_lock_detect_params(struct setting *s, const char *val)
 
   if (sscanf(val, "%f , %f , %" SCNu16 " , %" SCNu16,
              &p.k1, &p.k2, &p.lp, &p.lo) < 4) {
-      log_error("Ill-formatted lock detect param string.\n");
+      log_error("Ill-formatted lock detect param string.");
       return false;
   }
   /* Successfully parsed.  Save to memory. */


### PR DESCRIPTION
Used:

```
perl -pi -e 's/(log_.*)\\n"/\1"/' *.c
```

to strip the newlines out of the logging for most cases. Did the rest by hand.

/cc @gsmcmullin 