### PR TITLE
Change AT commands for radio and UartA baud

### DIFF
--- a/src/peripherals/3drradio.c
+++ b/src/peripherals/3drradio.c
@@ -32,7 +32,7 @@
 static const u32 baud_rates[] = {115200, 57600};//, 230400, 38400, 19200};
 
 /* This is the command string we send to the radios */
-static char commandstr[MAXLEN] = "AT&F,ATS1=115,ATS2=128,ATS5=0,AT&W,ATZ";
+static char commandstr[MAXLEN] = "AT&F,ATS1=57,ATS2=64,ATS5=0,AT&W,ATZ";
 
 /** Wait until the UART has data ready to be received.
 * or until ms time passes.

--- a/src/peripherals/usart.c
+++ b/src/peripherals/usart.c
@@ -39,7 +39,7 @@ usart_settings_t ftdi_usart = {
 
 usart_settings_t uarta_usart = {
   .mode               = SBP,
-  .baud_rate          = USART_DEFAULT_BAUD_TTL,
+  .baud_rate          = USART_DEFAULT_BAUD_RADIO,
   .sbp_message_mask   = 0x40,
   .configure_telemetry_radio_on_boot = 1,
 };

--- a/src/peripherals/usart.h
+++ b/src/peripherals/usart.h
@@ -59,6 +59,8 @@ extern usart_settings_t uartb_usart;
 
 #define USART_DEFAULT_BAUD_FTDI 1000000
 #define USART_DEFAULT_BAUD_TTL  115200
+#define USART_DEFAULT_BAUD_RADIO 57600
+
 
 /** USART DMA state structure. */
 typedef struct {


### PR DESCRIPTION
Request to change the default 3DR radio settings. (Change the baud from 115 to 57 and air rate from 128 to 64) From bench testing, it was found that the 57600 baud worked much better that 115200. Along with the 3DR settings, this also changes the default uartA baud to work with the 3DR radios.

This change also requires to change settings.yaml in piksi_tools. 