### PR TITLE
Enable WFI idle

### DIFF
--- a/src/chconf.h
+++ b/src/chconf.h
@@ -548,6 +548,8 @@ extern u64 g_ctime;
 /* Change vector table location for compatibility with the bootloader. */
 #define CORTEX_VTOR_INIT 0x08004000
 
+#define CORTEX_ENABLE_WFI_IDLE TRUE
+
 #define _CCM __attribute__((section (".ccmram")))
 #define WORKING_AREA_CCM(s, n) WORKING_AREA(s, n) _CCM
 


### PR DESCRIPTION
Enables execution of WFI power-saving instruction from the idle thread. Should reduce CPU power consumption significantly.