### PR TITLE
Reduce tracking state and thread state message rates

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -21,13 +21,14 @@ v0.21 <a name="v0.21"></a>
 -----
 
 #### Core
- * Fixes "dgnss_baseline returned error: -2" bug when dropping a satellite
- * Add heading output from baseline vector
- * 1PPS output on debug connector
+ * Fixes "dgnss_baseline returned error: -2" bug when dropping a satellite.
+ * Reduce occurence of "status glitches" that were observed by users integrating Piksi with Pixhawk by increasing RTK availablity.
+ * 1PPS output on debug connector (pin DEBUG1) 
  * New tracking lock detection architecture
  * Allow NMEA rates to be set to zero to disable
- * Reduce default baud rate for 3DR radios
+ * Reduce default baud and air rates for 3DR radios
  * Reduce observation message size for Mavlink encapsulation
+ * Reduce serial bus traffic to improve console responsiveness on user machines
  * Numerous minor fixes and improvements
 
 v0.20 <a name="v0.20"></a>

--- a/src/manage.c
+++ b/src/manage.c
@@ -461,8 +461,8 @@ static msg_t manage_track_thread(void *arg)
   (void)arg;
   chRegSetThreadName("manage track");
   while (TRUE) {
-    chThdSleepMilliseconds(200);
-    DO_EVERY(5,
+    chThdSleepMilliseconds(500);
+    DO_EVERY(2,
       check_clear_unhealthy();
       manage_track();
       nmea_gpgsa(tracking_channel, 0);

--- a/src/system_monitor.c
+++ b/src/system_monitor.c
@@ -194,8 +194,10 @@ static msg_t system_monitor_thread(void *arg)
       iar_state.num_hyps = dgnss_iar_num_hyps();
     }
     sbp_send_msg(SBP_MSG_IAR_STATE, sizeof(msg_iar_state_t), (u8 *)&iar_state);
-
-    send_thread_states();
+    
+    DO_EVERY(2, 
+     send_thread_states(); 
+    );
 
     u32 err = nap_error_rd_blocking();
     if (err) {


### PR DESCRIPTION
This is an attempt to reduce serial throughput to improve perceived piksi performance when using the console.

Note that the 1hz rate of running the manage_track block (each second) should not have changed.