### PR TITLE
NAP: Remove nap_acq_init_wr_disable_blocking(), which is irrelevant (and confusing) with the FFT acquisition engine

### DIFF
--- a/src/board/nap/acq_channel.c
+++ b/src/board/nap/acq_channel.c
@@ -80,19 +80,6 @@ void nap_acq_init_wr_params_blocking(s16 carrier_freq)
   nap_xfer_blocking(NAP_REG_ACQ_INIT, sizeof(temp), 0, temp);
 }
 
-/** Disable NAP acquisition channel.
- * Write to the acquisition channel's INIT register to disable the correlations
- * (clears enable bit). This must be written once to pipeline disable the
- * correlations, and then a second time to clear the ACQ_DONE IRQ after the
- * last correlation has finished.
- */
-void nap_acq_init_wr_disable_blocking()
-{
-  u8 temp[4] = { 0, 0, 0, 0 };
-
-  nap_xfer_blocking(NAP_REG_ACQ_INIT, 4, 0, temp);
-}
-
 /** Unpack correlations read from acquisition channel.
  *
  * \param packed Array of u8 data read from NAP acq channel CORR register.

--- a/src/board/nap/acq_channel.h
+++ b/src/board/nap/acq_channel.h
@@ -49,7 +49,6 @@ extern u8 nap_acq_downsample_stages;
 void nap_acq_load_wr_enable_blocking(void);
 void nap_acq_load_wr_disable_blocking(void);
 void nap_acq_init_wr_params_blocking(s16 carrier_freq);
-void nap_acq_init_wr_disable_blocking(void);
 void nap_acq_corr_rd_blocking(u16 *index, u16 *max, float *ave);
 void nap_acq_code_wr_blocking(u8 prn);
 


### PR DESCRIPTION
@gsmcmullin @cbeighley @fnoble can you confirm this is actually the case? :)