### PR TITLE
Ignore Eclipse IDE-specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ scripts/RELEASE-VERSION
 /scripts/testing/hub_ctrl
 /scripts/testing/bootload_log*
 
+.cproject
+.project
+.settings/
+


### PR DESCRIPTION
This commit adds Eclipse IDE-specific files to .gitignore file
so git is instructed not to track changes in those files.