### PR TITLE
reduce max size of observation packet to fit in mavlinks tiny 110 byt…

### DIFF
--- a/src/solution.c
+++ b/src/solution.c
@@ -57,7 +57,7 @@ double soln_freq = 10.0;
 u32 obs_output_divisor = 2;
 
 double known_baseline[3] = {0, 0, 0};
-u16 msg_obs_max_size = 104;
+u16 msg_obs_max_size = 102;
 
 static u16 lock_counters[MAX_SATS];
 


### PR DESCRIPTION
With the widened PRN, 6 observation messages (16 bytes each) plus the header (8 bytes) makes 111 bytes total for the observations.  Unfortunately there is a limit imposed in the mavlink GPS injection capability to 110 byte messages.  I don't know from where this limit originates, but it seems to have been related to RTCM message formats for some code differential format.

This proposed 2 byte limit change in the firmware will help us fit in the 110 byte limit in our ardupilot integration.  However, it means the observation message used to hold 7 satellites and now will hold 5.   Any thoughts or comments?  @fnoble @cbeighley @mfine 