### PR TITLE
Fix nmea bugs

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -22,7 +22,7 @@
  */
 #define DO_EVERY(n, cmd) do { \
   static u32 do_every_count = 0; \
-  if (if (n) > 0 && do_every_count % (n) == 0) { \
+  if ((n) > 0 && do_every_count % (n) == 0) { \
     cmd; \
   } \
   do_every_count++; \

--- a/src/main.h
+++ b/src/main.h
@@ -22,7 +22,7 @@
  */
 #define DO_EVERY(n, cmd) do { \
   static u32 do_every_count = 0; \
-  if (do_every_count % (n) == 0) { \
+  if (if (n) > 0 && do_every_count % (n) == 0) { \
     cmd; \
   } \
   do_every_count++; \

--- a/src/nmea.c
+++ b/src/nmea.c
@@ -398,18 +398,6 @@ void nmea_gpgll(const gnss_solution *soln, const gps_time_t *gps_t)
 void nmea_send_msgs(gnss_solution *soln, u8 n, 
                     navigation_measurement_t *nm)
 {
-  if (gpgsv_msg_rate < 1) {
-    gpgsv_msg_rate = 1;
-  }
-  if (gprmc_msg_rate < 1) {
-    gpgsv_msg_rate = 1;
-  }
-  if (gpvtg_msg_rate < 1) {
-    gpgsv_msg_rate = 1;
-  }
-  if (gpgll_msg_rate < 1) {
-    gpgsv_msg_rate = 1;
-  }
   DO_EVERY(gpgsv_msg_rate,
     nmea_gpgsv(n, nm, soln);
   );


### PR DESCRIPTION
If you set one of the NMEA rates to 0, it would crash your Piksi.  Also, we should have a way to set message output rates to 0 if required.   

Changes: 
* Protect the DO_EVERY macro against a divide by zero
* Remove overwrite of user specified settings (that had a typo)