### PR TITLE
MSG_BASE_POS_ECEF

### DIFF
--- a/src/system_monitor.c
+++ b/src/system_monitor.c
@@ -183,7 +183,7 @@ static msg_t system_monitor_thread(void *arg)
       if (base_distance > BASE_STATION_DISTANCE_THRESHOLD) {
         log_warn("Invalid surveyed position coordinates\n");
       } else {
-        sbp_send_msg(SBP_MSG_BASE_POS, sizeof(msg_base_pos_t), (u8 *)&base_llh);
+        sbp_send_msg(SBP_MSG_BASE_POS_ECEF, sizeof(msg_base_pos_ecef_t), (u8 *)&base_ecef);
       }
     }
 


### PR DESCRIPTION
Support a `MSG_BASE_POS_ECEF` message, for both publishing and consuming - publish and consume base position in ECEF coordinates.

Handle receiving a base position in either coordinate system - similar behavior, no conversion necessary for ECEF.

Bring in new settings:
+ `surveyed_position->broadcast_ecef`
+ `surveyed_position->surveyed_ecef_x`
+ `surveyed_position->surveyed_ecef_y`
+ `surveyed_position->surveyed_ecef_z`

If `broadcast_ecef` is set, then publish the ECEF coordinates. Existing behavior for `broadcast` works unchanged. Another approach here might be to stop publishing LLH coordinates and phase out our consumption of them (existing `surveyed_position` settings would still be used, just published as ECEF).

https://github.com/swift-nav/libsbp/pull/320

/cc @fnoble @mookerji @denniszollo 