### PR TITLE
Add PPS output to Piksi's debug connector

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -129,6 +129,7 @@ CSRC := $(PORTSRC) \
         $(SWIFTNAV_ROOT)/src/nmea.o \
         $(SWIFTNAV_ROOT)/src/system_monitor.o \
         $(SWIFTNAV_ROOT)/src/ephemeris.o \
+        $(SWIFTNAV_ROOT)/src/pps.o \
         main.c
 
 # C++ sources that can be compiled in ARM or THUMB mode depending on the global

--- a/src/board/nap/nap_common.h
+++ b/src/board/nap/nap_common.h
@@ -23,6 +23,8 @@
 /* NAP Register Addresses. */
 #define NAP_REG_IRQ                 0x00
 #define NAP_REG_ERROR               0x01
+#define NAP_REG_PPS_WIDTH           0xF4
+#define NAP_REG_PPS_COMPARE         0xF5
 #define NAP_REG_EXT_EVENT_TIME      0xF6
 #define NAP_REG_TIMING_COMPARE      0xF8
 #define NAP_REG_TIMING_COUNT        0xF9
@@ -94,6 +96,9 @@ bool nap_timing_strobe_wait(u32 timeout);
 
 u32 nap_rw_ext_event(u8 *event_pin, ext_event_trigger_t *event_trig,
 		     ext_event_trigger_t next_trig);
+
+void nap_pps(u64 rising_edge_count_8x);
+void nap_pps_width(u32 falling_edge_count);
 
 #endif  /* SWIFTNAV_NAP_COMMON_H */
 

--- a/src/main.c
+++ b/src/main.c
@@ -38,6 +38,7 @@
 #include "settings.h"
 #include "sbp_fileio.h"
 #include "ephemeris.h"
+#include "pps.h"
 
 extern void ext_setup(void);
 
@@ -189,6 +190,7 @@ int main(void)
 
   sbp_fileio_setup();
   ext_setup();
+  pps_setup();
 
   READ_ONLY_PARAMETER("system_info", "serial_number", serial_number, TYPE_INT);
   READ_ONLY_PARAMETER("system_info", "firmware_version", GIT_VERSION,

--- a/src/pps.c
+++ b/src/pps.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2011-2015 Swift Navigation Inc.
+ * Contact: Johannes Walter <johannes@swift-nav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <math.h>
+
+#include <ch.h>
+
+#include <libswiftnav/gpstime.h>
+#include <libswiftnav/logging.h>
+
+#include "board/nap/nap_common.h"
+#include "settings.h"
+#include "main.h"
+#include "timing.h"
+#include "pps.h"
+
+/** \defgroup pps Pulse-per-second (PPS)
+ * Generate a pulse-per-second in alignment with GPS time.
+ * \{ */
+
+/** Number of microseconds the PPS will remain high (default: 200000). */
+u32 pps_width_microseconds = PPS_WIDTH_MICROSECONDS;
+
+static WORKING_AREA_CCM(wa_pps_thread, 256);
+static msg_t pps_thread(void *arg)
+{
+  (void)arg;
+  chRegSetThreadName("PPS");
+
+  while (TRUE) {
+    if (time_quality == TIME_FINE) {
+      gps_time_t t = get_current_time();
+      t.tow = floor(t.tow) + 1;
+      u64 next = round(gps2rxtime(t) * PPS_NAP_CLOCK_RATIO) +
+                       (PPS_NAP_CYCLES_OFFSET);
+      nap_pps(next);
+    }
+    chThdSleepMilliseconds(PPS_THREAD_INTERVAL_MS);
+  }
+
+  return 0;
+}
+
+/** Set PPS width.
+ * Sets the pulse width to a provided duration in microseconds.
+ *
+ * \param microseconds Pulse width in microseconds (1-999999).
+ * \return Returns true if value is within valid range, false otherwise.
+ */
+bool pps_width(u32 microseconds)
+{
+  if (microseconds < 1 || microseconds >= 1e6) {
+    log_info("Invalid PPS width. Valid range: 1-999999\n");
+    return FALSE;
+  }
+
+  nap_pps_width(ceil((double)microseconds / (RX_DT_NOMINAL * 1e6)) - 1);
+  return TRUE;
+}
+
+/** Settings callback for PPS width.
+ * Updates the PPS width on NAP whenever the setting is changed.
+ *
+ * \param s Pointer to settings config.
+ * \param val Pointer to new value.
+ * \return Returns true if the change was successful, false otherwise.
+ */
+bool pps_width_changed(struct setting *s, const char *val)
+{
+  (void)s;
+  (void)val;
+
+  if (s->type->from_string(s->type->priv, s->addr, s->len, val)) {
+    return pps_width(pps_width_microseconds);
+  }
+  return FALSE;
+}
+
+/** Set up PPS generation.
+ * Sets the default value for the PPS width and starts a thread to generate
+ * the pulses.
+ */
+void pps_setup(void)
+{
+  pps_width(pps_width_microseconds);
+
+  SETTING_NOTIFY("pps", "width", pps_width_microseconds, TYPE_INT,
+                 pps_width_changed);
+
+  chThdCreateStatic(wa_pps_thread, sizeof(wa_pps_thread),
+                    NORMALPRIO+15, pps_thread, NULL);
+}
+
+/** \} */

--- a/src/pps.h
+++ b/src/pps.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2011-2015 Swift Navigation Inc.
+ * Contact: Johannes Walter <johannes@swift-nav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef SWIFTNAV_PPS_H
+#define SWIFTNAV_PPS_H
+
+#define PPS_WIDTH_MICROSECONDS 200000
+#define PPS_NAP_CYCLES_OFFSET  -14
+#define PPS_NAP_CLOCK_RATIO    8
+#define PPS_THREAD_INTERVAL_MS 100
+
+void pps_setup(void);
+
+#endif


### PR DESCRIPTION
Piksi generates a pulse-per-second synchronized with GPS time.

A thread periodically checks the current GPS time and time quality and
calculates the number of NAP clock cycles to the next full GPS second.
It then writes this value to an SPI register. Further, the pulse width
will be updated whenever the corresponding value is changed in Piksi
Console.

The PPS output has been tested in the lab with an oscilloscope using a
GPSDO as reference.