### PR TITLE
Tracking channel refactor, specialize by code type

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -114,6 +114,9 @@ CSRC := $(PORTSRC) \
         $(SWIFTNAV_ROOT)/src/sbp_utils.o \
         $(SWIFTNAV_ROOT)/src/error.o \
         $(SWIFTNAV_ROOT)/src/track.o \
+        $(SWIFTNAV_ROOT)/src/track_internal.o \
+        $(SWIFTNAV_ROOT)/src/track_api.o \
+        $(SWIFTNAV_ROOT)/src/track_gps_l1ca.o \
         $(SWIFTNAV_ROOT)/src/acq.o \
         $(SWIFTNAV_ROOT)/src/manage.o \
         $(SWIFTNAV_ROOT)/src/settings.o \

--- a/src/board/nap/nap_exti.c
+++ b/src/board/nap/nap_exti.c
@@ -118,7 +118,6 @@ static void handle_nap_exti(void)
 
     /* Test if the nth tracking irq flag is set, if so service it. */
     if ((irq >> n) & 1) {
-      tracking_channel_get_corrs(n);
       tracking_channel_update(n);
     }
   }

--- a/src/board/nap/nap_exti.c
+++ b/src/board/nap/nap_exti.c
@@ -106,21 +106,7 @@ static void handle_nap_exti(void)
 
   /* Mask off everything but tracking irqs. */
   irq &= NAP_IRQ_TRACK_MASK;
-
-  /* Loop over tracking irq bit flags. */
-  for (u8 n = 0; n < nap_track_n_channels; n++) {
-    /* Save a bit of time by seeing if the rest of the bits
-     * are zero in one go so we don't have to loop over all
-     * of them.
-     */
-    if (!(irq >> n))
-      break;
-
-    /* Test if the nth tracking irq flag is set, if so service it. */
-    if ((irq >> n) & 1) {
-      tracking_channel_update(n);
-    }
-  }
+  tracking_channels_update(irq);
 
   watchdog_notify(WD_NOTIFY_NAP_ISR);
   nap_exti_count++;

--- a/src/decode_gps_l1.c
+++ b/src/decode_gps_l1.c
@@ -98,11 +98,8 @@ static void decoder_gps_l1_process(const decoder_channel_info_t *channel_info,
     }
   }
 
-  /* Check if there is a new nav msg subframe to process.
-   * TODO: move this into a function */
-  tracking_channel_t *ch = &tracking_channel[channel_info->tracking_channel];
-  if ((ch->state != TRACKING_RUNNING) ||
-      !subframe_ready(&data->nav_msg))
+  /* Check if there is a new nav msg subframe to process. */
+  if (!subframe_ready(&data->nav_msg))
     return;
 
   /* Decode ephemeris to temporary struct */

--- a/src/main.c
+++ b/src/main.c
@@ -178,6 +178,7 @@ int main(void)
   static s32 serial_number;
   serial_number = nap_conf_rd_serial_number();
 
+  rng_setup();
   max2769_setup();
   timing_setup();
   ext_event_setup();
@@ -186,7 +187,6 @@ int main(void)
   decode_setup();
   decode_gps_l1_register();
 
-  rng_setup();
   manage_acq_setup();
   manage_track_setup();
   system_monitor_setup();

--- a/src/main.c
+++ b/src/main.c
@@ -28,6 +28,7 @@
 #include "init.h"
 #include "manage.h"
 #include "track.h"
+#include "track_gps_l1ca.h"
 #include "timing.h"
 #include "ext_events.h"
 #include "solution.h"
@@ -183,7 +184,8 @@ int main(void)
   timing_setup();
   ext_event_setup();
   position_setup();
-  tracking_setup();
+  track_setup();
+  track_gps_l1ca_register();
   decode_setup();
   decode_gps_l1_register();
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -462,8 +462,6 @@ static msg_t manage_track_thread(void *arg)
 
 void manage_track_setup()
 {
-  initialize_lock_counters();
-
   SETTING("track", "cn0_use", track_cn0_use_thres, TYPE_FLOAT);
   SETTING("solution", "elevation_mask", elevation_mask, TYPE_FLOAT);
 

--- a/src/manage.c
+++ b/src/manage.c
@@ -543,7 +543,7 @@ static void manage_track()
     }
 
     /* Is satellite below our elevation mask? */
-    if (ch->elevation < elevation_mask) {
+    if (tracking_channel_evelation_degrees_get(i) < elevation_mask) {
       log_info("%s below elevation mask, dropping", buf);
       drop_channel(i);
       /* Erase the tracking hint score, and any others it might have */
@@ -562,7 +562,7 @@ s8 use_tracking_channel(u8 i)
       /* Check SNR has been above threshold for the minimum time. */
       && (tracking_channel_cn0_useable_ms_get(i) > TRACK_SNR_THRES_COUNT)
       /* Satellite elevation is above the mask. */
-      && (ch->elevation >= elevation_mask)
+      && (tracking_channel_evelation_degrees_get(i) >= elevation_mask)
       /* Pessimistic phase lock detector = "locked". */
       && (tracking_channel_ld_pess_locked_ms_get(i) > TRACK_USE_LOCKED_T)
       /* Some time has elapsed since the last tracking channel mode

--- a/src/manage.c
+++ b/src/manage.c
@@ -92,7 +92,7 @@ static bool track_mask[PLATFORM_SIGNAL_COUNT];
 
 #define COMPILER_BARRIER() asm volatile ("" : : : "memory")
 
-#define TRACKING_STARTUP_FIFO_SIZE 8
+#define TRACKING_STARTUP_FIFO_SIZE 8    /* Must be a power of 2 */
 
 #define TRACKING_STARTUP_FIFO_INDEX_MASK ((TRACKING_STARTUP_FIFO_SIZE) - 1)
 #define TRACKING_STARTUP_FIFO_INDEX_DIFF(write_index, read_index) \

--- a/src/manage.c
+++ b/src/manage.c
@@ -564,7 +564,7 @@ s8 use_tracking_channel(u8 i)
       /* Satellite elevation is above the mask. */
       && (ch->elevation >= elevation_mask)
       /* Pessimistic phase lock detector = "locked". */
-      && (ch->lock_detect.outp)
+      && (tracking_channel_ld_pess_locked_ms_get(i) > TRACK_USE_LOCKED_T)
       /* Some time has elapsed since the last tracking channel mode
        * change, to allow any transients to stabilize.
        * TODO: is this still necessary? */

--- a/src/manage.h
+++ b/src/manage.h
@@ -42,6 +42,10 @@
     TRACK_DROP_UNLOCKED_T ms, drop the channel. */
 #define TRACK_DROP_UNLOCKED_T 5000
 
+/** If pessimistic phase lock detector shows "locked" for >=
+    TRACK_USE_LOCKED_T ms, use the channel. */
+#define TRACK_USE_LOCKED_T 100
+
 /** How many milliseconds to wait for the tracking loops to
  * stabilize after any mode change before using obs. */
 #define TRACK_STABILIZATION_T 1000

--- a/src/manage.h
+++ b/src/manage.h
@@ -62,6 +62,15 @@
 #define MANAGE_TRACK_THREAD_PRIORITY (NORMALPRIO-2)
 #define MANAGE_TRACK_THREAD_STACK   1400
 
+typedef struct {
+  gnss_signal_t sid;      /**< Signal identifier. */
+  u32 sample_count;       /**< Reference NAP sample count. */
+  float carrier_freq;     /**< Carrier frequency Doppler (Hz). */
+  float code_phase;       /**< Code phase (chips). */
+  float cn0_init;         /**< C/N0 estimate (dBHz). */
+  s8 elevation;           /**< Elevation (deg). */
+} tracking_startup_params_t;
+
 /** \} */
 
 void manage_acq_setup(void);
@@ -71,5 +80,7 @@ void manage_set_obs_hint(gnss_signal_t sid);
 void manage_track_setup(void);
 s8 use_tracking_channel(u8 i);
 u8 tracking_channels_ready(void);
+
+bool tracking_startup_request(const tracking_startup_params_t *startup_params);
 
 #endif

--- a/src/nmea.c
+++ b/src/nmea.c
@@ -180,17 +180,18 @@ void nmea_gpgga(const double pos_llh[3], const gps_time_t *gps_t, u8 n_used,
 /** Assemble a NMEA GPGSA message and send it out NMEA USARTs.
  * NMEA GPGSA message contains DOP and active satellites.
  *
- * \param chans Pointer to tracking_channel_t struct.
- * \param dops  Pointer to dops_t struct.
+ * \param prns      Array of prns to output
+ * \param num_prns  Length of prns array
+ * \param dops      Pointer to dops_t struct.
  */
-void nmea_gpgsa(const tracking_channel_t *chans, const dops_t *dops)
+void nmea_gpgsa(const u8 *prns, u8 num_prns, const dops_t *dops)
 {
   NMEA_SENTENCE_START(120);
   NMEA_SENTENCE_PRINTF("$GPGSA,A,3,");
 
   for (u8 i = 0; i < 12; i++) {
-    if (i < nap_track_n_channels && chans[i].state == TRACKING_RUNNING)
-      NMEA_SENTENCE_PRINTF("%02d,", chans[i].sid.sat + 1);
+    if (i < num_prns)
+      NMEA_SENTENCE_PRINTF("%02d,", prns[i]);
     else
       NMEA_SENTENCE_PRINTF(",");
   }
@@ -229,8 +230,9 @@ void nmea_gpgsv(u8 n_used, const navigation_measurement_t *nav_meas,
     for (u8 j = 0; j < 4; j++) {
       if (n < n_used) {
         wgsecef2azel(nav_meas[n].sat_pos, soln->pos_ecef, &az, &el);
+        /* TODO: only include GPS signals */
         NMEA_SENTENCE_PRINTF(",%02d,%02d,%03d,%02d",
-          nav_meas[n].sid.sat + 1,
+          nav_meas[n].sid.sat,
           (u8)round(el * R2D),
           (u16)round(az * R2D),
           (u8)round(nav_meas[n].snr)

--- a/src/nmea.h
+++ b/src/nmea.h
@@ -40,7 +40,7 @@
 void nmea_setup(void);
 void nmea_gpgga(const double pos_llh[3], const gps_time_t *gps_t, u8 n_used,
                 u8 fix_type, double hdop);
-void nmea_gpgsa(const tracking_channel_t *chans, const dops_t *dops);
+void nmea_gpgsa(const u8 *prns, u8 num_prns, const dops_t *dops);
 void nmea_gpgsv(u8 n_used, const navigation_measurement_t *nav_meas,
                 const gnss_solution *soln);
 void nmea_gprmc(const gnss_solution *soln, const gps_time_t *gps_t);

--- a/src/sbp_utils.c
+++ b/src/sbp_utils.c
@@ -55,8 +55,10 @@ gnss_signal_t sid_from_sbp(const sbp_gnss_signal_t from)
   /* Maintain legacy compatibility with GPS PRN encoding. Sat values for other
    * constellations are "real" satellite identifiers.
    */
-  if (sid_to_constellation(sid) == CONSTELLATION_GPS)
-    sid.sat += GPS_FIRST_PRN;
+  if (sid_valid(sid)) {
+    if (sid_to_constellation(sid) == CONSTELLATION_GPS)
+      sid.sat += GPS_FIRST_PRN;
+  }
 
   return sid;
 }

--- a/src/simulator.c
+++ b/src/simulator.c
@@ -317,7 +317,7 @@ void simulation_step_tracking_and_observations(double elapsed)
         .code = simulation_almanacs[i].sid.code,
         .sat = simulation_almanacs[i].sid.sat + SIM_PRN_OFFSET
       };
-      sim_state.tracking_channel[num_sats_selected].state = TRACKING_RUNNING;
+      sim_state.tracking_channel[num_sats_selected].state = 1;
       sim_state.tracking_channel[num_sats_selected].sid = sid_to_sbp(sid);
       sim_state.tracking_channel[num_sats_selected].cn0 = sim_state.nav_meas[num_sats_selected].snr;
 

--- a/src/solution.c
+++ b/src/solution.c
@@ -371,12 +371,7 @@ static void update_sat_elevations(const navigation_measurement_t nav_meas[],
   double _, el;
   for (int i = 0; i < n_meas; i++) {
     wgsecef2azel(nav_meas[i].sat_pos, pos_ecef, &_, &el);
-    for (int j = 0; j < nap_track_n_channels; j++) {
-      if (sid_is_equal(tracking_channel[j].sid, nav_meas[i].sid)) {
-        tracking_channel[j].elevation = (float)el * R2D;
-        break;
-      }
-    }
+    tracking_channel_evelation_degrees_set(nav_meas[i].sid, (float)el * R2D);
   }
 }
 

--- a/src/solution.c
+++ b/src/solution.c
@@ -397,12 +397,12 @@ static msg_t solution_thread(void *arg)
     u8 n_ready = 0;
     channel_measurement_t meas[MAX_CHANNELS];
     for (u8 i=0; i<nap_track_n_channels; i++) {
+      tracking_channel_lock(i);
       if (use_tracking_channel(i)) {
-        __asm__("CPSID i;");
-        __asm__("CPSIE i;");
         tracking_channel_measurement_get(i, &meas[n_ready]);
         n_ready++;
       }
+      tracking_channel_unlock(i);
     }
 
     if (n_ready < 4) {

--- a/src/solution.c
+++ b/src/solution.c
@@ -399,8 +399,8 @@ static msg_t solution_thread(void *arg)
     for (u8 i=0; i<nap_track_n_channels; i++) {
       if (use_tracking_channel(i)) {
         __asm__("CPSID i;");
-        tracking_update_measurement(i, &meas[n_ready]);
         __asm__("CPSIE i;");
+        tracking_channel_measurement_get(i, &meas[n_ready]);
         n_ready++;
       }
     }

--- a/src/track.c
+++ b/src/track.c
@@ -502,6 +502,46 @@ u32 tracking_channel_last_mode_change_ms_get(u8 channel)
       &tracking_channel[channel].mode_change_count);
 }
 
+/** Returns the sid currently associated with a tracking channel.
+ * \param channel Tracking channel to use.
+ */
+gnss_signal_t tracking_channel_sid_get(u8 channel)
+{
+  return tracking_channel[channel].sid;
+}
+
+/** Returns the current carrier frequency for a tracking channel.
+ * \param channel Tracking channel to use.
+ */
+double tracking_channel_carrier_freq_get(u8 channel)
+{
+  return tracking_channel[channel].carrier_freq;
+}
+
+/** Returns the current time of week for a tracking channel.
+ * \param channel Tracking channel to use.
+ */
+s32 tracking_channel_tow_ms_get(u8 channel)
+{
+  return tracking_channel[channel].TOW_ms;
+}
+
+/** Returns the bit sync status for a tracking channel.
+ * \param channel Tracking channel to use.
+ */
+bool tracking_channel_bit_sync_resolved(u8 channel)
+{
+  return (tracking_channel[channel].bit_sync.bit_phase_ref != BITSYNC_UNSYNCED);
+}
+
+/** Returns the bit polarity resolution status for a tracking channel.
+ * \param channel Tracking channel to use.
+ */
+bool tracking_channel_bit_polarity_resolved(u8 channel)
+{
+  return (tracking_channel[channel].bit_polarity != BIT_POLARITY_UNKNOWN);
+}
+
 /** Update tracking channels after the end of an integration period.
  * Update update_count, sample_count, TOW, run loop filters and update
  * SwiftNAP tracking channel frequencies.

--- a/src/track.c
+++ b/src/track.c
@@ -347,6 +347,8 @@ bool tracker_channel_init(tracker_channel_id_t id, gnss_signal_t sid,
   }
   tracker_channel_unlock(tracker_channel);
 
+  nap_timing_strobe_wait(100);
+
   return true;
 }
 

--- a/src/track.c
+++ b/src/track.c
@@ -552,6 +552,31 @@ bool tracking_channel_bit_polarity_resolved(u8 channel)
   return (tracking_channel[channel].bit_polarity != BIT_POLARITY_UNKNOWN);
 }
 
+/** Sets the elevation angle (deg) for a tracking channel by sid.
+ * \param sid         Signal identifier for which the elevation should be set.
+ * \param elevation   Elevation angle in degrees.
+ */
+bool tracking_channel_evelation_degrees_set(gnss_signal_t sid, s8 elevation)
+{
+  for (u32 i=0; i < NAP_MAX_N_TRACK_CHANNELS; i++) {
+    tracking_channel_t *ch = &tracking_channel[i];
+    /* TODO: Atomically check sid and set elevation */
+    if (sid_is_equal(ch->sid, sid)) {
+      ch->elevation = elevation;
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Returns the elevation angle (deg) for a tracking channel.
+ * \param channel Tracking channel to use.
+ */
+s8 tracking_channel_evelation_degrees_get(u8 channel)
+{
+  return tracking_channel[channel].elevation;
+}
+
 /** Update tracking channels after the end of an integration period.
  * Update update_count, sample_count, TOW, run loop filters and update
  * SwiftNAP tracking channel frequencies.

--- a/src/track.c
+++ b/src/track.c
@@ -493,6 +493,16 @@ u32 tracking_channel_ld_opti_unlocked_ms_get(u8 channel)
       &tracking_channel[channel].ld_opti_locked_count);
 }
 
+/** Returns the time in ms for which the pessimistic lock detector has reported
+ * being locked for a tracking channel.
+ * \param channel Tracking channel to use.
+ */
+u32 tracking_channel_ld_pess_locked_ms_get(u8 channel)
+{
+  return update_count_diff(channel,
+      &tracking_channel[channel].ld_pess_unlocked_count);
+}
+
 /** Returns the time in ms since the last mode change for a tracking channel.
  * \param channel Tracking channel to use.
  */
@@ -675,6 +685,8 @@ void tracking_channel_update(u8 channel)
       lock_detect_update(&chan->lock_detect, cs[1].I, cs[1].Q, chan->int_ms);
       if (chan->lock_detect.outo)
         chan->ld_opti_locked_count = chan->update_count;
+      if (!chan->lock_detect.outp)
+        chan->ld_pess_unlocked_count = chan->update_count;
 
       /* Reset carrier phase ambiguity if there's doubt as to our phase lock */
       if (last_outp && !chan->lock_detect.outp) {

--- a/src/track.c
+++ b/src/track.c
@@ -236,15 +236,6 @@ static bool nav_time_sync_get(nav_time_sync_t *sync, s32 *TOW_ms,
   return result;
 }
 
-/* Initialize the lock counters to random numbers
- */
-void initialize_lock_counters(void)
-{
-  for (u32 i=0; i < PLATFORM_SIGNAL_COUNT; i++) {
-    tracking_lock_counters[i] = random_int();
-  }
-}
-
 /** Calculate the future code phase after N samples.
  * Calculate the expected code phase in N samples time with carrier aiding.
  *
@@ -837,7 +828,7 @@ bool track_iq_output_notify(struct setting *s, const char *val)
 }
 
 
-/** Set up tracking subsystem - presently just hooks for settings
+/** Set up tracking subsystem
  */
 void tracking_setup()
 {
@@ -849,6 +840,10 @@ void tracking_setup()
                  TYPE_STRING, parse_lock_detect_params);
   SETTING("track", "cn0_drop", track_cn0_drop_thres, TYPE_FLOAT);
   SETTING("track", "alias_detect", use_alias_detection, TYPE_BOOL);
+
+  for (u32 i=0; i < PLATFORM_SIGNAL_COUNT; i++) {
+    tracking_lock_counters[i] = random_int();
+  }
 }
 
 /** Read the next pending nav bit for a tracking channel.

--- a/src/track.c
+++ b/src/track.c
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2011-2014 Swift Navigation Inc.
+ * Copyright (C) 2011-2016 Swift Navigation Inc.
  * Contact: Fergus Noble <fergus@swift-nav.com>
+ * Contact: Jacob McNamee <jacob@swiftnav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
  * be be distributed together with this source. All other rights reserved.
@@ -16,19 +17,18 @@
 #include <assert.h>
 #include <ch.h>
 
+#include <libswiftnav/constants.h>
+#include <libswiftnav/logging.h>
+
 #include "board/nap/track_channel.h"
 #include "sbp.h"
 #include "sbp_utils.h"
 #include "track.h"
+#include "track_api.h"
+#include "track_internal.h"
 #include "simulator.h"
-#include "peripherals/random.h"
 #include "settings.h"
 #include "signal.h"
-
-#include <libswiftnav/constants.h>
-#include <libswiftnav/logging.h>
-#include <libswiftnav/signal.h>
-#include <libswiftnav/bit_sync.h>
 
 /** \defgroup tracking Tracking
  * Track satellites via interrupt driven updates to SwiftNAP tracking channels.
@@ -37,64 +37,12 @@
  * tracking measurements each integration period.
  * \{ */
 
+#define NUM_TRACKER_CHANNELS  12
+
 #define COMPILER_BARRIER() asm volatile ("" : : : "memory")
 
-/*  code: nbw zeta k carr_to_code
- carrier:                    nbw  zeta k fll_aid */
-#define LOOP_PARAMS_SLOW \
-  "(1 ms, (1, 0.7, 1, 1540), (10, 0.7, 1, 5))," \
- "(20 ms, (1, 0.7, 1, 1540), (12, 0.7, 1, 0))"
-
-#define LOOP_PARAMS_MED \
-  "(1 ms, (1, 0.7, 1, 1540), (10, 0.7, 1, 5))," \
-  "(5 ms, (1, 0.7, 1, 1540), (50, 0.7, 1, 0))"
-
-#define LOOP_PARAMS_FAST \
-  "(1 ms, (1, 0.7, 1, 1540), (40, 0.7, 1, 5))," \
-  "(4 ms, (1, 0.7, 1, 1540), (62, 0.7, 1, 0))"
-
-#define LOOP_PARAMS_EXTRAFAST \
-  "(1 ms, (1, 0.7, 1, 1540), (50, 0.7, 1, 5))," \
-  "(2 ms, (1, 0.7, 1, 1540), (100, 0.7, 1, 0))"
-
-
-/*                          k1,   k2,  lp,  lo */
-#define LD_PARAMS_PESS     "0.10, 1.4, 200, 50"
-#define LD_PARAMS_NORMAL   "0.05, 1.4, 150, 50"
-#define LD_PARAMS_OPT      "0.02, 1.1, 150, 50"
-#define LD_PARAMS_EXTRAOPT "0.02, 0.8, 150, 50"
-#define LD_PARAMS_DISABLE  "0.02, 1e-6, 1, 1"
-
-static char loop_params_string[120] = LOOP_PARAMS_MED;
-static char lock_detect_params_string[24] = LD_PARAMS_DISABLE;
-static bool use_alias_detection = true;
-
-#define CN0_EST_LPF_CUTOFF 5
 #define GPS_WEEK_LENGTH_ms (1000 * WEEK_SECS)
 #define CHANNEL_SHUTDOWN_TIME_ms 100
-
-#define NAV_BIT_FIFO_INDEX_MASK ((NAV_BIT_FIFO_SIZE) - 1)
-#define NAV_BIT_FIFO_INDEX_DIFF(write_index, read_index) \
-          ((nav_bit_fifo_index_t)((write_index) - (read_index)))
-#define NAV_BIT_FIFO_LENGTH(p_fifo) \
-          (NAV_BIT_FIFO_INDEX_DIFF((p_fifo)->write_index, (p_fifo)->read_index))
-
-static struct loop_params {
-  float code_bw, code_zeta, code_k, carr_to_code;
-  float carr_bw, carr_zeta, carr_k, carr_fll_aid_gain;
-  u8 coherent_ms;
-} loop_params_stage[2];
-
-static struct lock_detect_params {
-  float k1, k2;
-  u16 lp, lo;
-} lock_detect_params;
-
-static float track_cn0_use_thres = 31.0; /* dBHz */
-static float track_cn0_drop_thres = 31.0;
-static u16 iq_output_mask = 0;
-
-#define NAV_BIT_FIFO_SIZE 32 /**< Size of nav bit FIFO. Must be a power of 2 */
 
 typedef enum {
   STATE_DISABLED,
@@ -108,759 +56,86 @@ typedef enum {
   EVENT_DISABLE
 } event_t;
 
+/** Top-level generic tracker channel. */
 typedef struct {
-  s8 soft_bit;
-} nav_bit_fifo_element_t;
+  /** State of this channel. */
+  state_t state;
+  /** Time at which the channel was disabled. */
+  systime_t disable_time;
+  /** Info associated with this channel. */
+  tracker_channel_info_t info;
+  /** Data common to all tracker implementations. RW from channel interface
+   * functions. RO from functions in this module. */
+  tracker_common_data_t common_data;
+  /** Data used by the API for all tracker implementations. RW from API
+   * functions called within channel interface functions. RO from functions
+   * in this module. */
+  tracker_internal_data_t internal_data;
+  /** Mutex used to protect access to the channel. */
+  Mutex mutex;
+  /** Mutex used to handle NAP shutdown delay. */
+  Mutex nap_mutex;
+  /** Elevation angle, degrees. TODO: find a better place for this. */
+  s8 elevation;
+  /** Associated tracker instance. */
+  tracker_t *tracker;
+} tracker_channel_t;
 
-typedef u8 nav_bit_fifo_index_t;
+static tracker_channel_t tracker_channels[NUM_TRACKER_CHANNELS];
 
-typedef struct {
-  nav_bit_fifo_index_t read_index;
-  nav_bit_fifo_index_t write_index;
-  nav_bit_fifo_element_t elements[NAV_BIT_FIFO_SIZE];
-} nav_bit_fifo_t;
+static const tracker_interface_t tracker_interface_default = {
+  .code =         CODE_INVALID,
+  .init =         0,
+  .disable =      0,
+  .update =       0,
+  .trackers =     0,
+  .num_trackers = 0
+};
 
-typedef struct {
-  s32 TOW_ms;
-  s8 bit_polarity;
-  nav_bit_fifo_index_t read_index;
-  bool valid;
-} nav_time_sync_t;
+static u16 iq_output_mask = 0;
 
-typedef u32 update_count_t;
+static void tracker_channel_process(tracker_channel_t *tracker_channel,
+                                     bool update_required);
 
-/** Tracking channel parameters as of end of last correlation period. */
-typedef struct {
-  state_t state;               /**< Tracking channel state. */
-  /* TODO : u32's big enough? */
-  update_count_t update_count; /**< Number of ms channel has been running */
-  update_count_t mode_change_count;
-                               /**< update_count at last mode change. */
-  update_count_t cn0_below_use_thres_count;
-                               /**< update_count value when SNR was
-                                  last below the use threshold. */
-  update_count_t cn0_above_drop_thres_count;
-                               /**< update_count value when SNR was
-                                  last above the drop threshold. */
-  update_count_t ld_opti_locked_count;
-                               /**< update_count value when optimistic
-                                  phase detector last "locked". */
-  update_count_t ld_pess_unlocked_count;
-                               /**< update_count value when pessimistic
-                                  phase detector last "unlocked". */
-  s32 TOW_ms;                  /**< TOW in ms. */
-  u32 nav_bit_TOW_offset_ms;   /**< Time since last nav bit was appended to the nav bit FIFO */
-  gnss_signal_t sid;           /**< Satellite signal being tracked. */
-  u32 sample_count;            /**< Total num samples channel has tracked for. */
-  u32 code_phase_early;        /**< Early code phase. */
-  aided_tl_state_t tl_state;   /**< Tracking loop filter state. */
-  double code_phase_rate;      /**< Code phase rate in chips/s. */
-  u32 code_phase_rate_fp;      /**< Code phase rate in NAP register units. */
-  u32 code_phase_rate_fp_prev; /**< Previous code phase rate in NAP register units. */
-  s64 carrier_phase;           /**< Carrier phase in NAP register units. */
-  s32 carrier_freq_fp;         /**< Carrier frequency in NAP register units. */
-  s32 carrier_freq_fp_prev;    /**< Previous carrier frequency in NAP register units. */
-  double carrier_freq;         /**< Carrier frequency Hz. */
-  u32 corr_sample_count;       /**< Number of samples in correlation period. */
-  corr_t cs[3];                /**< EPL correlation results in correlation period. */
-  bit_sync_t bit_sync;         /**< Bit sync state. */
-  s8 bit_polarity;             /**< Polarity of nav message bits. */
-  u16 lock_counter;            /**< Lock counter. Increments when tracking new signal. */
-  cn0_est_state_t cn0_est;     /**< C/N0 Estimator. */
-  float cn0;                   /**< Current estimate of C/N0. */
-  u8 int_ms;                   /**< Integration length. */
-  u8 next_int_ms;              /**< Integration length for the next cycle. */
-  bool short_cycle;            /**< Set to true when a short 1ms integration is requested. */
-  bool output_iq;              /**< Set if this channel should output I/Q samples on SBP. */
-  u8 stage;                    /**< 0 = First-stage. 1 ms integration.
-                                    1 = Second-stage. After nav bit sync,
-                                    retune loop filters and typically (but
-                                    not necessarily) use longer integration. */
-  s8 elevation;                /**< Elevation angle, degrees */
-  alias_detect_t alias_detect; /**< Alias lock detector. */
-  lock_detect_t lock_detect;   /**< Phase-lock detector state. */
-  nav_bit_fifo_t nav_bit_fifo; /**< FIFO for navigation message bits. */
-  nav_time_sync_t nav_time_sync;  /**< Used to sync time decoded from navigation
-                                       message back to tracking channel. */
-  systime_t disable_time;      /**< Time at which the channel was disabled. */
-} tracking_channel_t;
-
-static tracking_channel_t tracking_channel[NAP_MAX_N_TRACK_CHANNELS];
-
-/** Mutex used for
- *  1. Atomic data access with channel enabled.
- *  2. Preventing race conditions between state transitions
- *     and NAP register writes.
- */
-static Mutex tracking_channel_mutex[NAP_MAX_N_TRACK_CHANNELS];
-
-/* signal lock counter
- * A map of signal to an initially random number that increments each time that
- * signal begins being tracked.
- */
-static u16 tracking_lock_counters[PLATFORM_SIGNAL_COUNT];
-
-static MUTEX_DECL(nav_time_sync_mutex);
-
-static void nav_bit_fifo_init(nav_bit_fifo_t *fifo);
-static bool nav_bit_fifo_write(nav_bit_fifo_t *fifo,
-                               const nav_bit_fifo_element_t *element);
-static bool nav_bit_fifo_read(nav_bit_fifo_t *fifo,
-                              nav_bit_fifo_element_t *element);
-static void nav_time_sync_init(nav_time_sync_t *sync);
-static bool nav_time_sync_set(nav_time_sync_t *sync, s32 TOW_ms,
-                              s8 bit_polarity, nav_bit_fifo_index_t read_index);
-static bool nav_time_sync_get(nav_time_sync_t *sync, s32 *TOW_ms,
-                              s8 *bit_polarity, nav_bit_fifo_index_t *read_index);
-
-static s8 nav_bit_quantize(s32 bit_integrate);
-static update_count_t update_count_diff(u8 channel, update_count_t *val);
-
-static state_t state_get(const tracking_channel_t *t);
-static void event(tracking_channel_t *t, event_t event);
-static void nap_channel_disable(u8 channel);
-static void tracking_channel_ambiguity_unknown(u8 channel);
-static void tracking_channel_get_corrs(u8 channel);
-static void tracking_channel_process(u8 channel, bool update_required);
-static void tracking_channel_update(u8 channel);
-
-static bool parse_loop_params(struct setting *s, const char *val);
-static bool parse_lock_detect_params(struct setting *s, const char *val);
+static update_count_t update_count_diff(const tracker_channel_t *
+                                        tracker_channel,
+                                        const update_count_t *val);
 static bool track_iq_output_notify(struct setting *s, const char *val);
-
-/** Initialize a nav_bit_fifo_t struct. */
-static void nav_bit_fifo_init(nav_bit_fifo_t *fifo)
-{
-  fifo->read_index = 0;
-  fifo->write_index = 0;
-}
-
-/** Write data to the nav bit FIFO.
- *
- * \note This function should only be called internally by the tracking thread.
- *
- * \param fifo        nav_bit_fifo_t struct to use.
- * \param element     Element to write to the FIFO.
- *
- * \return true if element was read, false otherwise.
- */
-static bool nav_bit_fifo_write(nav_bit_fifo_t *fifo,
-                               const nav_bit_fifo_element_t *element)
-{
-  if (NAV_BIT_FIFO_LENGTH(fifo) < NAV_BIT_FIFO_SIZE) {
-    COMPILER_BARRIER(); /* Prevent compiler reordering */
-    memcpy(&fifo->elements[fifo->write_index & NAV_BIT_FIFO_INDEX_MASK],
-           element, sizeof(nav_bit_fifo_element_t));
-    COMPILER_BARRIER(); /* Prevent compiler reordering */
-    fifo->write_index++;
-    return true;
-  }
-
-  return false;
-}
-
-/** Read pending data from the nav bit FIFO.
- *
- * \note This function should only be called externally by the decoder thread.
- *
- * \param fifo        nav_bit_fifo_t struct to use.
- * \param element     Output element read from the FIFO.
- *
- * \return true if element was read, false otherwise.
- */
-static bool nav_bit_fifo_read(nav_bit_fifo_t *fifo,
-                              nav_bit_fifo_element_t *element)
-{
-  if (NAV_BIT_FIFO_LENGTH(fifo) > 0) {
-    COMPILER_BARRIER(); /* Prevent compiler reordering */
-    memcpy(element, &fifo->elements[fifo->read_index & NAV_BIT_FIFO_INDEX_MASK],
-           sizeof(nav_bit_fifo_element_t));
-    COMPILER_BARRIER(); /* Prevent compiler reordering */
-    fifo->read_index++;
-    return true;
-  }
-
-  return false;
-}
-
-/** Initialize a nav_time_sync_t struct. */
-static void nav_time_sync_init(nav_time_sync_t *sync)
-{
-  sync->valid = false;
-}
-
-/** Write pending time sync data from the decoder thread.
- *
- * \note This function should only be called externally by the decoder thread.
- *
- * \param sync          nav_time_sync_t struct to use.
- * \param TOW_ms        TOW in ms.
- * \param bit_polarity  Bit polarity.
- * \param read_index    Nav bit FIFO read index to which the above values
- *                      are synchronized.
- *
- * \return true if data was stored successfully, false otherwise.
- */
-static bool nav_time_sync_set(nav_time_sync_t *sync, s32 TOW_ms,
-                              s8 bit_polarity, nav_bit_fifo_index_t read_index)
-{
-  bool result = false;
-  chMtxLock(&nav_time_sync_mutex);
-
-  sync->TOW_ms = TOW_ms;
-  sync->bit_polarity = bit_polarity;
-  sync->read_index = read_index;
-  sync->valid = true;
-  result = true;
-
-  Mutex *m = chMtxUnlock();
-  assert(m == &nav_time_sync_mutex);
-  return result;
-}
-
-/** Read pending time sync data provided by the decoder thread.
- *
- * \note This function should only be called internally by the tracking thread.
- *
- * \param sync          nav_time_sync_t struct to use.
- * \param TOW_ms        TOW in ms.
- * \param bit_polarity  Bit polarity.
- * \param read_index    Nav bit FIFO read index to which the above values
- *                      are synchronized.
- *
- * \return true if outputs are valid, false otherwise.
- */
-static bool nav_time_sync_get(nav_time_sync_t *sync, s32 *TOW_ms,
-                              s8 *bit_polarity, nav_bit_fifo_index_t *read_index)
-{
-  bool result = false;
-  chMtxLock(&nav_time_sync_mutex);
-
-  if (sync->valid) {
-    *TOW_ms = sync->TOW_ms;
-    *bit_polarity = sync->bit_polarity;
-    *read_index = sync->read_index;
-    sync->valid = false;
-    result = true;
-  }
-
-  Mutex *m = chMtxUnlock();
-  assert(m == &nav_time_sync_mutex);
-  return result;
-}
-
-/** Compress a 32 bit integration value down to 8 bits. */
-static s8 nav_bit_quantize(s32 bit_integrate)
-{
-  //  0 through  2^24 - 1 ->  0 = weakest positive bit
-  // -1 through -2^24     -> -1 = weakest negative bit
-
-  if (bit_integrate >= 0)
-    return bit_integrate / (1 << 24);
-  else
-    return ((bit_integrate + 1) / (1 << 24)) - 1;
-}
-
-/** Returns the unsigned difference between update_count and *val for the
- * specified tracking channel.
- *
- * \note This function ensures that update_count is read prior to *val
- * such that erroneous jumps between zero and large positive numbers are
- * avoided.
- *
- * \param channel   Tracking channel to use.
- * \param val       Pointer to the value to be subtracted from update_count.
- *
- * \return The unsigned difference between update_count and *val.
- */
-static update_count_t update_count_diff(u8 channel, update_count_t *val)
-{
-  /* Ensure that update_count is read prior to *val */
-  update_count_t update_count = tracking_channel[channel].update_count;
-  COMPILER_BARRIER(); /* Prevent compiler reordering */
-  return (update_count_t)(update_count - *val);
-}
-
-/** Return the state of a tracking channel.
- *
- * \note This function performs an acquire operation, meaning that it ensures
- * the returned state was read before any subsequent memory accesses.
- *
- * \param t         Tracking channel to use.
- *
- * \return state of the tracking channel.
- */
-static state_t state_get(const tracking_channel_t *t)
-{
-  state_t state = t->state;
-  COMPILER_BARRIER(); /* Prevent compiler reordering */
-  return state;
-}
-
-/** Update the state of a tracking channel.
- *
- * \note This function performs a release operation, meaning that it ensures
- * all prior memory accesses have completed before updating state information.
- *
- * \param t         Tracking channel to use.
- * \param event     Event to process.
- */
-static void event(tracking_channel_t *t, event_t event)
-{
-  switch (event) {
-  case EVENT_ENABLE: {
-    assert(t->state == STATE_DISABLED);
-    COMPILER_BARRIER(); /* Prevent compiler reordering */
-    t->state = STATE_ENABLED;
-  }
-  break;
-
-  case EVENT_DISABLE_REQUEST: {
-    assert(t->state == STATE_ENABLED);
-    t->state = STATE_DISABLE_REQUESTED;
-  }
-  break;
-
-  case EVENT_DISABLE: {
-    assert(t->state == STATE_DISABLE_REQUESTED);
-    COMPILER_BARRIER(); /* Prevent compiler reordering */
-    t->state = STATE_DISABLED;
-  }
-  break;
-  }
-}
-
-/** Disable a tracking channel in the NAP.
- * \param channel Tracking channel to disable.
- */
-static void nap_channel_disable(u8 channel)
-{
-  nap_track_update_wr_blocking(channel, 0, 0, 0, 0);
-}
-
-/** Sets a channel's carrier phase ambiguity to unknown.
- * Changes the lock counter to indicate to the consumer of the tracking channel
- * observations that the carrier phase ambiguity may have changed. Also
- * invalidates the half cycle ambiguity, which must be resolved again by the navigation
- *  message processing. Should be called if a cycle slip is suspected.
- *
- * \param channel Tracking channel number to mark phase-ambiguous.
- */
-static void tracking_channel_ambiguity_unknown(u8 channel)
-{
-  gnss_signal_t sid = tracking_channel[channel].sid;
-
-  tracking_channel[channel].bit_polarity = BIT_POLARITY_UNKNOWN;
-  tracking_channel[channel].lock_counter =
-      ++tracking_lock_counters[sid_to_global_index(sid)];
-}
-
-/** Get correlations from a NAP tracking channel and store them in the
- * tracking channel state struct.
- * \param channel Tracking channel to read correlations for.
- */
-static void tracking_channel_get_corrs(u8 channel)
-{
-  tracking_channel_t* chan = &tracking_channel[channel];
-
-  /* Read early ([0]), prompt ([1]) and late ([2]) correlations. */
-  if ((chan->int_ms > 1) && !chan->short_cycle) {
-    /* If we just requested the short cycle, this is the long cycle's
-     * correlations. */
-    corr_t cs[3];
-    nap_track_corr_rd_blocking(channel, &chan->corr_sample_count, cs);
-    /* accumulate short cycle correlations with long */
-    for(int i = 0; i < 3; i++) {
-      chan->cs[i].I += cs[i].I;
-      chan->cs[i].Q += cs[i].Q;
-    }
-  } else {
-    nap_track_corr_rd_blocking(channel, &chan->corr_sample_count, chan->cs);
-    alias_detect_first(&chan->alias_detect, chan->cs[1].I, chan->cs[1].Q);
-  }
-}
-
-/** Checks the state of a tracking channel and generates events if required.
- * \param channel           Tracking channel to use.
- * \param update_required   True when correlations are pending for the
- *                          tracking channel.
- */
-static void tracking_channel_process(u8 channel, bool update_required)
-{
-  tracking_channel_t* chan = &tracking_channel[channel];
-  switch (state_get(chan)) {
-    case STATE_ENABLED:
-    {
-      if (update_required) {
-        tracking_channel_update(channel);
-      }
-      break;
-    }
-    case STATE_DISABLE_REQUESTED:
-    {
-      nap_channel_disable(channel);
-      chan->disable_time = chTimeNow();
-      event(chan, EVENT_DISABLE);
-      break;
-    }
-    case STATE_DISABLED:
-    {
-      /* Tracking channel is not owned by the update thread, but the update
-       * register must be written to clear the interrupt flag. Atomically
-       * verify state and write the update register. */
-      tracking_channel_lock(channel);
-      if (state_get(chan) == STATE_DISABLED) {
-        nap_channel_disable(channel);
-      }
-      tracking_channel_unlock(channel);
-      break;
-    }
-    default:
-    {
-      assert(!"Invalid tracking channel state");
-      break;
-    }
-  }
-}
-
-/** Update tracking channels after the end of an integration period.
- * Update update_count, sample_count, TOW, run loop filters and update
- * SwiftNAP tracking channel frequencies.
- * \param channel Tracking channel to update.
- */
-static void tracking_channel_update(u8 channel)
-{
-  tracking_channel_t* chan = &tracking_channel[channel];
-
-  char buf[SID_STR_LEN_MAX];
-  sid_to_string(buf, sizeof(buf), chan->sid);
-
-  tracking_channel_get_corrs(channel);
-
-  /* Lock while updating data to allow atomic reads from other threads. */
-  /* TODO: Minimize the lock duration. */
-  tracking_channel_lock(channel);
-
-  chan->sample_count += chan->corr_sample_count;
-  chan->code_phase_early = (u64)chan->code_phase_early +
-                           (u64)chan->corr_sample_count
-                             * chan->code_phase_rate_fp_prev;
-  chan->carrier_phase += (s64)chan->carrier_freq_fp_prev
-                           * chan->corr_sample_count;
-  /* TODO: Fix this in the FPGA - first integration is one sample short. */
-  if (chan->update_count == 0)
-    chan->carrier_phase -= chan->carrier_freq_fp_prev;
-  chan->code_phase_rate_fp_prev = chan->code_phase_rate_fp;
-  chan->carrier_freq_fp_prev = chan->carrier_freq_fp;
-
-  /* Latch TOW from nav message if pending */
-  s32 pending_TOW_ms;
-  s8 pending_bit_polarity;
-  nav_bit_fifo_index_t pending_TOW_read_index;
-  if (nav_time_sync_get(&chan->nav_time_sync, &pending_TOW_ms,
-                        &pending_bit_polarity, &pending_TOW_read_index)) {
-
-    /* Compute time since the pending data was read from the FIFO */
-    nav_bit_fifo_index_t fifo_length =
-      NAV_BIT_FIFO_INDEX_DIFF(chan->nav_bit_fifo.write_index,
-                              pending_TOW_read_index);
-    u32 fifo_time_diff_ms = fifo_length * chan->bit_sync.bit_length;
-
-    /* Add full bit times + fractional bit time to the specified TOW */
-    s32 TOW_ms = pending_TOW_ms + fifo_time_diff_ms +
-                   chan->nav_bit_TOW_offset_ms;
-
-    if (TOW_ms >= GPS_WEEK_LENGTH_ms)
-      TOW_ms -= GPS_WEEK_LENGTH_ms;
-
-    /* Warn if updated TOW does not match the current value */
-    if ((chan->TOW_ms != TOW_INVALID) && (chan->TOW_ms != TOW_ms)) {
-      log_warn("%s TOW mismatch: %ld, %lu", buf, chan->TOW_ms, TOW_ms);
-    }
-    chan->TOW_ms = TOW_ms;
-    chan->bit_polarity = pending_bit_polarity;
-  }
-
-  u8 int_ms = chan->short_cycle ? 1 : (chan->int_ms-1);
-  chan->nav_bit_TOW_offset_ms += int_ms;
-
-  if (chan->TOW_ms != TOW_INVALID) {
-    /* Have a valid time of week - increment it. */
-    chan->TOW_ms += int_ms;
-    if (chan->TOW_ms >= GPS_WEEK_LENGTH_ms)
-      chan->TOW_ms -= GPS_WEEK_LENGTH_ms;
-    /* TODO: maybe keep track of week number in channel state, or
-       derive it from system time */
-  }
-
-  if (chan->int_ms > 1) {
-    /* If we're doing long integrations, alternate between short and long
-     * cycles.  This is because of FPGA pipelining and latency.  The
-     * loop parameters can only be updated at the end of the second
-     * integration interval and waiting a whole 20ms is too long.
-     */
-    chan->short_cycle = !chan->short_cycle;
-
-    if (!chan->short_cycle) {
-      /* Unlock and write NAP update register. */
-      tracking_channel_unlock(channel);
-      nap_track_update_wr_blocking(
-        channel,
-        chan->carrier_freq_fp,
-        chan->code_phase_rate_fp,
-        0, 0
-      );
-      return;
-    }
-  }
-
-  chan->update_count += chan->int_ms;
-  /* Prevent compiler reordering of store to update_count and stores to
-   * dependent variables */
-  COMPILER_BARRIER();
-
-  /* Update bit sync */
-  s32 bit_integrate;
-  if (bit_sync_update(&chan->bit_sync, chan->cs[1].I, chan->int_ms,
-                      &bit_integrate)) {
-
-    s8 soft_bit = nav_bit_quantize(bit_integrate);
-
-    // write to FIFO
-    nav_bit_fifo_element_t element = { .soft_bit = soft_bit };
-    if (!nav_bit_fifo_write(&chan->nav_bit_fifo, &element)) {
-      log_warn("%s nav bit FIFO overrun", buf);
-    }
-
-    // clear nav bit TOW offset
-    chan->nav_bit_TOW_offset_ms = 0;
-  }
-
-  /* Correlations should already be in chan->cs thanks to
-   * tracking_channel_get_corrs. */
-  corr_t* cs = chan->cs;
-
-  /* Update C/N0 estimate */
-  chan->cn0 = cn0_est(&chan->cn0_est, cs[1].I/chan->int_ms, cs[1].Q/chan->int_ms);
-  if (chan->cn0 > track_cn0_drop_thres)
-    chan->cn0_above_drop_thres_count = chan->update_count;
-
-  if (chan->cn0 < track_cn0_use_thres) {
-    /* SNR has dropped below threshold, indicate that the carrier phase
-     * ambiguity is now unknown as cycle slips are likely. */
-    tracking_channel_ambiguity_unknown(channel);
-    /* Update the latest time we were below the threshold. */
-    chan->cn0_below_use_thres_count = chan->update_count;
-  }
-
-  /* Update PLL lock detector */
-  bool last_outp = chan->lock_detect.outp;
-  lock_detect_update(&chan->lock_detect, cs[1].I, cs[1].Q, chan->int_ms);
-  if (chan->lock_detect.outo)
-    chan->ld_opti_locked_count = chan->update_count;
-  if (!chan->lock_detect.outp)
-    chan->ld_pess_unlocked_count = chan->update_count;
-
-  /* Reset carrier phase ambiguity if there's doubt as to our phase lock */
-  if (last_outp && !chan->lock_detect.outp) {
-    if (chan->stage > 0) {
-      log_info("%s PLL stress", buf);
-    }
-    tracking_channel_ambiguity_unknown(channel);
-  }
-
-  /* Run the loop filters. */
-
-  /* TODO: Make this more elegant. */
-  correlation_t cs2[3];
-  for (u32 i = 0; i < 3; i++) {
-    cs2[i].I = cs[2-i].I;
-    cs2[i].Q = cs[2-i].Q;
-  }
-
-  /* Output I/Q correlations using SBP if enabled for this channel */
-  if (chan->output_iq && (chan->int_ms > 1)) {
-    msg_tracking_iq_t msg = {
-      .channel = channel,
-    };
-    msg.sid = sid_to_sbp(chan->sid);
-    for (u32 i = 0; i < 3; i++) {
-      msg.corrs[i].I = cs[i].I;
-      msg.corrs[i].Q = cs[i].Q;
-    }
-    sbp_send_msg(SBP_MSG_TRACKING_IQ, sizeof(msg), (u8*)&msg);
-  }
-
-  aided_tl_update(&(chan->tl_state), cs2);
-  chan->carrier_freq = chan->tl_state.carr_freq;
-  chan->code_phase_rate = chan->tl_state.code_freq + GPS_CA_CHIPPING_RATE;
-
-  chan->code_phase_rate_fp_prev = chan->code_phase_rate_fp;
-  chan->code_phase_rate_fp = chan->code_phase_rate
-    * NAP_TRACK_CODE_PHASE_RATE_UNITS_PER_HZ;
-
-  chan->carrier_freq_fp = chan->carrier_freq
-    * NAP_TRACK_CARRIER_FREQ_UNITS_PER_HZ;
-
-  /* Attempt alias detection if we have pessimistic phase lock detect, OR
-     (optimistic phase lock detect AND are in second-stage tracking) */
-  if (use_alias_detection &&
-      (chan->lock_detect.outp ||
-       (chan->lock_detect.outo && chan->stage > 0))) {
-    s32 I = (cs[1].I - chan->alias_detect.first_I) / (chan->int_ms - 1);
-    s32 Q = (cs[1].Q - chan->alias_detect.first_Q) / (chan->int_ms - 1);
-    float err = alias_detect_second(&chan->alias_detect, I, Q);
-    if (fabs(err) > (250 / chan->int_ms)) {
-      if (chan->lock_detect.outp) {
-        log_warn("False phase lock detected on %s: err=%f", buf, err);
-      }
-
-      tracking_channel_ambiguity_unknown(channel);
-      /* Indicate that a mode change has occurred. */
-      chan->mode_change_count = chan->update_count;
-
-      chan->tl_state.carr_freq += err;
-      chan->tl_state.carr_filt.y = chan->tl_state.carr_freq;
-    }
-  }
-
-  /* Consider moving from stage 0 (1 ms integration) to stage 1 (longer). */
-  if ((chan->stage == 0) &&
-      /* Must have (at least optimistic) phase lock */
-      (chan->lock_detect.outo) &&
-      /* Must have nav bit sync, and be correctly aligned */
-      (chan->bit_sync.bit_phase == chan->bit_sync.bit_phase_ref)) {
-    log_info("%s synced @ %u ms, %.1f dBHz",
-             buf, (unsigned int)chan->update_count, chan->cn0);
-    chan->stage = 1;
-    const struct loop_params *l = &loop_params_stage[1];
-    chan->int_ms = MIN(l->coherent_ms, chan->bit_sync.bit_length);
-    chan->short_cycle = true;
-
-    cn0_est_init(&chan->cn0_est, 1e3 / chan->int_ms, chan->cn0,
-                 CN0_EST_LPF_CUTOFF, 1e3 / chan->int_ms);
-
-    /* Recalculate filter coefficients */
-    aided_tl_retune(&chan->tl_state, 1e3 / chan->int_ms,
-                    l->code_bw, l->code_zeta, l->code_k,
-                    l->carr_to_code,
-                    l->carr_bw, l->carr_zeta, l->carr_k,
-                    l->carr_fll_aid_gain);
-
-    lock_detect_reinit(&chan->lock_detect,
-                       lock_detect_params.k1 * chan->int_ms,
-                       lock_detect_params.k2,
-                       /* TODO: Should also adjust lp and lo? */
-                       lock_detect_params.lp, lock_detect_params.lo);
-
-    /* Indicate that a mode change has occurred. */
-    chan->mode_change_count = chan->update_count;
-  }
-
-  /* Unlock and write NAP update register. */
-  tracking_channel_unlock(channel);
-  nap_track_update_wr_blocking(
-    channel,
-    chan->carrier_freq_fp,
-    chan->code_phase_rate_fp,
-    chan->int_ms == 1 ? 0 : chan->int_ms - 2, 0
-  );
-}
-
-/** Parse a string describing the tracking loop filter parameters into
-    the loop_params_stage structs. */
-static bool parse_loop_params(struct setting *s, const char *val)
-{
-  /** The string contains loop parameters for either one or two
-      stages.  If the second is omitted, we'll use the same parameters
-      as the first stage.*/
-
-  struct loop_params loop_params_parse[2];
-
-  const char *str = val;
-  for (int stage = 0; stage < 2; stage++) {
-    struct loop_params *l = &loop_params_parse[stage];
-
-    int n_chars_read = 0;
-    unsigned int tmp; /* newlib's sscanf doesn't support hh size modifier */
-
-    if (sscanf(str, "( %u ms , ( %f , %f , %f , %f ) , ( %f , %f , %f , %f ) ) , %n",
-               &tmp,
-               &l->code_bw, &l->code_zeta, &l->code_k, &l->carr_to_code,
-               &l->carr_bw, &l->carr_zeta, &l->carr_k, &l->carr_fll_aid_gain,
-               &n_chars_read) < 9) {
-      log_error("Ill-formatted tracking loop param string.");
-      return false;
-    }
-    l->coherent_ms = tmp;
-    /* If string omits second-stage parameters, then after the first
-       stage has been parsed, n_chars_read == 0 because of missing
-       comma and we'll parse the string again into loop_params_parse[1]. */
-    str += n_chars_read;
-
-    if ((l->coherent_ms == 0)
-        || ((20 % l->coherent_ms) != 0) /* i.e. not 1, 2, 4, 5, 10 or 20 */
-        || (stage == 0 && l->coherent_ms != 1)) {
-      log_error("Invalid coherent integration length.");
-      return false;
-    }
-  }
-  /* Successfully parsed both stages.  Save to memory. */
-  strncpy(s->addr, val, s->len);
-  memcpy(loop_params_stage, loop_params_parse, sizeof(loop_params_stage));
-  return true;
-}
-
-/** Parse a string describing the tracking loop phase lock detector
-    parameters into the lock_detect_params structs. */
-static bool parse_lock_detect_params(struct setting *s, const char *val)
-{
-  struct lock_detect_params p;
-
-  if (sscanf(val, "%f , %f , %" SCNu16 " , %" SCNu16,
-             &p.k1, &p.k2, &p.lp, &p.lo) < 4) {
-      log_error("Ill-formatted lock detect param string.");
-      return false;
-  }
-  /* Successfully parsed.  Save to memory. */
-  strncpy(s->addr, val, s->len);
-  memcpy(&lock_detect_params, &p, sizeof(lock_detect_params));
-  return true;
-}
-
-/** Parse the IQ output enable bitfield. */
-static bool track_iq_output_notify(struct setting *s, const char *val)
-{
-  if (s->type->from_string(s->type->priv, s->addr, s->len, val)) {
-    for (int i = 0; i < NAP_MAX_N_TRACK_CHANNELS; i++) {
-      tracking_channel[i].output_iq = (iq_output_mask & (1 << i)) != 0;
-    }
-    return true;
-  }
-  return false;
-}
-
-/** Set up tracking subsystem
- */
-void tracking_setup()
+static void nap_channel_disable(const tracker_channel_t *tracker_channel);
+
+static tracker_channel_t * tracker_channel_get(tracker_channel_id_t id);
+static const tracker_interface_t * tracker_interface_get(gnss_signal_t sid);
+static bool tracker_channel_runnable(const tracker_channel_t *tracker_channel,
+                                     gnss_signal_t sid, tracker_t **tracker,
+                                     const tracker_interface_t **
+                                     tracker_interface);
+static bool available_tracker_get(const tracker_interface_t *tracker_interface,
+                                  tracker_t **tracker);
+static state_t tracker_channel_state_get(const tracker_channel_t *
+                                         tracker_channel);
+static bool tracker_active(const tracker_t *tracker);
+static void interface_function(tracker_channel_t *tracker_channel,
+                               tracker_interface_function_t func);
+static void event(tracker_channel_t *d, event_t event);
+static void common_data_init(tracker_common_data_t *common_data,
+                             u32 sample_count, float carrier_freq, float cn0);
+static void tracker_channel_lock(tracker_channel_t *tracker_channel);
+static void tracker_channel_unlock(tracker_channel_t *tracker_channel);
+
+
+/** Set up the tracking module. */
+void track_setup(void)
 {
   SETTING_NOTIFY("track", "iq_output_mask", iq_output_mask, TYPE_INT,
                  track_iq_output_notify);
-  SETTING_NOTIFY("track", "loop_params", loop_params_string,
-                 TYPE_STRING, parse_loop_params);
-  SETTING_NOTIFY("track", "lock_detect_params", lock_detect_params_string,
-                 TYPE_STRING, parse_lock_detect_params);
-  SETTING("track", "cn0_use", track_cn0_use_thres, TYPE_FLOAT);
-  SETTING("track", "cn0_drop", track_cn0_drop_thres, TYPE_FLOAT);
-  SETTING("track", "alias_detect", use_alias_detection, TYPE_BOOL);
 
-  for (u32 i=0; i < PLATFORM_SIGNAL_COUNT; i++) {
-    tracking_lock_counters[i] = random_int();
-  }
+  track_internal_setup();
 
-  for (u32 i=0; i< NAP_MAX_N_TRACK_CHANNELS; i++) {
-    tracking_channel[i].state = STATE_DISABLED;
-    chMtxInit(&tracking_channel_mutex[i]);
+  for (u32 i=0; i<NUM_TRACKER_CHANNELS; i++) {
+    tracker_channels[i].state = STATE_DISABLED;
+    tracker_channels[i].tracker = 0;
+    chMtxInit(&tracker_channels[i].mutex);
+    chMtxInit(&tracker_channels[i].nap_mutex);
   }
 }
 
@@ -889,29 +164,37 @@ void tracking_send_state()
   } else {
 
     for (u8 i=0; i<nap_track_n_channels; i++) {
-      states[i].state = tracking_channel_running(i) ? 1 : 0;
-      states[i].sid = sid_to_sbp(tracking_channel[i].sid);
-      states[i].cn0 = tracking_channel_running(i) ?
-                          tracking_channel[i].cn0 : -1;
+
+      tracker_channel_t *tracker_channel = tracker_channel_get(i);
+      const tracker_common_data_t *common_data = &tracker_channel->common_data;
+
+      bool running;
+      gnss_signal_t sid;
+      float cn0;
+
+      tracker_channel_lock(tracker_channel);
+      {
+        running =
+            (tracker_channel_state_get(tracker_channel) == STATE_ENABLED);
+        sid = tracker_channel->info.sid;
+        cn0 = common_data->cn0;
+      }
+      tracker_channel_unlock(tracker_channel);
+
+      if (!running) {
+        states[i].state = 0;
+        states[i].sid.code = 0;
+        states[i].sid.sat = 0;
+        states[i].cn0 = -1;
+      } else {
+        states[i].state = 1;
+        states[i].sid = sid_to_sbp(sid);
+        states[i].cn0 = cn0;
+      }
     }
   }
 
   sbp_send_msg(SBP_MSG_TRACKING_STATE, sizeof(states), (u8*)states);
-}
-
-/** Force a satellite to drop.
- * This function is used for testing.  It clobbers the code frequency in the
- * loop filter which destroys the correlations.  The satellite is dropped
- * by manage.c which checks the SNR.
- */
-void tracking_drop_satellite(gnss_signal_t sid)
-{
-  for (u8 i=0; i<nap_track_n_channels; i++) {
-    if (!sid_is_equal(tracking_channel[i].sid, sid))
-      continue;
-
-    tracking_channel[i].tl_state.code_filt.y += 500;
-  }
 }
 
 /** Calculate the future code phase after N samples.
@@ -927,7 +210,8 @@ void tracking_drop_satellite(gnss_signal_t sid)
 float propagate_code_phase(float code_phase, float carrier_freq, u32 n_samples)
 {
   /* Calculate the code phase rate with carrier aiding. */
-  u32 code_phase_rate = (1.0 + carrier_freq/GPS_L1_HZ) * NAP_TRACK_NOMINAL_CODE_PHASE_RATE;
+  u32 code_phase_rate = (1.0 + carrier_freq/GPS_L1_HZ) *
+                            NAP_TRACK_NOMINAL_CODE_PHASE_RATE;
 
   /* Internal Swift NAP code phase is in chips*2^32:
    *
@@ -939,7 +223,8 @@ float propagate_code_phase(float code_phase, float carrier_freq, u32 n_samples)
    */
 
   /* Calculate code phase in chips*2^32. */
-  u64 propagated_code_phase = (u64)(code_phase * (((u64)1)<<32)) + n_samples * (u64)code_phase_rate;
+  u64 propagated_code_phase = (u64)(code_phase * (((u64)1)<<32)) + n_samples *
+                                  (u64)code_phase_rate;
 
   /* Convert code phase back to natural units with sub-chip precision.
    * NOTE: the modulo is required to fix the fact rollover should
@@ -948,149 +233,9 @@ float propagate_code_phase(float code_phase, float carrier_freq, u32 n_samples)
   return (float)((u32)(propagated_code_phase >> 28) % (1023*16)) / 16.0;
 }
 
-/** Determines whether the specified tracking channel is available to track
- * the specified sid.
- * \param channel Tracking channel to use.
- * \param sid     Signal to track.
- */
-bool tracking_channel_available(u8 channel, gnss_signal_t sid)
-{
-  (void) sid;
-  const tracking_channel_t *t = &tracking_channel[channel];
-  if (state_get(t) == STATE_DISABLED) {
-    if (chTimeElapsedSince(t->disable_time) >=
-          MS2ST(CHANNEL_SHUTDOWN_TIME_ms)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/** Initialises a tracking channel.
- * Initialises a tracking channel on the Swift NAP. The start_sample_count
- * must be contrived to be at or close to a PRN edge (PROMPT code phase = 0).
- *
- * \param prn                PRN number - 1 (0-31).
- * \param channel            Tracking channel number on the Swift NAP.
- * \param carrier_freq       Carrier frequency (Doppler) at start of tracking in Hz.
- * \param start_sample_count Sample count on which to start tracking.
- * \param cn0_init           Estimated C/N0 from acquisition
- * \param elevation          Satellite elevation in degrees, or
- *                           TRACKING_ELEVATION_UNKNOWN
- */
-void tracking_channel_init(u8 channel, gnss_signal_t sid, float carrier_freq,
-                           u32 start_sample_count, float cn0_init, s8 elevation)
-{
-  tracking_channel_t *chan = &tracking_channel[channel];
-
-  /* Initialize all fields in the channel to 0 */
-  memset(chan, 0, sizeof(tracking_channel_t));
-
-  bit_sync_init(&chan->bit_sync, sid);
-  nav_bit_fifo_init(&chan->nav_bit_fifo);
-  nav_time_sync_init(&chan->nav_time_sync);
-
-  /* Adjust the channel start time as the start_sample_count passed
-   * in corresponds to a PROMPT code phase rollover but we want to
-   * start the channel on an EARLY code phase rollover.
-   */
-  /* TODO : change hardcoded sample rate */
-  start_sample_count -= 0.5*16;
-
-  /* Setup tracking_channel struct. */
-  chan->sid = sid;
-  chan->elevation = elevation;
-
-  /* Initialize TOW_ms and lock_count. */
-  tracking_channel_ambiguity_unknown(channel);
-  chan->TOW_ms = TOW_INVALID;
-  chan->bit_polarity = BIT_POLARITY_UNKNOWN;
-
-  const struct loop_params *l = &loop_params_stage[0];
-
-  /* Note: The only coherent integration interval currently supported
-     for first-stage tracking (i.e. loop_params_stage[0].coherent_ms)
-     is 1. */
-  chan->int_ms = MIN(l->coherent_ms, chan->bit_sync.bit_length);
-
-  /* Calculate code phase rate with carrier aiding. */
-  float code_phase_rate = (1 + carrier_freq/GPS_L1_HZ) * GPS_CA_CHIPPING_RATE;
-
-  aided_tl_init(&(chan->tl_state), 1e3 / chan->int_ms,
-                code_phase_rate - GPS_CA_CHIPPING_RATE,
-                l->code_bw, l->code_zeta, l->code_k,
-                l->carr_to_code,
-                carrier_freq,
-                l->carr_bw, l->carr_zeta, l->carr_k,
-                l->carr_fll_aid_gain);
-
-  chan->code_phase_rate_fp = code_phase_rate*NAP_TRACK_CODE_PHASE_RATE_UNITS_PER_HZ;
-  chan->code_phase_rate_fp_prev = chan->code_phase_rate_fp;
-  chan->code_phase_rate = code_phase_rate;
-  chan->carrier_freq = carrier_freq;
-  chan->carrier_freq_fp = (s32)(carrier_freq * NAP_TRACK_CARRIER_FREQ_UNITS_PER_HZ);
-  chan->carrier_freq_fp_prev = chan->carrier_freq_fp;
-  chan->sample_count = start_sample_count;
-  chan->short_cycle = true;
-
-  /* Initialise C/N0 estimator */
-  cn0_est_init(&chan->cn0_est, 1e3/chan->int_ms, cn0_init, CN0_EST_LPF_CUTOFF, 1e3/chan->int_ms);
-
-  lock_detect_init(&chan->lock_detect,
-                   lock_detect_params.k1, lock_detect_params.k2,
-                   lock_detect_params.lp, lock_detect_params.lo);
-
-  /* TODO: Reconfigure alias detection between stages */
-  u8 alias_detect_ms = MIN(loop_params_stage[1].coherent_ms,
-                           chan->bit_sync.bit_length);
-  alias_detect_init(&chan->alias_detect, 500/alias_detect_ms,
-                    (alias_detect_ms-1)*1e-3);
-
-  /* Lock the channel while setting up NAP registers and updating state. This
-   * allows the update thread to deal with trailing interrupts after the
-   * channel is disabled by writing the update register as required.  */
-  tracking_channel_lock(channel);
-
-  /* Starting carrier phase is set to zero as we don't
-   * know the carrier freq well enough to calculate it.
-   */
-  /* Start with code phase of zero as we have conspired for the
-   * channel to be initialised on an EARLY code phase rollover.
-   */
-  nap_track_code_wr_blocking(channel, sid);
-  nap_track_init_wr_blocking(channel, 0, 0, 0);
-  nap_track_update_wr_blocking(
-    channel,
-    carrier_freq*NAP_TRACK_CARRIER_FREQ_UNITS_PER_HZ,
-    chan->code_phase_rate_fp,
-    0, 0
-  );
-
-  /* Schedule the timing strobe for start_sample_count. */
-  nap_timing_strobe(start_sample_count);
-
-  /* Change the channel state to ENABLED. */
-  event(chan, EVENT_ENABLE);
-
-  tracking_channel_unlock(channel);
-}
-
-/** Disable tracking channel.
- * Change tracking channel state to TRACKING_DISABLED and write 0 to SwiftNAP
- * tracking channel code / carrier frequencies to stop channel from raising
- * interrupts.
- *
- * \param channel Tracking channel to disable.
- */
-void tracking_channel_disable(u8 channel)
-{
-  tracking_channel_t *t = &tracking_channel[channel];
-  event(t, EVENT_DISABLE_REQUEST);
-}
-
 /** Handles pending IRQs for the specified tracking channels.
- * \param channels_mask Bitfield indicating the tracking channels for which
- *                      an IRQ is pending.
+ * \param channels_mask   Bitfield indicating the tracking channels for which
+ *                        an IRQ is pending.
  */
 void tracking_channels_update(u32 channels_mask)
 {
@@ -1099,249 +244,760 @@ void tracking_channels_update(u32 channels_mask)
    * channels_mask.
    */
   for (u32 channel = 0; channel < nap_track_n_channels; channel++) {
+    tracker_channel_t *tracker_channel = tracker_channel_get(channel);
     bool update_required = (channels_mask & 1) ? true : false;
-    tracking_channel_process(channel, update_required);
+    tracker_channel_process(tracker_channel, update_required);
     channels_mask >>= 1;
   }
 }
 
-/** Locks a tracking channel for exclusive access.
+/** Determine if a tracker channel is available to track the specified sid.
+ *
+ * \param id      ID of the tracker channel to be checked.
+ * \param sid     Signal to be tracked.
+ *
+ * \return true if the tracker channel is available, false otherwise.
+ */
+bool tracker_channel_available(tracker_channel_id_t id, gnss_signal_t sid)
+{
+  const tracker_channel_t *tracker_channel = tracker_channel_get(id);
+
+  tracker_t *tracker;
+  const tracker_interface_t *tracker_interface;
+  return tracker_channel_runnable(tracker_channel, sid, &tracker,
+                                  &tracker_interface);
+}
+
+/** Initialize a tracker channel to track the specified sid.
+ *
+ * \param id                    ID of the tracker channel to be initialized.
+ * \param sid                   Signal to be tracked.
+ * \param carrier_freq          Carrier frequency Doppler (Hz).
+ * \param start_sample_count    NAP sample count at which to start the channel.
+ * \param cn0_init              Initial C/N0 estimate (dBHz).
+ * \param elevation             Elevation (deg).
+ *
+ * \return true if the tracker channel was initialized, false otherwise.
+ */
+bool tracker_channel_init(tracker_channel_id_t id, gnss_signal_t sid,
+                          float carrier_freq,  u32 start_sample_count,
+                          float cn0_init, s8 elevation)
+{
+  tracker_channel_t *tracker_channel = tracker_channel_get(id);
+
+  const tracker_interface_t *tracker_interface;
+  tracker_t *tracker;
+  if(!tracker_channel_runnable(tracker_channel, sid, &tracker,
+                               &tracker_interface)) {
+    return false;
+  }
+
+  tracker_channel_lock(tracker_channel);
+  {
+    /* Set up channel */
+    tracker_channel->info.sid = sid;
+    tracker_channel->info.context = tracker_channel;
+    tracker_channel->info.nap_channel = id;
+    tracker_channel->tracker = tracker;
+
+    tracker_channel->elevation = elevation;
+
+    /* Adjust the channel start time as the start_sample_count passed
+     * in corresponds to a PROMPT code phase rollover but we want to
+     * start the channel on an EARLY code phase rollover.
+     */
+    /* TODO : change hardcoded sample rate */
+    start_sample_count -= 0.5*16;
+
+    common_data_init(&tracker_channel->common_data, start_sample_count,
+                     carrier_freq, cn0_init);
+    internal_data_init(&tracker_channel->internal_data, sid);
+    interface_function(tracker_channel, tracker_interface->init);
+
+    const tracker_common_data_t *common_data = &tracker_channel->common_data;
+
+    /* Lock the NAP mutex while setting up NAP registers and updating state.
+     * This allows the update thread to deal with trailing interrupts after
+     * the channel is disabled by writing the update register as required. */
+    chMtxLock(&tracker_channel->nap_mutex);
+
+    /* Starting carrier phase is set to zero as we don't
+     * know the carrier freq well enough to calculate it.
+     */
+    /* Start with code phase of zero as we have conspired for the
+     * channel to be initialised on an EARLY code phase rollover.
+     */
+    nap_track_code_wr_blocking(tracker_channel->info.nap_channel, sid);
+    nap_track_init_wr_blocking(tracker_channel->info.nap_channel, 0, 0, 0);
+    nap_track_update_wr_blocking(
+      tracker_channel->info.nap_channel,
+      common_data->carrier_freq * NAP_TRACK_CARRIER_FREQ_UNITS_PER_HZ,
+      common_data->code_phase_rate * NAP_TRACK_CODE_PHASE_RATE_UNITS_PER_HZ,
+      0, 0
+    );
+
+    /* Schedule the timing strobe for start_sample_count. */
+    nap_timing_strobe(start_sample_count);
+
+    /* Change the channel state to ENABLED. */
+    event(tracker_channel, EVENT_ENABLE);
+
+    Mutex *m = chMtxUnlock();
+    assert(m == &tracker_channel->nap_mutex);
+  }
+  tracker_channel_unlock(tracker_channel);
+
+  return true;
+}
+
+/** Disable the specified tracker channel.
+ *
+ * \param id      ID of the tracker channel to be disabled.
+ *
+ * \return true if the tracker channel was disabled, false otherwise.
+ */
+bool tracker_channel_disable(tracker_channel_id_t id)
+{
+  /* Request disable */
+  tracker_channel_t *tracker_channel = tracker_channel_get(id);
+  event(tracker_channel, EVENT_DISABLE_REQUEST);
+  return true;
+}
+
+/** Lock a tracker channel for exclusive access.
+ *
  * \note Blocking or long-running operations should not be performed while
  *       holding the lock for a tracking channel.
- * \param channel Tracking channel to lock.
+ *
+ * \param id      ID of the tracker channel to be locked.
  */
-void tracking_channel_lock(u8 channel)
+void tracking_channel_lock(tracker_channel_id_t id)
 {
-  chMtxLock(&tracking_channel_mutex[channel]);
+  tracker_channel_t *tracker_channel = tracker_channel_get(id);
+  tracker_channel_lock(tracker_channel);
 }
 
-/** Unlocks a locked tracking channel.
- * \param channel Tracking channel to unlock.
+/** Unlock a locked tracker channel.
+ *
+ * \param id      ID of the tracker channel to be unlocked.
  */
-void tracking_channel_unlock(u8 channel)
+void tracking_channel_unlock(tracker_channel_id_t id)
 {
-  Mutex *m = chMtxUnlock();
-  assert(m == &tracking_channel_mutex[channel]);
+  tracker_channel_t *tracker_channel = tracker_channel_get(id);
+  tracker_channel_unlock(tracker_channel);
 }
 
-/** Determines whether the specified tracking channel is currently running.
- * \param channel Tracking channel to use.
+/** Determine whether a tracker channel is currently running.
+ *
+ * \param id      ID of the tracker channel to use.
  */
-bool tracking_channel_running(u8 channel)
+bool tracking_channel_running(tracker_channel_id_t id)
 {
-  const tracking_channel_t *t = &tracking_channel[channel];
-  return (state_get(t) == STATE_ENABLED);
+  const tracker_channel_t *tracker_channel = tracker_channel_get(id);
+  return (tracker_channel_state_get(tracker_channel) == STATE_ENABLED);
 }
 
-/** Determines if C/NO is above the use threshold for a tracking channel.
- * \param channel Tracking channel to use.
+/** Return the C/N0 estimate for a tracker channel.
+ *
+ * \param id      ID of the tracker channel to use.
  */
-bool tracking_channel_cn0_useable(u8 channel)
+float tracking_channel_cn0_get(tracker_channel_id_t id)
 {
-  return (tracking_channel[channel].cn0 > track_cn0_use_thres);
+  const tracker_channel_t *tracker_channel = tracker_channel_get(id);
+  const tracker_common_data_t *common_data = &tracker_channel->common_data;
+  return common_data->cn0;
 }
 
-/** Returns the time in ms for which tracking channel has been running.
- * \param channel Tracking channel to use.
+/** Return the time in ms for which a tracker channel has been running.
+ *
+ * \param id      ID of the tracker channel to use.
  */
-u32 tracking_channel_running_time_ms_get(u8 channel)
+u32 tracking_channel_running_time_ms_get(tracker_channel_id_t id)
 {
-  return tracking_channel[channel].update_count;
+  const tracker_channel_t *tracker_channel = tracker_channel_get(id);
+  const tracker_common_data_t *common_data = &tracker_channel->common_data;
+  return common_data->update_count;
 }
 
-/** Returns the time in ms for which C/N0 has been above the use threshold for
- * a tracking channel.
- * \param channel Tracking channel to use.
+/** Return the time in ms for which C/N0 has been above the use threshold for
+ * a tracker channel.
+ *
+ * \param id      ID of the tracker channel to use.
  */
-u32 tracking_channel_cn0_useable_ms_get(u8 channel)
+u32 tracking_channel_cn0_useable_ms_get(tracker_channel_id_t id)
 {
-  return update_count_diff(channel,
-      &tracking_channel[channel].cn0_below_use_thres_count);
+  const tracker_channel_t *tracker_channel = tracker_channel_get(id);
+  const tracker_common_data_t *common_data = &tracker_channel->common_data;
+  return update_count_diff(tracker_channel,
+                           &common_data->cn0_below_use_thres_count);
 }
 
-/** Returns the time in ms for which C/N0 has been below the drop threshold for
- * a tracking channel.
- * \param channel Tracking channel to use.
+/** Return the time in ms for which C/N0 has been below the drop threshold for
+ * a tracker channel.
+ *
+ * \param id      ID of the tracker channel to use.
  */
-u32 tracking_channel_cn0_drop_ms_get(u8 channel)
+u32 tracking_channel_cn0_drop_ms_get(tracker_channel_id_t id)
 {
-  return update_count_diff(channel,
-      &tracking_channel[channel].cn0_above_drop_thres_count);
+  const tracker_channel_t *tracker_channel = tracker_channel_get(id);
+  const tracker_common_data_t *common_data = &tracker_channel->common_data;
+  return update_count_diff(tracker_channel,
+                           &common_data->cn0_above_drop_thres_count);
 }
 
-/** Returns the time in ms for which the optimistic lock detector has reported
- * being unlocked for a tracking channel.
- * \param channel Tracking channel to use.
+/** Return the time in ms for which the optimistic lock detector has reported
+ * being unlocked for a tracker channel.
+ *
+ * \param id      ID of the tracker channel to use.
  */
-u32 tracking_channel_ld_opti_unlocked_ms_get(u8 channel)
+u32 tracking_channel_ld_opti_unlocked_ms_get(tracker_channel_id_t id)
 {
-  return update_count_diff(channel,
-      &tracking_channel[channel].ld_opti_locked_count);
+  const tracker_channel_t *tracker_channel = tracker_channel_get(id);
+  const tracker_common_data_t *common_data = &tracker_channel->common_data;
+  return update_count_diff(tracker_channel,
+                           &common_data->ld_opti_locked_count);
 }
 
-/** Returns the time in ms for which the pessimistic lock detector has reported
- * being locked for a tracking channel.
- * \param channel Tracking channel to use.
+/** Return the time in ms for which the pessimistic lock detector has reported
+ * being locked for a tracker channel.
+ *
+ * \param id      ID of the tracker channel to use.
  */
-u32 tracking_channel_ld_pess_locked_ms_get(u8 channel)
+u32 tracking_channel_ld_pess_locked_ms_get(tracker_channel_id_t id)
 {
-  return update_count_diff(channel,
-      &tracking_channel[channel].ld_pess_unlocked_count);
+  const tracker_channel_t *tracker_channel = tracker_channel_get(id);
+  const tracker_common_data_t *common_data = &tracker_channel->common_data;
+  return update_count_diff(tracker_channel,
+                           &common_data->ld_pess_unlocked_count);
 }
 
-/** Returns the time in ms since the last mode change for a tracking channel.
- * \param channel Tracking channel to use.
+/** Return the time in ms since the last mode change for a tracker channel.
+ *
+ * \param id      ID of the tracker channel to use.
  */
-u32 tracking_channel_last_mode_change_ms_get(u8 channel)
+u32 tracking_channel_last_mode_change_ms_get(tracker_channel_id_t id)
 {
-  return update_count_diff(channel,
-      &tracking_channel[channel].mode_change_count);
+  const tracker_channel_t *tracker_channel = tracker_channel_get(id);
+  const tracker_common_data_t *common_data = &tracker_channel->common_data;
+  return update_count_diff(tracker_channel,
+                           &common_data->mode_change_count);
 }
 
-/** Returns the sid currently associated with a tracking channel.
- * \param channel Tracking channel to use.
+/** Return the sid currently associated with a tracker channel.
+ *
+ * \note The returned sid is only guaranteed to be valid if the tracker
+ *       channel is running.
+ *
+ * \param id      ID of the tracker channel to use.
  */
-gnss_signal_t tracking_channel_sid_get(u8 channel)
+gnss_signal_t tracking_channel_sid_get(tracker_channel_id_t id)
 {
-  return tracking_channel[channel].sid;
+  const tracker_channel_t *tracker_channel = tracker_channel_get(id);
+  return tracker_channel->info.sid;
 }
 
-/** Returns the current carrier frequency for a tracking channel.
- * \param channel Tracking channel to use.
+/** Return the current carrier frequency for a tracker channel.
+ *
+ * \param id      ID of the tracker channel to use.
  */
-double tracking_channel_carrier_freq_get(u8 channel)
+double tracking_channel_carrier_freq_get(tracker_channel_id_t id)
 {
-  return tracking_channel[channel].carrier_freq;
+  const tracker_channel_t *tracker_channel = tracker_channel_get(id);
+  const tracker_common_data_t *common_data = &tracker_channel->common_data;
+  return common_data->carrier_freq;
 }
 
-/** Returns the current time of week for a tracking channel.
- * \param channel Tracking channel to use.
+/** Return the current time of week for a tracker channel.
+ *
+ * \param id      ID of the tracker channel to use.
  */
-s32 tracking_channel_tow_ms_get(u8 channel)
+s32 tracking_channel_tow_ms_get(tracker_channel_id_t id)
 {
-  return tracking_channel[channel].TOW_ms;
+  const tracker_channel_t *tracker_channel = tracker_channel_get(id);
+  const tracker_common_data_t *common_data = &tracker_channel->common_data;
+  return common_data->TOW_ms;
 }
 
-/** Returns the bit sync status for a tracking channel.
- * \param channel Tracking channel to use.
+/** Return the bit sync status for a tracker channel.
+ *
+ * \param id      ID of the tracker channel to use.
  */
-bool tracking_channel_bit_sync_resolved(u8 channel)
+bool tracking_channel_bit_sync_resolved(tracker_channel_id_t id)
 {
-  return (tracking_channel[channel].bit_sync.bit_phase_ref != BITSYNC_UNSYNCED);
+  const tracker_channel_t *tracker_channel = tracker_channel_get(id);
+  const tracker_internal_data_t *internal_data =
+      &tracker_channel->internal_data;
+  return (internal_data->bit_sync.bit_phase_ref != BITSYNC_UNSYNCED);
 }
 
-/** Returns the bit polarity resolution status for a tracking channel.
- * \param channel Tracking channel to use.
+/** Return the bit polarity resolution status for a tracker channel.
+ *
+ * \param id      ID of the tracker channel to use.
  */
-bool tracking_channel_bit_polarity_resolved(u8 channel)
+bool tracking_channel_bit_polarity_resolved(tracker_channel_id_t id)
 {
-  return (tracking_channel[channel].bit_polarity != BIT_POLARITY_UNKNOWN);
+  const tracker_channel_t *tracker_channel = tracker_channel_get(id);
+  const tracker_internal_data_t *internal_data =
+      &tracker_channel->internal_data;
+  return (internal_data->bit_polarity != BIT_POLARITY_UNKNOWN);
 }
 
-/** Update channel measurement for a tracking channel.
- * \param channel Tracking channel to update measurement from.
- * \param meas Pointer to channel_measurement_t where measurement will be put.
+/** Retrieve a channel measurement for a tracker channel.
+ *
+ * \param id      ID of the tracker channel to use.
+ * \param meas    Pointer to output channel_measurement_t.
  */
-void tracking_channel_measurement_get(u8 channel, channel_measurement_t *meas)
+void tracking_channel_measurement_get(tracker_channel_id_t id,
+                                      channel_measurement_t *meas)
 {
-  tracking_channel_t* chan = &tracking_channel[channel];
+  tracker_channel_t *tracker_channel = tracker_channel_get(id);
+  const tracker_internal_data_t *internal_data =
+      &tracker_channel->internal_data;
+  const tracker_common_data_t *common_data = &tracker_channel->common_data;
 
   /* Update our channel measurement. */
-  meas->sid = chan->sid;
-  meas->code_phase_chips = (double)chan->code_phase_early /
+  meas->sid = tracker_channel->info.sid;
+  meas->code_phase_chips = (double)common_data->code_phase_early /
                                NAP_TRACK_CODE_PHASE_UNITS_PER_CHIP;
-  meas->code_phase_rate = chan->code_phase_rate;
-  meas->carrier_phase = chan->carrier_phase / (double)(1<<24);
-  meas->carrier_freq = chan->carrier_freq;
-  meas->time_of_week_ms = chan->TOW_ms;
-  meas->receiver_time = (double)chan->sample_count / SAMPLE_FREQ;
-  meas->snr = chan->cn0;
-  if (chan->bit_polarity == BIT_POLARITY_INVERTED) {
+  meas->code_phase_rate = common_data->code_phase_rate;
+  meas->carrier_phase = common_data->carrier_phase / (double)(1<<24);
+  meas->carrier_freq = common_data->carrier_freq;
+  meas->time_of_week_ms = common_data->TOW_ms;
+  meas->receiver_time = (double)common_data->sample_count / SAMPLE_FREQ;
+  meas->snr = common_data->cn0;
+  if (internal_data->bit_polarity == BIT_POLARITY_INVERTED) {
     meas->carrier_phase += 0.5;
   }
-  meas->lock_counter = chan->lock_counter;
+  meas->lock_counter = internal_data->lock_counter;
 }
 
-/** Sets the elevation angle (deg) for a tracking channel by sid.
+/** Set the elevation angle for a tracker channel by sid.
+ *
  * \param sid         Signal identifier for which the elevation should be set.
- * \param elevation   Elevation angle in degrees.
+ * \param elevation   Elevation angle (deg).
  */
 bool tracking_channel_evelation_degrees_set(gnss_signal_t sid, s8 elevation)
 {
   bool result = false;
-  for (u32 i=0; i < NAP_MAX_N_TRACK_CHANNELS; i++) {
-    tracking_channel_t *ch = &tracking_channel[i];
+  for (u32 i=0; i < NUM_TRACKER_CHANNELS; i++) {
+    tracker_channel_t *tracker_channel = tracker_channel_get(i);
 
     /* Check SID before locking. */
-    if (!sid_is_equal(ch->sid, sid)) {
+    if (!sid_is_equal(tracker_channel->info.sid, sid)) {
       continue;
     }
 
     /* Lock and update if SID matches. */
-    tracking_channel_lock(i);
-    if (sid_is_equal(ch->sid, sid)) {
-      ch->elevation = elevation;
-      result = true;
+    tracker_channel_lock(tracker_channel);
+    {
+      if (sid_is_equal(tracker_channel->info.sid, sid)) {
+        tracker_channel->elevation = elevation;
+        result = true;
+      }
     }
-    tracking_channel_unlock(i);
+    tracker_channel_unlock(tracker_channel);
     break;
   }
   return result;
 }
 
-/** Returns the elevation angle (deg) for a tracking channel.
- * \param channel Tracking channel to use.
+/** Return the elevation angle for a tracker channel.
+ *
+ * \param id      ID of the tracker channel to use.
  */
-s8 tracking_channel_evelation_degrees_get(u8 channel)
+s8 tracking_channel_evelation_degrees_get(tracker_channel_id_t id)
 {
-  return tracking_channel[channel].elevation;
+  const tracker_channel_t *tracker_channel = tracker_channel_get(id);
+  return tracker_channel->elevation;
 }
 
-/** Read the next pending nav bit for a tracking channel.
+/** Read the next pending nav bit for a tracker channel.
  *
  * \note This function should should be called from the same thread as
  * tracking_channel_time_sync().
  *
- * \param channel     Tracking channel to use.
- * \param soft_bit    Output soft nav bit value.
+ * \param id            ID of the tracker channel to read from.
+ * \param soft_bit      Output soft nav bit value.
  *
  * \return true if *soft_bit is valid, false otherwise.
  */
-bool tracking_channel_nav_bit_get(u8 channel, s8 *soft_bit)
+bool tracking_channel_nav_bit_get(tracker_channel_id_t id, s8 *soft_bit)
 {
-  tracking_channel_t *chan = &tracking_channel[channel];
+  tracker_channel_t *tracker_channel = tracker_channel_get(id);
+  tracker_internal_data_t *internal_data = &tracker_channel->internal_data;
+
   nav_bit_fifo_element_t element;
-  if (nav_bit_fifo_read(&chan->nav_bit_fifo, &element)) {
+  if (nav_bit_fifo_read(&internal_data->nav_bit_fifo, &element)) {
     *soft_bit = element.soft_bit;
     return true;
   }
   return false;
 }
 
-/** Propagate decoded time of week and bit polarity back to a tracking channel.
+/** Propagate decoded time of week and bit polarity back to a tracker channel.
  *
  * \note This function should be called from the same thread as
  * tracking_channel_nav_bit_get().
  * \note It is assumed that the specified data is synchronized with the most
  * recent nav bit read from the FIFO using tracking_channel_nav_bit_get().
  *
- * \param channel       Tracking channel to use.
+ * \param id            ID of the tracker channel to synchronize.
  * \param TOW_ms        Time of week in milliseconds.
  * \param bit_polarity  Bit polarity.
  *
  * \return true if data was enqueued successfully, false otherwise.
  */
-bool tracking_channel_time_sync(u8 channel, s32 TOW_ms, s8 bit_polarity)
+bool tracking_channel_time_sync(tracker_channel_id_t id, s32 TOW_ms,
+                                s8 bit_polarity)
 {
   assert(TOW_ms >= 0);
   assert(TOW_ms < GPS_WEEK_LENGTH_ms);
   assert((bit_polarity == BIT_POLARITY_NORMAL) ||
          (bit_polarity == BIT_POLARITY_INVERTED));
 
-  tracking_channel_t *chan = &tracking_channel[channel];
-  nav_bit_fifo_index_t read_index = chan->nav_bit_fifo.read_index;
-  return nav_time_sync_set(&chan->nav_time_sync,
+  tracker_channel_t *tracker_channel = tracker_channel_get(id);
+  tracker_internal_data_t *internal_data = &tracker_channel->internal_data;
+  nav_bit_fifo_index_t read_index = internal_data->nav_bit_fifo.read_index;
+  return nav_time_sync_set(&internal_data->nav_time_sync,
                            TOW_ms, bit_polarity, read_index);
+}
+
+/** Retrieve the channel info and internal data associated with a
+ * tracker context.
+ *
+ * \note This function is declared in track_internal.h to avoid polluting
+ * the public API in track.h
+ *
+ * \param tracker_context     Tracker context to be resolved.
+ * \param channel_info        Output tracker channel info.
+ * \param internal_data       Output tracker internal data.
+ */
+void tracker_internal_context_resolve(tracker_context_t *tracker_context,
+                                      const tracker_channel_info_t **channel_info,
+                                      tracker_internal_data_t **internal_data)
+{
+  tracker_channel_t *tracker_channel = (tracker_channel_t *)tracker_context;
+  *channel_info = &tracker_channel->info;
+  *internal_data = &tracker_channel->internal_data;
+}
+
+/** Check the state of a tracker channel and generate events as required.
+ * \param tracker_channel   Tracker channel to use.
+ * \param update_required   True when correlations are pending for the
+ *                          tracking channel.
+ */
+static void tracker_channel_process(tracker_channel_t *tracker_channel,
+                                    bool update_required)
+{
+  switch (tracker_channel_state_get(tracker_channel)) {
+    case STATE_ENABLED:
+    {
+      if (update_required) {
+        const tracker_interface_t *tracker_interface =
+            tracker_interface_get(tracker_channel->info.sid);
+        tracker_channel_lock(tracker_channel);
+        {
+          interface_function(tracker_channel, tracker_interface->update);
+        }
+        tracker_channel_unlock(tracker_channel);
+      }
+      break;
+    }
+    case STATE_DISABLE_REQUESTED:
+    {
+      const tracker_interface_t *tracker_interface =
+          tracker_interface_get(tracker_channel->info.sid);
+      nap_channel_disable(tracker_channel);
+      tracker_channel_lock(tracker_channel);
+      {
+        interface_function(tracker_channel, tracker_interface->disable);
+        tracker_channel->disable_time = chTimeNow();
+        event(tracker_channel, EVENT_DISABLE);
+      }
+      tracker_channel_unlock(tracker_channel);
+      break;
+    }
+    case STATE_DISABLED:
+    {
+      if (update_required) {
+        /* Tracking channel is not owned by the update thread, but the update
+         * register must be written to clear the interrupt flag. Atomically
+         * verify state and write the update register. */
+        chMtxLock(&tracker_channel->nap_mutex);
+        if (tracker_channel_state_get(tracker_channel) == STATE_DISABLED) {
+          nap_channel_disable(tracker_channel);
+        }
+        Mutex *m = chMtxUnlock();
+        assert(m == &tracker_channel->nap_mutex);
+      }
+      break;
+    }
+    default:
+    {
+      assert(!"Invalid tracking channel state");
+      break;
+    }
+  }
+}
+
+/** Return the unsigned difference between update_count and *val for a
+ * tracker channel.
+ *
+ * \note This function allows some margin to avoid glitches in case values
+ * are not read atomically from the tracking channel data.
+ *
+ * \param tracker_channel   Tracker channel to use.
+ * \param val               Pointer to the value to be subtracted
+ *                          from update_count.
+ *
+ * \return The unsigned difference between update_count and *val.
+ */
+static update_count_t update_count_diff(const tracker_channel_t *
+                                        tracker_channel,
+                                        const update_count_t *val)
+{
+  const tracker_common_data_t *common_data = &tracker_channel->common_data;
+  update_count_t result = (update_count_t)(common_data->update_count - *val);
+  COMPILER_BARRIER(); /* Prevent compiler reordering */
+  /* Allow some margin in case values were not read atomically.
+   * Treat a difference of [-10000, 0) as zero. */
+  if (result > (update_count_t)(UINT32_MAX - 10000))
+    return 0;
+  else
+    return result;
+}
+
+/** Parse the IQ output enable bitfield. */
+static bool track_iq_output_notify(struct setting *s, const char *val)
+{
+  if (s->type->from_string(s->type->priv, s->addr, s->len, val)) {
+    for (int i = 0; i < NUM_TRACKER_CHANNELS; i++) {
+      tracker_channel_t *tracker_channel = tracker_channel_get(i);
+      tracker_internal_data_t *internal_data = &tracker_channel->internal_data;
+      internal_data->output_iq = (iq_output_mask & (1 << i)) != 0;
+    }
+    return true;
+  }
+  return false;
+}
+
+/** Disable the NAP tracking channel associated with a tracker channel.
+ *
+ * \param tracker_channel   Tracker channel to use.
+ */
+static void nap_channel_disable(const tracker_channel_t *tracker_channel)
+{
+  nap_track_update_wr_blocking(tracker_channel->info.nap_channel, 0, 0, 0, 0);
+}
+
+/** Retrieve the tracker channel associated with a tracker channel ID.
+ *
+ * \param tracker_channel_id    ID of the tracker channel to be retrieved.
+ *
+ * \return Associated tracker channel.
+ */
+static tracker_channel_t * tracker_channel_get(tracker_channel_id_t id)
+{
+  assert(id < NUM_TRACKER_CHANNELS);
+  return &tracker_channels[id];
+}
+
+/** Retrieve the tracker interface for the specified sid.
+ *
+ * \param sid       Signal to be tracked.
+ *
+ * \return Associated tracker interface. May be the default interface.
+ */
+static const tracker_interface_t * tracker_interface_get(gnss_signal_t sid)
+{
+  const tracker_interface_list_element_t *e = *tracker_interface_list_ptr_get();
+  while (e != 0) {
+    const tracker_interface_t *interface = e->interface;
+    if (interface->code == sid.code) {
+      return interface;
+    }
+    e = e->next;
+  }
+
+  return &tracker_interface_default;
+}
+
+/** Determine if a tracker channel can be started to track the specified sid.
+ *
+ * \param tracker_channel_id    ID of the tracker channel to be checked.
+ * \param sid                   Signal to be tracked.
+ * \param tracker_interface     Output tracker interface to use.
+ * \param tracker               Output tracker instance to use.
+ *
+ * \return true if the tracker channel is available, false otherwise.
+ */
+static bool tracker_channel_runnable(const tracker_channel_t *tracker_channel,
+                                     gnss_signal_t sid, tracker_t **tracker,
+                                     const tracker_interface_t **
+                                     tracker_interface)
+{
+  if (tracker_channel_state_get(tracker_channel) != STATE_DISABLED)
+      return false;
+  if (chTimeElapsedSince(tracker_channel->disable_time) <
+        MS2ST(CHANNEL_SHUTDOWN_TIME_ms))
+    return false;
+
+  *tracker_interface = tracker_interface_get(sid);
+  if (!available_tracker_get(*tracker_interface, tracker))
+    return false;
+
+  return true;
+}
+
+/** Find an inactive tracker instance for the specified tracker interface.
+ *
+ * \param tracker_interface   Tracker interface to use.
+ * \param tracker             Output inactive tracker instance.
+ *
+ * \return true if *tracker points to an inactive tracker instance,
+ * false otherwise.
+ */
+static bool available_tracker_get(const tracker_interface_t *tracker_interface,
+                                  tracker_t **tracker)
+{
+  /* Search for a free tracker */
+  for (u32 i=0; i<tracker_interface->num_trackers; i++) {
+    tracker_t *t = &tracker_interface->trackers[i];
+    if (!tracker_active(t)) {
+      *tracker = t;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/** Return the state of a tracker channel.
+ *
+ * \note This function performs an acquire operation, meaning that it ensures
+ * the returned state was read before any subsequent memory accesses.
+ *
+ * \param tracker_channel   Tracker channel to use.
+ *
+ * \return state of the decoder channel.
+ */
+static state_t tracker_channel_state_get(const tracker_channel_t *
+                                         tracker_channel)
+{
+  state_t state = tracker_channel->state;
+  COMPILER_BARRIER(); /* Prevent compiler reordering */
+  return state;
+}
+
+/** Return the state of a tracker instance.
+ *
+ * \note This function performs an acquire operation, meaning that it ensures
+ * the returned state was read before any subsequent memory accesses.
+ *
+ * \param tracker   Tracker to use.
+ *
+ * \return true if the tracker is active, false if inactive.
+ */
+static bool tracker_active(const tracker_t *tracker)
+{
+  bool active = tracker->active;
+  COMPILER_BARRIER(); /* Prevent compiler reordering */
+  return active;
+}
+
+/** Execute an interface function on a tracker channel.
+ *
+ * \param tracker_channel   Tracker channel to use.
+ * \param func              Interface function to execute.
+ */
+static void interface_function(tracker_channel_t *tracker_channel,
+                               tracker_interface_function_t func)
+{
+  func(&tracker_channel->info, &tracker_channel->common_data,
+       tracker_channel->tracker->data);
+}
+
+/** Update the state of a tracker channel and its associated tracker instance.
+ *
+ * \note This function performs a release operation, meaning that it ensures
+ * all prior memory accesses have completed before updating state information.
+ *
+ * \param tracker_channel   Tracker channel to use.
+ * \param event             Event to process.
+ */
+static void event(tracker_channel_t *tracker_channel, event_t event)
+{
+  switch (event) {
+  case EVENT_ENABLE: {
+    assert(tracker_channel->state == STATE_DISABLED);
+    assert(tracker_channel->tracker->active == false);
+    tracker_channel->tracker->active = true;
+    /* Sequence point for enable is setting channel state = STATE_ENABLED */
+    COMPILER_BARRIER(); /* Prevent compiler reordering */
+    tracker_channel->state = STATE_ENABLED;
+  }
+  break;
+
+  case EVENT_DISABLE_REQUEST: {
+    assert(tracker_channel->state == STATE_ENABLED);
+    tracker_channel->state = STATE_DISABLE_REQUESTED;
+  }
+  break;
+
+  case EVENT_DISABLE: {
+    assert(tracker_channel->state == STATE_DISABLE_REQUESTED);
+    assert(tracker_channel->tracker->active == true);
+    /* Sequence point for disable is setting channel state = STATE_DISABLED
+     * and/or tracker active = false (order of these two is irrelevant here) */
+    COMPILER_BARRIER(); /* Prevent compiler reordering */
+    tracker_channel->tracker->active = false;
+    tracker_channel->state = STATE_DISABLED;
+  }
+  break;
+  }
+}
+
+/** Initialize a tracker common data structure.
+ *
+ * \param tracker_channel   Tracker channel to use.
+ * \param sample_count      Sample count.
+ * \param carrier_freq      Carrier frequency.
+ * \param cn0               C/N0 estimate.
+ */
+static void common_data_init(tracker_common_data_t *common_data,
+                             u32 sample_count, float carrier_freq, float cn0)
+{
+  /* Initialize all fields to 0 */
+  memset(common_data, 0, sizeof(tracker_common_data_t));
+
+  common_data->TOW_ms = TOW_INVALID;
+
+  /* Calculate code phase rate with carrier aiding. */
+  common_data->code_phase_rate = (1 + carrier_freq/GPS_L1_HZ) *
+                                    GPS_CA_CHIPPING_RATE;
+  common_data->carrier_freq = carrier_freq;
+
+  common_data->sample_count = sample_count;
+  common_data->cn0 = cn0;
+}
+
+/** Lock a tracker channel for exclusive access.
+ *
+ * \param tracker_channel   Tracker channel to use.
+ */
+static void tracker_channel_lock(tracker_channel_t *tracker_channel)
+{
+  chMtxLock(&tracker_channel->mutex);
+}
+
+/** Unlock a locked tracker channel.
+ *
+ * \param tracker_channel   Tracker channel to use.
+ */
+static void tracker_channel_unlock(tracker_channel_t *tracker_channel)
+{
+  Mutex *m = chMtxUnlock();
+  assert(m == &tracker_channel->mutex);
 }
 
 /** \} */

--- a/src/track.h
+++ b/src/track.h
@@ -52,20 +52,26 @@ typedef struct {
   bool valid;
 } nav_time_sync_t;
 
+typedef u32 update_count_t;
+
 /** Tracking channel parameters as of end of last correlation period. */
 typedef struct {
   u8 state;                    /**< Tracking channel state. */
   /* TODO : u32's big enough? */
-  u32 update_count;            /**< Number of ms channel has been running */
-  u32 mode_change_count;       /**< update_count at last mode change. */
-  u32 cn0_above_drop_thres_count;
+  update_count_t update_count; /**< Number of ms channel has been running */
+  update_count_t mode_change_count;
+                               /**< update_count at last mode change. */
+  update_count_t cn0_below_use_thres_count;
                                /**< update_count value when SNR was
-                                  last above a certain margin. */
-  u32 ld_opti_locked_count;    /**< update_count value when optimistic
+                                  last below the use threshold. */
+  update_count_t cn0_above_drop_thres_count;
+                               /**< update_count value when SNR was
+                                  last above the drop threshold. */
+  update_count_t ld_opti_locked_count;
+                               /**< update_count value when optimistic
                                   phase detector last "locked". */
   s32 TOW_ms;                  /**< TOW in ms. */
   u32 nav_bit_TOW_offset_ms;   /**< Time since last nav bit was appended to the nav bit FIFO */
-  u32 cn0_below_threshold_count;     /**< update_count value when SNR was last below a certain margin. */
   gnss_signal_t sid;           /**< Satellite signal being tracked. */
   u32 sample_count;            /**< Total num samples channel has tracked for. */
   u32 code_phase_early;        /**< Early code phase. */
@@ -122,6 +128,11 @@ void tracking_send_state(void);
 void tracking_setup(void);
 void tracking_drop_satellite(gnss_signal_t sid);
 bool tracking_channel_cn0_useable(u8 channel);
+u32 tracking_channel_running_time_ms_get(u8 channel);
+u32 tracking_channel_cn0_useable_ms_get(u8 channel);
+u32 tracking_channel_cn0_drop_ms_get(u8 channel);
+u32 tracking_channel_ld_opti_unlocked_ms_get(u8 channel);
+u32 tracking_channel_last_mode_change_ms_get(u8 channel);
 bool tracking_channel_nav_bit_get(u8 channel, s8 *soft_bit);
 bool tracking_channel_time_sync(u8 channel, s32 TOW_ms, s8 bit_polarity);
 

--- a/src/track.h
+++ b/src/track.h
@@ -70,6 +70,9 @@ typedef struct {
   update_count_t ld_opti_locked_count;
                                /**< update_count value when optimistic
                                   phase detector last "locked". */
+  update_count_t ld_pess_unlocked_count;
+                               /**< update_count value when pessimistic
+                                  phase detector last "unlocked". */
   s32 TOW_ms;                  /**< TOW in ms. */
   u32 nav_bit_TOW_offset_ms;   /**< Time since last nav bit was appended to the nav bit FIFO */
   gnss_signal_t sid;           /**< Satellite signal being tracked. */
@@ -132,6 +135,7 @@ u32 tracking_channel_running_time_ms_get(u8 channel);
 u32 tracking_channel_cn0_useable_ms_get(u8 channel);
 u32 tracking_channel_cn0_drop_ms_get(u8 channel);
 u32 tracking_channel_ld_opti_unlocked_ms_get(u8 channel);
+u32 tracking_channel_ld_pess_locked_ms_get(u8 channel);
 u32 tracking_channel_last_mode_change_ms_get(u8 channel);
 gnss_signal_t tracking_channel_sid_get(u8 channel);
 double tracking_channel_carrier_freq_get(u8 channel);

--- a/src/track.h
+++ b/src/track.h
@@ -38,7 +38,7 @@ void tracking_channel_init(u8 channel, gnss_signal_t sid, float carrier_freq,
                            u32 start_sample_count, float cn0_init, s8 elevation);
 bool tracking_channel_running(u8 channel);
 
-void tracking_channel_update(u8 channel);
+void tracking_channels_update(u32 channels_mask);
 void tracking_channel_disable(u8 channel);
 void tracking_channel_ambiguity_unknown(u8 channel);
 void tracking_update_measurement(u8 channel, channel_measurement_t *meas);

--- a/src/track.h
+++ b/src/track.h
@@ -116,7 +116,6 @@ s8 nav_bit_quantize(s32 bit_integrate);
 void tracking_channel_init(u8 channel, gnss_signal_t sid, float carrier_freq,
                            u32 start_sample_count, float cn0_init, s8 elevation);
 
-void tracking_channel_get_corrs(u8 channel);
 void tracking_channel_update(u8 channel);
 void tracking_channel_disable(u8 channel);
 void tracking_channel_ambiguity_unknown(u8 channel);

--- a/src/track.h
+++ b/src/track.h
@@ -35,13 +35,19 @@ void tracking_drop_satellite(gnss_signal_t sid);
 
 float propagate_code_phase(float code_phase, float carrier_freq, u32 n_samples);
 
+/* State management interface */
 bool tracking_channel_available(u8 channel, gnss_signal_t sid);
 void tracking_channel_init(u8 channel, gnss_signal_t sid, float carrier_freq,
                            u32 start_sample_count, float cn0_init, s8 elevation);
 void tracking_channel_disable(u8 channel);
 
+/* Update interface */
 void tracking_channels_update(u32 channels_mask);
 
+/* Tracking parameters interface.
+ * Lock should be acquired for atomicity. */
+void tracking_channel_lock(u8 channel);
+void tracking_channel_unlock(u8 channel);
 
 bool tracking_channel_running(u8 channel);
 bool tracking_channel_cn0_useable(u8 channel);

--- a/src/track.h
+++ b/src/track.h
@@ -108,8 +108,6 @@ typedef struct {
 /* TODO: NAP_MAX_N_TRACK_CHANNELS is a duplicate of MAX_CHANNELS */
 extern tracking_channel_t tracking_channel[NAP_MAX_N_TRACK_CHANNELS];
 
-void initialize_lock_counters(void);
-
 float propagate_code_phase(float code_phase, float carrier_freq, u32 n_samples);
 s8 nav_bit_quantize(s32 bit_integrate);
 

--- a/src/track.h
+++ b/src/track.h
@@ -142,6 +142,8 @@ double tracking_channel_carrier_freq_get(u8 channel);
 s32 tracking_channel_tow_ms_get(u8 channel);
 bool tracking_channel_bit_sync_resolved(u8 channel);
 bool tracking_channel_bit_polarity_resolved(u8 channel);
+bool tracking_channel_evelation_degrees_set(gnss_signal_t sid, s8 elevation);
+s8 tracking_channel_evelation_degrees_get(u8 channel);
 bool tracking_channel_nav_bit_get(u8 channel, s8 *soft_bit);
 bool tracking_channel_time_sync(u8 channel, s32 TOW_ms, s8 bit_polarity);
 

--- a/src/track.h
+++ b/src/track.h
@@ -18,9 +18,7 @@
 #include <libswiftnav/nav_msg.h>
 #include <libswiftnav/track.h>
 #include <libswiftnav/signal.h>
-#include <libswiftnav/bit_sync.h>
 
-#include "board/nap/nap_common.h"
 #include "board/nap/track_channel.h"
 
 /** \addtogroup tracking
@@ -30,21 +28,22 @@
 
 /** \} */
 
+void tracking_setup(void);
+
+void tracking_send_state(void);
+void tracking_drop_satellite(gnss_signal_t sid);
+
 float propagate_code_phase(float code_phase, float carrier_freq, u32 n_samples);
-s8 nav_bit_quantize(s32 bit_integrate);
 
 bool tracking_channel_available(u8 channel, gnss_signal_t sid);
 void tracking_channel_init(u8 channel, gnss_signal_t sid, float carrier_freq,
                            u32 start_sample_count, float cn0_init, s8 elevation);
-bool tracking_channel_running(u8 channel);
+void tracking_channel_disable(u8 channel);
 
 void tracking_channels_update(u32 channels_mask);
-void tracking_channel_disable(u8 channel);
-void tracking_channel_ambiguity_unknown(u8 channel);
-void tracking_update_measurement(u8 channel, channel_measurement_t *meas);
-void tracking_send_state(void);
-void tracking_setup(void);
-void tracking_drop_satellite(gnss_signal_t sid);
+
+
+bool tracking_channel_running(u8 channel);
 bool tracking_channel_cn0_useable(u8 channel);
 u32 tracking_channel_running_time_ms_get(u8 channel);
 u32 tracking_channel_cn0_useable_ms_get(u8 channel);
@@ -57,8 +56,12 @@ double tracking_channel_carrier_freq_get(u8 channel);
 s32 tracking_channel_tow_ms_get(u8 channel);
 bool tracking_channel_bit_sync_resolved(u8 channel);
 bool tracking_channel_bit_polarity_resolved(u8 channel);
+void tracking_channel_measurement_get(u8 channel, channel_measurement_t *meas);
+
 bool tracking_channel_evelation_degrees_set(gnss_signal_t sid, s8 elevation);
 s8 tracking_channel_evelation_degrees_get(u8 channel);
+
+/* Decoder interface */
 bool tracking_channel_nav_bit_get(u8 channel, s8 *soft_bit);
 bool tracking_channel_time_sync(u8 channel, s32 TOW_ms, s8 bit_polarity);
 

--- a/src/track.h
+++ b/src/track.h
@@ -121,6 +121,7 @@ void tracking_update_measurement(u8 channel, channel_measurement_t *meas);
 void tracking_send_state(void);
 void tracking_setup(void);
 void tracking_drop_satellite(gnss_signal_t sid);
+bool tracking_channel_cn0_useable(u8 channel);
 bool tracking_channel_nav_bit_get(u8 channel, s8 *soft_bit);
 bool tracking_channel_time_sync(u8 channel, s32 TOW_ms, s8 bit_polarity);
 

--- a/src/track.h
+++ b/src/track.h
@@ -133,6 +133,11 @@ u32 tracking_channel_cn0_useable_ms_get(u8 channel);
 u32 tracking_channel_cn0_drop_ms_get(u8 channel);
 u32 tracking_channel_ld_opti_unlocked_ms_get(u8 channel);
 u32 tracking_channel_last_mode_change_ms_get(u8 channel);
+gnss_signal_t tracking_channel_sid_get(u8 channel);
+double tracking_channel_carrier_freq_get(u8 channel);
+s32 tracking_channel_tow_ms_get(u8 channel);
+bool tracking_channel_bit_sync_resolved(u8 channel);
+bool tracking_channel_bit_polarity_resolved(u8 channel);
 bool tracking_channel_nav_bit_get(u8 channel, s8 *soft_bit);
 bool tracking_channel_time_sync(u8 channel, s32 TOW_ms, s8 bit_polarity);
 

--- a/src/track.h
+++ b/src/track.h
@@ -26,102 +26,17 @@
 /** \addtogroup tracking
  * \{ */
 
-#define TRACKING_DISABLED 0 /**< Tracking channel disabled state. */
-#define TRACKING_RUNNING  1 /**< Tracking channel running state. */
 #define TRACKING_ELEVATION_UNKNOWN 100 /* Ensure it will be above elev. mask */
-extern u8 n_rollovers;
-
-#define NAV_BIT_FIFO_SIZE 32 /**< Size of nav bit FIFO. Must be a power of 2 */
-
-typedef struct {
-  s8 soft_bit;
-} nav_bit_fifo_element_t;
-
-typedef u8 nav_bit_fifo_index_t;
-
-typedef struct {
-  nav_bit_fifo_index_t read_index;
-  nav_bit_fifo_index_t write_index;
-  nav_bit_fifo_element_t elements[NAV_BIT_FIFO_SIZE];
-} nav_bit_fifo_t;
-
-typedef struct {
-  s32 TOW_ms;
-  s8 bit_polarity;
-  nav_bit_fifo_index_t read_index;
-  bool valid;
-} nav_time_sync_t;
-
-typedef u32 update_count_t;
-
-/** Tracking channel parameters as of end of last correlation period. */
-typedef struct {
-  u8 state;                    /**< Tracking channel state. */
-  /* TODO : u32's big enough? */
-  update_count_t update_count; /**< Number of ms channel has been running */
-  update_count_t mode_change_count;
-                               /**< update_count at last mode change. */
-  update_count_t cn0_below_use_thres_count;
-                               /**< update_count value when SNR was
-                                  last below the use threshold. */
-  update_count_t cn0_above_drop_thres_count;
-                               /**< update_count value when SNR was
-                                  last above the drop threshold. */
-  update_count_t ld_opti_locked_count;
-                               /**< update_count value when optimistic
-                                  phase detector last "locked". */
-  update_count_t ld_pess_unlocked_count;
-                               /**< update_count value when pessimistic
-                                  phase detector last "unlocked". */
-  s32 TOW_ms;                  /**< TOW in ms. */
-  u32 nav_bit_TOW_offset_ms;   /**< Time since last nav bit was appended to the nav bit FIFO */
-  gnss_signal_t sid;           /**< Satellite signal being tracked. */
-  u32 sample_count;            /**< Total num samples channel has tracked for. */
-  u32 code_phase_early;        /**< Early code phase. */
-  aided_tl_state_t tl_state;   /**< Tracking loop filter state. */
-  double code_phase_rate;      /**< Code phase rate in chips/s. */
-  u32 code_phase_rate_fp;      /**< Code phase rate in NAP register units. */
-  u32 code_phase_rate_fp_prev; /**< Previous code phase rate in NAP register units. */
-  s64 carrier_phase;           /**< Carrier phase in NAP register units. */
-  s32 carrier_freq_fp;         /**< Carrier frequency in NAP register units. */
-  s32 carrier_freq_fp_prev;    /**< Previous carrier frequency in NAP register units. */
-  double carrier_freq;         /**< Carrier frequency Hz. */
-  u32 corr_sample_count;       /**< Number of samples in correlation period. */
-  corr_t cs[3];                /**< EPL correlation results in correlation period. */
-  bit_sync_t bit_sync;         /**< Bit sync state. */
-  s8 bit_polarity;             /**< Polarity of nav message bits. */
-  u16 lock_counter;            /**< Lock counter. Increments when tracking new signal. */
-  cn0_est_state_t cn0_est;     /**< C/N0 Estimator. */
-  float cn0;                   /**< Current estimate of C/N0. */
-  u8 int_ms;                   /**< Integration length. */
-  u8 next_int_ms;              /**< Integration length for the next cycle. */
-  bool short_cycle;            /**< Set to true when a short 1ms integration is requested. */
-  bool output_iq;              /**< Set if this channel should output I/Q samples on SBP. */
-  u8 stage;                    /**< 0 = First-stage. 1 ms integration.
-                                    1 = Second-stage. After nav bit sync,
-                                    retune loop filters and typically (but
-                                    not necessarily) use longer integration. */
-  s8 elevation;                /**< Elevation angle, degrees */
-  alias_detect_t alias_detect; /**< Alias lock detector. */
-  lock_detect_t lock_detect;   /**< Phase-lock detector state. */
-  nav_bit_fifo_t nav_bit_fifo; /**< FIFO for navigation message bits. */
-  nav_time_sync_t nav_time_sync;  /**< Used to sync time decoded from navigation
-                                       message back to tracking channel. */
-} tracking_channel_t;
 
 /** \} */
-
-/* Assuming we will never have a greater number of tracking channels than 12
- * We have to declare the number here as the number of tracking channels in
- * the FPGA is read at runtime. */
-/* TODO: NAP_MAX_N_TRACK_CHANNELS is a duplicate of MAX_CHANNELS */
-extern tracking_channel_t tracking_channel[NAP_MAX_N_TRACK_CHANNELS];
 
 float propagate_code_phase(float code_phase, float carrier_freq, u32 n_samples);
 s8 nav_bit_quantize(s32 bit_integrate);
 
+bool tracking_channel_available(u8 channel, gnss_signal_t sid);
 void tracking_channel_init(u8 channel, gnss_signal_t sid, float carrier_freq,
                            u32 start_sample_count, float cn0_init, s8 elevation);
+bool tracking_channel_running(u8 channel);
 
 void tracking_channel_update(u8 channel);
 void tracking_channel_disable(u8 channel);

--- a/src/track.h
+++ b/src/track.h
@@ -1,6 +1,7 @@
 /*
- * Copyright (C) 2011-2014 Swift Navigation Inc.
+ * Copyright (C) 2011-2016 Swift Navigation Inc.
  * Contact: Fergus Noble <fergus@swift-nav.com>
+ * Contact: Jacob McNamee <jacob@swiftnav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
  * be be distributed together with this source. All other rights reserved.
@@ -19,6 +20,8 @@
 #include <libswiftnav/track.h>
 #include <libswiftnav/signal.h>
 
+#include <ch.h>
+
 #include "board/nap/track_channel.h"
 
 /** \addtogroup tracking
@@ -26,49 +29,53 @@
 
 #define TRACKING_ELEVATION_UNKNOWN 100 /* Ensure it will be above elev. mask */
 
+typedef u8 tracker_channel_id_t;
+
 /** \} */
 
-void tracking_setup(void);
+void track_setup(void);
 
 void tracking_send_state(void);
-void tracking_drop_satellite(gnss_signal_t sid);
 
 float propagate_code_phase(float code_phase, float carrier_freq, u32 n_samples);
-
-/* State management interface */
-bool tracking_channel_available(u8 channel, gnss_signal_t sid);
-void tracking_channel_init(u8 channel, gnss_signal_t sid, float carrier_freq,
-                           u32 start_sample_count, float cn0_init, s8 elevation);
-void tracking_channel_disable(u8 channel);
 
 /* Update interface */
 void tracking_channels_update(u32 channels_mask);
 
+/* State management interface */
+bool tracker_channel_available(tracker_channel_id_t id, gnss_signal_t sid);
+bool tracker_channel_init(tracker_channel_id_t id, gnss_signal_t sid,
+                          float carrier_freq,  u32 start_sample_count,
+                          float cn0_init, s8 elevation);
+bool tracker_channel_disable(tracker_channel_id_t id);
+
 /* Tracking parameters interface.
  * Lock should be acquired for atomicity. */
-void tracking_channel_lock(u8 channel);
-void tracking_channel_unlock(u8 channel);
+void tracking_channel_lock(tracker_channel_id_t id);
+void tracking_channel_unlock(tracker_channel_id_t id);
 
-bool tracking_channel_running(u8 channel);
-bool tracking_channel_cn0_useable(u8 channel);
-u32 tracking_channel_running_time_ms_get(u8 channel);
-u32 tracking_channel_cn0_useable_ms_get(u8 channel);
-u32 tracking_channel_cn0_drop_ms_get(u8 channel);
-u32 tracking_channel_ld_opti_unlocked_ms_get(u8 channel);
-u32 tracking_channel_ld_pess_locked_ms_get(u8 channel);
-u32 tracking_channel_last_mode_change_ms_get(u8 channel);
-gnss_signal_t tracking_channel_sid_get(u8 channel);
-double tracking_channel_carrier_freq_get(u8 channel);
-s32 tracking_channel_tow_ms_get(u8 channel);
-bool tracking_channel_bit_sync_resolved(u8 channel);
-bool tracking_channel_bit_polarity_resolved(u8 channel);
-void tracking_channel_measurement_get(u8 channel, channel_measurement_t *meas);
+bool tracking_channel_running(tracker_channel_id_t id);
+float tracking_channel_cn0_get(tracker_channel_id_t id);
+u32 tracking_channel_running_time_ms_get(tracker_channel_id_t id);
+u32 tracking_channel_cn0_useable_ms_get(tracker_channel_id_t id);
+u32 tracking_channel_cn0_drop_ms_get(tracker_channel_id_t id);
+u32 tracking_channel_ld_opti_unlocked_ms_get(tracker_channel_id_t id);
+u32 tracking_channel_ld_pess_locked_ms_get(tracker_channel_id_t id);
+u32 tracking_channel_last_mode_change_ms_get(tracker_channel_id_t id);
+gnss_signal_t tracking_channel_sid_get(tracker_channel_id_t id);
+double tracking_channel_carrier_freq_get(tracker_channel_id_t id);
+s32 tracking_channel_tow_ms_get(tracker_channel_id_t id);
+bool tracking_channel_bit_sync_resolved(tracker_channel_id_t id);
+bool tracking_channel_bit_polarity_resolved(tracker_channel_id_t id);
+void tracking_channel_measurement_get(tracker_channel_id_t id,
+                                      channel_measurement_t *meas);
 
 bool tracking_channel_evelation_degrees_set(gnss_signal_t sid, s8 elevation);
-s8 tracking_channel_evelation_degrees_get(u8 channel);
+s8 tracking_channel_evelation_degrees_get(tracker_channel_id_t id);
 
 /* Decoder interface */
-bool tracking_channel_nav_bit_get(u8 channel, s8 *soft_bit);
-bool tracking_channel_time_sync(u8 channel, s32 TOW_ms, s8 bit_polarity);
+bool tracking_channel_nav_bit_get(tracker_channel_id_t id, s8 *soft_bit);
+bool tracking_channel_time_sync(tracker_channel_id_t id, s32 TOW_ms,
+                                s8 bit_polarity);
 
 #endif

--- a/src/track_api.c
+++ b/src/track_api.c
@@ -1,0 +1,255 @@
+/*
+ * Copyright (C) 2016 Swift Navigation Inc.
+ * Contact: Jacob McNamee <jacob@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "track_api.h"
+#include "track_internal.h"
+#include "track.h"
+
+#include <libswiftnav/constants.h>
+#include <libswiftnav/logging.h>
+
+#include <ch.h>
+#include <assert.h>
+
+#include "sbp.h"
+#include "sbp_utils.h"
+#include "signal.h"
+
+/** \defgroup track_api Tracking API
+ * API functions used by tracking channel implementations.
+ * \{ */
+
+#define GPS_WEEK_LENGTH_ms (1000 * WEEK_SECS)
+
+/** Register a tracker interface to enable tracking for a code type.
+ *
+ * \note element and all subordinate data must be statically allocated!
+ *
+ * \param element   Struct describing the interface to register.
+ */
+void tracker_interface_register(tracker_interface_list_element_t *element)
+{
+  /* p_next = address of next pointer which must be updated */
+  tracker_interface_list_element_t **p_next = tracker_interface_list_ptr_get();
+
+  while (*p_next != 0)
+    p_next = &(*p_next)->next;
+
+  element->next = 0;
+  *p_next = element;
+}
+
+/** Read correlations from the NAP for a tracker channel.
+ *
+ * \param context         Tracker context.
+ * \param cs              Output array of correlations.
+ * \param sample_count    Output sample count.
+ */
+void tracker_correlations_read(tracker_context_t *context, corr_t *cs,
+                               u32 *sample_count)
+{
+  const tracker_channel_info_t *channel_info;
+  tracker_internal_data_t *internal_data;
+  tracker_internal_context_resolve(context, &channel_info, &internal_data);
+
+  /* Read NAP CORR register */
+  nap_track_corr_rd_blocking(channel_info->nap_channel, sample_count, cs);
+}
+
+/** Write the NAP update register for a tracker channel.
+ *
+ * \param context             Tracker context.
+ * \param carrier_freq_fp     Carrier frequency in NAP register units.
+ * \param code_phase_rate_fp  Code phase rate in NAP register units.
+ * \param rollover_count      Number of code cycles to integrate over.
+ */
+void tracker_retune(tracker_context_t *context, s32 carrier_freq_fp,
+                    u32 code_phase_rate_fp, u8 rollover_count)
+{
+  const tracker_channel_info_t *channel_info;
+  tracker_internal_data_t *internal_data;
+  tracker_internal_context_resolve(context, &channel_info, &internal_data);
+
+  /* Write NAP UPDATE register. */
+  nap_track_update_wr_blocking(channel_info->nap_channel, carrier_freq_fp,
+                               code_phase_rate_fp, rollover_count, 0);
+}
+
+/** Update the TOW for a tracker channel.
+ *
+ * \param context           Tracker context.
+ * \param current_TOW_ms    Current TOW (ms).
+ * \param int_ms            Integration period (ms).
+ *
+ * \return Updated TOW (ms).
+ */
+s32 tracker_tow_update(tracker_context_t *context, s32 current_TOW_ms,
+                       u32 int_ms)
+{
+  const tracker_channel_info_t *channel_info;
+  tracker_internal_data_t *internal_data;
+  tracker_internal_context_resolve(context, &channel_info, &internal_data);
+
+  /* Latch TOW from nav message if pending */
+  s32 pending_TOW_ms;
+  s8 pending_bit_polarity;
+  nav_bit_fifo_index_t pending_TOW_read_index;
+  if (nav_time_sync_get(&internal_data->nav_time_sync, &pending_TOW_ms,
+                        &pending_bit_polarity, &pending_TOW_read_index)) {
+
+    /* Compute time since the pending data was read from the FIFO */
+    nav_bit_fifo_index_t fifo_length =
+      NAV_BIT_FIFO_INDEX_DIFF(internal_data->nav_bit_fifo.write_index,
+                              pending_TOW_read_index);
+    u32 fifo_time_diff_ms = fifo_length * internal_data->bit_sync.bit_length;
+
+    /* Add full bit times + fractional bit time to the specified TOW */
+    s32 TOW_ms = pending_TOW_ms + fifo_time_diff_ms +
+                   internal_data->nav_bit_TOW_offset_ms;
+
+    if (TOW_ms >= GPS_WEEK_LENGTH_ms)
+      TOW_ms -= GPS_WEEK_LENGTH_ms;
+
+    /* Warn if updated TOW does not match the current value */
+    if ((current_TOW_ms != TOW_INVALID) && (current_TOW_ms != TOW_ms)) {
+      char buf[SID_STR_LEN_MAX];
+      sid_to_string(buf, sizeof(buf), channel_info->sid);
+      log_warn("%s TOW mismatch: %ld, %lu", buf, current_TOW_ms, TOW_ms);
+    }
+    current_TOW_ms = TOW_ms;
+    internal_data->bit_polarity = pending_bit_polarity;
+  }
+
+  internal_data->nav_bit_TOW_offset_ms += int_ms;
+
+  if (current_TOW_ms != TOW_INVALID) {
+    /* Have a valid time of week - increment it. */
+    current_TOW_ms += int_ms;
+    if (current_TOW_ms >= GPS_WEEK_LENGTH_ms)
+      current_TOW_ms -= GPS_WEEK_LENGTH_ms;
+    /* TODO: maybe keep track of week number in channel state, or
+       derive it from system time */
+  }
+
+  return current_TOW_ms;
+}
+
+/** Update bit sync and output navigation message bits for a tracker channel.
+ *
+ * \param context           Tracker context.
+ * \param int_ms            Integration period (ms).
+ * \param corr_prompt_real  Real part of the prompt correlation.
+ */
+void tracker_bit_sync_update(tracker_context_t *context, u32 int_ms,
+                             s32 corr_prompt_real)
+{
+  const tracker_channel_info_t *channel_info;
+  tracker_internal_data_t *internal_data;
+  tracker_internal_context_resolve(context, &channel_info, &internal_data);
+
+  /* Update bit sync */
+  s32 bit_integrate;
+  if (bit_sync_update(&internal_data->bit_sync, corr_prompt_real, int_ms,
+                      &bit_integrate)) {
+
+    s8 soft_bit = nav_bit_quantize(bit_integrate);
+
+    // write to FIFO
+    nav_bit_fifo_element_t element = { .soft_bit = soft_bit };
+    if (!nav_bit_fifo_write(&internal_data->nav_bit_fifo, &element)) {
+      char buf[SID_STR_LEN_MAX];
+      sid_to_string(buf, sizeof(buf), channel_info->sid);
+      log_warn("%s nav bit FIFO overrun", buf);
+    }
+
+    // clear nav bit TOW offset
+    internal_data->nav_bit_TOW_offset_ms = 0;
+  }
+}
+
+/** Get the bit length for a tracker channel.
+ *
+ * \param context     Tracker context.
+ *
+ * \return Bit length
+ */
+u8 tracker_bit_length_get(tracker_context_t *context)
+{
+  const tracker_channel_info_t *channel_info;
+    tracker_internal_data_t *internal_data;
+    tracker_internal_context_resolve(context, &channel_info, &internal_data);
+
+    return internal_data->bit_sync.bit_length;
+}
+
+/** Get the bit alignment state for a tracker channel.
+ *
+ * \param context     Tracker context.
+ *
+ * \return true if bit sync has been established and the most recent
+ *         integration is bit aligned, false otherwise.
+ */
+bool tracker_bit_aligned(tracker_context_t *context)
+{
+  const tracker_channel_info_t *channel_info;
+    tracker_internal_data_t *internal_data;
+    tracker_internal_context_resolve(context, &channel_info, &internal_data);
+
+  return (internal_data->bit_sync.bit_phase ==
+            internal_data->bit_sync.bit_phase_ref);
+}
+
+/** Sets a channel's carrier phase ambiguity to unknown.
+ * Changes the lock counter to indicate to the consumer of the tracking channel
+ * observations that the carrier phase ambiguity may have changed. Also
+ * invalidates the half cycle ambiguity, which must be resolved again by the navigation
+ *  message processing. Should be called if a cycle slip is suspected.
+ *
+ * \param context     Tracker context.
+ */
+void tracker_ambiguity_unknown(tracker_context_t *context)
+{
+  const tracker_channel_info_t *channel_info;
+  tracker_internal_data_t *internal_data;
+  tracker_internal_context_resolve(context, &channel_info, &internal_data);
+
+  internal_data->bit_polarity = BIT_POLARITY_UNKNOWN;
+  internal_data->lock_counter =
+      tracking_lock_counter_increment(channel_info->sid);
+}
+
+/** Output a correlation data message for a tracker channel.
+ *
+ * \param context     Tracker context.
+ * \param cs          Array of correlations to send.
+ */
+void tracker_correlations_send(tracker_context_t *context, const corr_t *cs)
+{
+  const tracker_channel_info_t *channel_info;
+  tracker_internal_data_t *internal_data;
+  tracker_internal_context_resolve(context, &channel_info, &internal_data);
+
+  /* Output I/Q correlations using SBP if enabled for this channel */
+  if (internal_data->output_iq) {
+    msg_tracking_iq_t msg = {
+      .channel = channel_info->nap_channel,
+    };
+    msg.sid = sid_to_sbp(channel_info->sid);
+    for (u32 i = 0; i < 3; i++) {
+      msg.corrs[i].I = cs[i].I;
+      msg.corrs[i].Q = cs[i].Q;
+    }
+    sbp_send_msg(SBP_MSG_TRACKING_IQ, sizeof(msg), (u8*)&msg);
+  }
+}
+
+/** \} */

--- a/src/track_api.h
+++ b/src/track_api.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2016 Swift Navigation Inc.
+ * Contact: Jacob McNamee <jacob@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+#ifndef SWIFTNAV_TRACK_API_H
+#define SWIFTNAV_TRACK_API_H
+
+#include <libswiftnav/common.h>
+#include <libswiftnav/signal.h>
+
+#include "board/nap/nap_common.h"
+#include "board/nap/track_channel.h"
+
+/** \addtogroup track_api
+ * \{ */
+
+typedef u32 update_count_t;
+
+typedef struct {
+  update_count_t update_count; /**< Number of ms channel has been running */
+  update_count_t mode_change_count;
+                               /**< update_count at last mode change. */
+  update_count_t cn0_below_use_thres_count;
+                               /**< update_count value when SNR was
+                                    last below the use threshold. */
+  update_count_t cn0_above_drop_thres_count;
+                               /**< update_count value when SNR was
+                                    last above the drop threshold. */
+  update_count_t ld_opti_locked_count;
+                               /**< update_count value when optimistic
+                                    phase detector last "locked". */
+  update_count_t ld_pess_unlocked_count;
+                               /**< update_count value when pessimistic
+                                    phase detector last "unlocked". */
+  s32 TOW_ms;                  /**< TOW in ms. */
+  u32 sample_count;            /**< Total num samples channel has tracked for. */
+  u32 code_phase_early;        /**< Early code phase. */
+  double code_phase_rate;      /**< Code phase rate in chips/s. */
+  s64 carrier_phase;           /**< Carrier phase in NAP register units. */
+  double carrier_freq;         /**< Carrier frequency Hz. */
+  float cn0;                   /**< Current estimate of C/N0. */
+} tracker_common_data_t;
+
+typedef void tracker_data_t;
+typedef void tracker_context_t;
+
+/** Instance of a tracker implementation. */
+typedef struct {
+  /** true if tracker is in use. */
+  bool active;
+  /** Pointer to implementation-specific data used by tracker instance. */
+  tracker_data_t *data;
+} tracker_t;
+
+/** Info associated with a tracker channel. */
+typedef struct {
+  gnss_signal_t sid;            /**< Current signal being decoded. */
+  u8 nap_channel;               /**< Associated NAP channel. */
+  tracker_context_t *context;   /**< Current context for library functions. */
+} tracker_channel_info_t;
+
+/** Tracker interface function template. */
+typedef void (*tracker_interface_function_t)(
+                 const tracker_channel_info_t *channel_info,
+                 tracker_common_data_t *common_data,
+                 tracker_data_t *tracker_data);
+
+/** Interface to a tracker implementation. */
+typedef struct {
+  /** Code type for which the implementation may be used. */
+  enum code code;
+  /** Init function. Called to set up tracker instance when tracking begins. */
+  tracker_interface_function_t init;
+  /** Disable function. Called when tracking stops. */
+  tracker_interface_function_t disable;
+  /** Update function. Called when new correlation outputs are available. */
+  tracker_interface_function_t update;
+  /** Array of tracker instances used by this interface. */
+  tracker_t *trackers;
+  /** Number of tracker instances in trackers array. */
+  u8 num_trackers;
+} tracker_interface_t;
+
+/** List element passed to tracker_interface_register(). */
+typedef struct tracker_interface_list_element_t {
+  const tracker_interface_t *interface;
+  struct tracker_interface_list_element_t *next;
+} tracker_interface_list_element_t;
+
+/** \} */
+
+void tracker_interface_register(tracker_interface_list_element_t *element);
+
+/* Tracker instance API functions. Must be called from within an
+ * interface function. */
+void tracker_correlations_read(tracker_context_t *context, corr_t *cs,
+                               u32 *sample_count);
+void tracker_retune(tracker_context_t *context, s32 carrier_freq_fp,
+                    u32 code_phase_rate_fp, u8 rollover_count);
+s32 tracker_tow_update(tracker_context_t *context, s32 current_TOW_ms,
+                       u32 int_ms);
+void tracker_bit_sync_update(tracker_context_t *context, u32 int_ms,
+                             s32 corr_prompt_real);
+u8 tracker_bit_length_get(tracker_context_t *context);
+bool tracker_bit_aligned(tracker_context_t *context);
+void tracker_ambiguity_unknown(tracker_context_t *context);
+void tracker_correlations_send(tracker_context_t *context, const corr_t *cs);
+
+#endif

--- a/src/track_gps_l1ca.c
+++ b/src/track_gps_l1ca.c
@@ -1,0 +1,437 @@
+/*
+ * Copyright (C) 2016 Swift Navigation Inc.
+ * Contact: Jacob McNamee <jacob@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "track_gps_l1ca.h"
+#include "track_api.h"
+
+#include <libswiftnav/constants.h>
+#include <libswiftnav/logging.h>
+#include <libswiftnav/signal.h>
+#include <libswiftnav/track.h>
+
+#include <string.h>
+
+#include "settings.h"
+
+#define NUM_GPS_L1CA_TRACKERS   12
+
+/*  code: nbw zeta k carr_to_code
+ carrier:                    nbw  zeta k fll_aid */
+#define LOOP_PARAMS_SLOW \
+  "(1 ms, (1, 0.7, 1, 1540), (10, 0.7, 1, 5))," \
+ "(20 ms, (1, 0.7, 1, 1540), (12, 0.7, 1, 0))"
+
+#define LOOP_PARAMS_MED \
+  "(1 ms, (1, 0.7, 1, 1540), (10, 0.7, 1, 5))," \
+  "(5 ms, (1, 0.7, 1, 1540), (50, 0.7, 1, 0))"
+
+#define LOOP_PARAMS_FAST \
+  "(1 ms, (1, 0.7, 1, 1540), (40, 0.7, 1, 5))," \
+  "(4 ms, (1, 0.7, 1, 1540), (62, 0.7, 1, 0))"
+
+#define LOOP_PARAMS_EXTRAFAST \
+  "(1 ms, (1, 0.7, 1, 1540), (50, 0.7, 1, 5))," \
+  "(2 ms, (1, 0.7, 1, 1540), (100, 0.7, 1, 0))"
+
+/*                          k1,   k2,  lp,  lo */
+#define LD_PARAMS_PESS     "0.10, 1.4, 200, 50"
+#define LD_PARAMS_NORMAL   "0.05, 1.4, 150, 50"
+#define LD_PARAMS_OPT      "0.02, 1.1, 150, 50"
+#define LD_PARAMS_EXTRAOPT "0.02, 0.8, 150, 50"
+#define LD_PARAMS_DISABLE  "0.02, 1e-6, 1, 1"
+
+#define CN0_EST_LPF_CUTOFF 5
+
+static struct loop_params {
+  float code_bw, code_zeta, code_k, carr_to_code;
+  float carr_bw, carr_zeta, carr_k, carr_fll_aid_gain;
+  u8 coherent_ms;
+} loop_params_stage[2];
+
+static struct lock_detect_params {
+  float k1, k2;
+  u16 lp, lo;
+} lock_detect_params;
+
+static float track_cn0_use_thres = 31.0; /* dBHz */
+static float track_cn0_drop_thres = 31.0;
+
+static char loop_params_string[120] = LOOP_PARAMS_MED;
+static char lock_detect_params_string[24] = LD_PARAMS_DISABLE;
+static bool use_alias_detection = true;
+
+typedef struct {
+  aided_tl_state_t tl_state;   /**< Tracking loop filter state. */
+  u32 code_phase_rate_fp;      /**< Code phase rate in NAP register units. */
+  u32 code_phase_rate_fp_prev; /**< Previous code phase rate in NAP register units. */
+  s32 carrier_freq_fp;         /**< Carrier frequency in NAP register units. */
+  s32 carrier_freq_fp_prev;    /**< Previous carrier frequency in NAP register units. */
+  u32 corr_sample_count;       /**< Number of samples in correlation period. */
+  corr_t cs[3];                /**< EPL correlation results in correlation period. */
+  cn0_est_state_t cn0_est;     /**< C/N0 Estimator. */
+  u8 int_ms;                   /**< Integration length. */
+  bool short_cycle;            /**< Set to true when a short 1ms integration is requested. */
+  u8 stage;                    /**< 0 = First-stage. 1 ms integration.
+                                    1 = Second-stage. After nav bit sync,
+                                    retune loop filters and typically (but
+                                    not necessarily) use longer integration. */
+  alias_detect_t alias_detect; /**< Alias lock detector. */
+  lock_detect_t lock_detect;   /**< Phase-lock detector state. */
+} gps_l1ca_tracker_data_t;
+
+static tracker_t gps_l1ca_trackers[NUM_GPS_L1CA_TRACKERS];
+static gps_l1ca_tracker_data_t gps_l1ca_tracker_data[NUM_GPS_L1CA_TRACKERS];
+
+static void tracker_gps_l1ca_init(const tracker_channel_info_t *channel_info,
+                                  tracker_common_data_t *common_data,
+                                  tracker_data_t *tracker_data);
+static void tracker_gps_l1ca_disable(const tracker_channel_info_t *channel_info,
+                                     tracker_common_data_t *common_data,
+                                     tracker_data_t *tracker_data);
+static void tracker_gps_l1ca_update(const tracker_channel_info_t *channel_info,
+                                    tracker_common_data_t *common_data,
+                                    tracker_data_t *tracker_data);
+
+static bool parse_loop_params(struct setting *s, const char *val);
+static bool parse_lock_detect_params(struct setting *s, const char *val);
+
+static const tracker_interface_t tracker_interface_gps_l1ca = {
+  .code =         CODE_GPS_L1CA,
+  .init =         tracker_gps_l1ca_init,
+  .disable =      tracker_gps_l1ca_disable,
+  .update =       tracker_gps_l1ca_update,
+  .trackers =     gps_l1ca_trackers,
+  .num_trackers = NUM_GPS_L1CA_TRACKERS
+};
+
+static tracker_interface_list_element_t
+tracker_interface_list_element_gps_l1ca = {
+  .interface = &tracker_interface_gps_l1ca,
+  .next = 0
+};
+
+void track_gps_l1ca_register(void)
+{
+  SETTING_NOTIFY("track", "loop_params", loop_params_string,
+                 TYPE_STRING, parse_loop_params);
+  SETTING_NOTIFY("track", "lock_detect_params", lock_detect_params_string,
+                 TYPE_STRING, parse_lock_detect_params);
+  SETTING("track", "cn0_use", track_cn0_use_thres, TYPE_FLOAT);
+  SETTING("track", "cn0_drop", track_cn0_drop_thres, TYPE_FLOAT);
+  SETTING("track", "alias_detect", use_alias_detection, TYPE_BOOL);
+
+  for (u32 i=0; i<NUM_GPS_L1CA_TRACKERS; i++) {
+    gps_l1ca_trackers[i].active = false;
+    gps_l1ca_trackers[i].data = &gps_l1ca_tracker_data[i];
+  }
+
+  tracker_interface_register(&tracker_interface_list_element_gps_l1ca);
+}
+
+static void tracker_gps_l1ca_init(const tracker_channel_info_t *channel_info,
+                                  tracker_common_data_t *common_data,
+                                  tracker_data_t *tracker_data)
+{
+  (void)channel_info;
+  gps_l1ca_tracker_data_t *data = tracker_data;
+
+  memset(data, 0, sizeof(gps_l1ca_tracker_data_t));
+  tracker_ambiguity_unknown(channel_info->context);
+
+  const struct loop_params *l = &loop_params_stage[0];
+
+  /* Note: The only coherent integration interval currently supported
+     for first-stage tracking (i.e. loop_params_stage[0].coherent_ms)
+     is 1. */
+  data->int_ms = MIN(l->coherent_ms,
+                     tracker_bit_length_get(channel_info->context));
+
+  aided_tl_init(&(data->tl_state), 1e3 / data->int_ms,
+                common_data->code_phase_rate - GPS_CA_CHIPPING_RATE,
+                l->code_bw, l->code_zeta, l->code_k,
+                l->carr_to_code,
+                common_data->carrier_freq,
+                l->carr_bw, l->carr_zeta, l->carr_k,
+                l->carr_fll_aid_gain);
+
+  data->code_phase_rate_fp = common_data->code_phase_rate*NAP_TRACK_CODE_PHASE_RATE_UNITS_PER_HZ;
+  data->code_phase_rate_fp_prev = data->code_phase_rate_fp;
+  data->carrier_freq_fp = (s32)(common_data->carrier_freq * NAP_TRACK_CARRIER_FREQ_UNITS_PER_HZ);
+  data->carrier_freq_fp_prev = data->carrier_freq_fp;
+  data->short_cycle = true;
+
+  /* Initialise C/N0 estimator */
+  cn0_est_init(&data->cn0_est, 1e3/data->int_ms, common_data->cn0, CN0_EST_LPF_CUTOFF, 1e3/data->int_ms);
+
+  lock_detect_init(&data->lock_detect,
+                   lock_detect_params.k1, lock_detect_params.k2,
+                   lock_detect_params.lp, lock_detect_params.lo);
+
+  /* TODO: Reconfigure alias detection between stages */
+  u8 alias_detect_ms = MIN(loop_params_stage[1].coherent_ms,
+                           tracker_bit_length_get(channel_info->context));
+  alias_detect_init(&data->alias_detect, 500/alias_detect_ms,
+                    (alias_detect_ms-1)*1e-3);
+
+}
+
+static void tracker_gps_l1ca_disable(const tracker_channel_info_t *channel_info,
+                                     tracker_common_data_t *common_data,
+                                     tracker_data_t *tracker_data)
+{
+  (void)channel_info;
+  (void)common_data;
+  (void)tracker_data;
+}
+
+static void tracker_gps_l1ca_update(const tracker_channel_info_t *channel_info,
+                                    tracker_common_data_t *common_data,
+                                    tracker_data_t *tracker_data)
+{
+  gps_l1ca_tracker_data_t *data = tracker_data;
+
+  char buf[SID_STR_LEN_MAX];
+  sid_to_string(buf, sizeof(buf), channel_info->sid);
+
+  /* Read early ([0]), prompt ([1]) and late ([2]) correlations. */
+  if ((data->int_ms > 1) && !data->short_cycle) {
+    /* If we just requested the short cycle, this is the long cycle's
+     * correlations. */
+    corr_t cs[3];
+    tracker_correlations_read(channel_info->context, cs,
+                              &data->corr_sample_count);
+    /* accumulate short cycle correlations with long */
+    for(int i = 0; i < 3; i++) {
+      data->cs[i].I += cs[i].I;
+      data->cs[i].Q += cs[i].Q;
+    }
+  } else {
+    tracker_correlations_read(channel_info->context, data->cs,
+                              &data->corr_sample_count);
+    alias_detect_first(&data->alias_detect, data->cs[1].I, data->cs[1].Q);
+  }
+
+  common_data->sample_count += data->corr_sample_count;
+  common_data->code_phase_early = (u64)common_data->code_phase_early +
+                           (u64)data->corr_sample_count
+                             * data->code_phase_rate_fp_prev;
+  common_data->carrier_phase += (s64)data->carrier_freq_fp_prev
+                           * data->corr_sample_count;
+  /* TODO: Fix this in the FPGA - first integration is one sample short. */
+  if (common_data->update_count == 0)
+    common_data->carrier_phase -= data->carrier_freq_fp_prev;
+  data->code_phase_rate_fp_prev = data->code_phase_rate_fp;
+  data->carrier_freq_fp_prev = data->carrier_freq_fp;
+
+  common_data->TOW_ms = tracker_tow_update(channel_info->context,
+                                   common_data->TOW_ms,
+                                   data->short_cycle ? 1 : (data->int_ms-1));
+
+  if (data->int_ms > 1) {
+    /* If we're doing long integrations, alternate between short and long
+     * cycles.  This is because of FPGA pipelining and latency.  The
+     * loop parameters can only be updated at the end of the second
+     * integration interval and waiting a whole 20ms is too long.
+     */
+    data->short_cycle = !data->short_cycle;
+
+    if (!data->short_cycle) {
+      tracker_retune(channel_info->context, data->carrier_freq_fp,
+                     data->code_phase_rate_fp, 0);
+      return;
+    }
+  }
+
+  common_data->update_count += data->int_ms;
+
+  tracker_bit_sync_update(channel_info->context, data->int_ms, data->cs[1].I);
+
+  /* Correlations should already be in chan->cs thanks to
+   * tracking_channel_get_corrs. */
+  corr_t* cs = data->cs;
+
+  /* Update C/N0 estimate */
+  common_data->cn0 = cn0_est(&data->cn0_est, cs[1].I/data->int_ms, cs[1].Q/data->int_ms);
+  if (common_data->cn0 > track_cn0_drop_thres)
+    common_data->cn0_above_drop_thres_count = common_data->update_count;
+
+  if (common_data->cn0 < track_cn0_use_thres) {
+    /* SNR has dropped below threshold, indicate that the carrier phase
+     * ambiguity is now unknown as cycle slips are likely. */
+    tracker_ambiguity_unknown(channel_info->context);
+    /* Update the latest time we were below the threshold. */
+    common_data->cn0_below_use_thres_count = common_data->update_count;
+  }
+
+  /* Update PLL lock detector */
+  bool last_outp = data->lock_detect.outp;
+  lock_detect_update(&data->lock_detect, cs[1].I, cs[1].Q, data->int_ms);
+  if (data->lock_detect.outo)
+    common_data->ld_opti_locked_count = common_data->update_count;
+  if (!data->lock_detect.outp)
+    common_data->ld_pess_unlocked_count = common_data->update_count;
+
+  /* Reset carrier phase ambiguity if there's doubt as to our phase lock */
+  if (last_outp && !data->lock_detect.outp) {
+    if (data->stage > 0) {
+      log_info("%s PLL stress", buf);
+    }
+    tracker_ambiguity_unknown(channel_info->context);
+  }
+
+  /* Run the loop filters. */
+
+  /* TODO: Make this more elegant. */
+  correlation_t cs2[3];
+  for (u32 i = 0; i < 3; i++) {
+    cs2[i].I = cs[2-i].I;
+    cs2[i].Q = cs[2-i].Q;
+  }
+
+  /* Output I/Q correlations using SBP if enabled for this channel */
+  if (data->int_ms > 1) {
+    tracker_correlations_send(channel_info->context, cs);
+  }
+
+  aided_tl_update(&data->tl_state, cs2);
+  common_data->carrier_freq = data->tl_state.carr_freq;
+  common_data->code_phase_rate = data->tl_state.code_freq + GPS_CA_CHIPPING_RATE;
+
+  data->code_phase_rate_fp_prev = data->code_phase_rate_fp;
+  data->code_phase_rate_fp = common_data->code_phase_rate
+    * NAP_TRACK_CODE_PHASE_RATE_UNITS_PER_HZ;
+
+  data->carrier_freq_fp = common_data->carrier_freq
+    * NAP_TRACK_CARRIER_FREQ_UNITS_PER_HZ;
+
+  /* Attempt alias detection if we have pessimistic phase lock detect, OR
+     (optimistic phase lock detect AND are in second-stage tracking) */
+  if (use_alias_detection &&
+      (data->lock_detect.outp ||
+       (data->lock_detect.outo && data->stage > 0))) {
+    s32 I = (cs[1].I - data->alias_detect.first_I) / (data->int_ms - 1);
+    s32 Q = (cs[1].Q - data->alias_detect.first_Q) / (data->int_ms - 1);
+    float err = alias_detect_second(&data->alias_detect, I, Q);
+    if (fabs(err) > (250 / data->int_ms)) {
+      if (data->lock_detect.outp) {
+        log_warn("False phase lock detected on %s: err=%f", buf, err);
+      }
+
+      tracker_ambiguity_unknown(channel_info->context);
+      /* Indicate that a mode change has occurred. */
+      common_data->mode_change_count = common_data->update_count;
+
+      data->tl_state.carr_freq += err;
+      data->tl_state.carr_filt.y = data->tl_state.carr_freq;
+    }
+  }
+
+  /* Consider moving from stage 0 (1 ms integration) to stage 1 (longer). */
+  if ((data->stage == 0) &&
+      /* Must have (at least optimistic) phase lock */
+      (data->lock_detect.outo) &&
+      /* Must have nav bit sync, and be correctly aligned */
+      tracker_bit_aligned(channel_info->context)) {
+    log_info("%s synced @ %u ms, %.1f dBHz",
+             buf, (unsigned int)common_data->update_count,
+             common_data->cn0);
+    data->stage = 1;
+    const struct loop_params *l = &loop_params_stage[1];
+    data->int_ms = MIN(l->coherent_ms,
+                       tracker_bit_length_get(channel_info->context));
+    data->short_cycle = true;
+
+    cn0_est_init(&data->cn0_est, 1e3 / data->int_ms, common_data->cn0,
+                 CN0_EST_LPF_CUTOFF, 1e3 / data->int_ms);
+
+    /* Recalculate filter coefficients */
+    aided_tl_retune(&data->tl_state, 1e3 / data->int_ms,
+                    l->code_bw, l->code_zeta, l->code_k,
+                    l->carr_to_code,
+                    l->carr_bw, l->carr_zeta, l->carr_k,
+                    l->carr_fll_aid_gain);
+
+    lock_detect_reinit(&data->lock_detect,
+                       lock_detect_params.k1 * data->int_ms,
+                       lock_detect_params.k2,
+                       /* TODO: Should also adjust lp and lo? */
+                       lock_detect_params.lp, lock_detect_params.lo);
+
+    /* Indicate that a mode change has occurred. */
+    common_data->mode_change_count = common_data->update_count;
+  }
+
+  tracker_retune(channel_info->context, data->carrier_freq_fp,
+                 data->code_phase_rate_fp,
+                 data->int_ms == 1 ? 0 : data->int_ms - 2);
+}
+
+/** Parse a string describing the tracking loop filter parameters into
+    the loop_params_stage structs. */
+static bool parse_loop_params(struct setting *s, const char *val)
+{
+  /** The string contains loop parameters for either one or two
+      stages.  If the second is omitted, we'll use the same parameters
+      as the first stage.*/
+
+  struct loop_params loop_params_parse[2];
+
+  const char *str = val;
+  for (int stage = 0; stage < 2; stage++) {
+    struct loop_params *l = &loop_params_parse[stage];
+
+    int n_chars_read = 0;
+    unsigned int tmp; /* newlib's sscanf doesn't support hh size modifier */
+
+    if (sscanf(str, "( %u ms , ( %f , %f , %f , %f ) , ( %f , %f , %f , %f ) ) , %n",
+               &tmp,
+               &l->code_bw, &l->code_zeta, &l->code_k, &l->carr_to_code,
+               &l->carr_bw, &l->carr_zeta, &l->carr_k, &l->carr_fll_aid_gain,
+               &n_chars_read) < 9) {
+      log_error("Ill-formatted tracking loop param string.");
+      return false;
+    }
+    l->coherent_ms = tmp;
+    /* If string omits second-stage parameters, then after the first
+       stage has been parsed, n_chars_read == 0 because of missing
+       comma and we'll parse the string again into loop_params_parse[1]. */
+    str += n_chars_read;
+
+    if ((l->coherent_ms == 0)
+        || ((20 % l->coherent_ms) != 0) /* i.e. not 1, 2, 4, 5, 10 or 20 */
+        || (stage == 0 && l->coherent_ms != 1)) {
+      log_error("Invalid coherent integration length.");
+      return false;
+    }
+  }
+  /* Successfully parsed both stages.  Save to memory. */
+  strncpy(s->addr, val, s->len);
+  memcpy(loop_params_stage, loop_params_parse, sizeof(loop_params_stage));
+  return true;
+}
+
+/** Parse a string describing the tracking loop phase lock detector
+    parameters into the lock_detect_params structs. */
+static bool parse_lock_detect_params(struct setting *s, const char *val)
+{
+  struct lock_detect_params p;
+
+  if (sscanf(val, "%f , %f , %" SCNu16 " , %" SCNu16,
+             &p.k1, &p.k2, &p.lp, &p.lo) < 4) {
+      log_error("Ill-formatted lock detect param string.");
+      return false;
+  }
+  /* Successfully parsed.  Save to memory. */
+  strncpy(s->addr, val, s->len);
+  memcpy(&lock_detect_params, &p, sizeof(lock_detect_params));
+  return true;
+}

--- a/src/track_gps_l1ca.h
+++ b/src/track_gps_l1ca.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2016 Swift Navigation Inc.
+ * Contact: Jacob McNamee <jacob@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+#ifndef SWIFTNAV_TRACK_GPS_L1CA_H
+#define SWIFTNAV_TRACK_GPS_L1CA_H
+
+#include <libswiftnav/common.h>
+
+void track_gps_l1ca_register(void);
+
+#endif

--- a/src/track_internal.c
+++ b/src/track_internal.c
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C) 2016 Swift Navigation Inc.
+ * Contact: Jacob McNamee <jacob@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "track_internal.h"
+#include "track.h"
+
+#include <string.h>
+#include <assert.h>
+
+#include <ch.h>
+
+#include "signal.h"
+#include "peripherals/random.h"
+
+/** \addtogroup tracking
+ * \{ */
+
+#define COMPILER_BARRIER() asm volatile ("" : : : "memory")
+
+static MUTEX_DECL(nav_time_sync_mutex);
+
+static tracker_interface_list_element_t *tracker_interface_list = 0;
+
+/* signal lock counter
+ * A map of signal to an initially random number that increments each time that
+ * signal begins being tracked.
+ */
+static u16 tracking_lock_counters[PLATFORM_SIGNAL_COUNT];
+
+/** Set up internal tracker data. */
+void track_internal_setup(void)
+{
+  for (u32 i=0; i < PLATFORM_SIGNAL_COUNT; i++) {
+    tracking_lock_counters[i] = random_int();
+  }
+}
+
+/** Return a pointer to the tracker interface list. */
+tracker_interface_list_element_t ** tracker_interface_list_ptr_get(void)
+{
+  return &tracker_interface_list;
+}
+
+/** Initialize a tracker internal data structure.
+ *
+ * \param tracker_channel   Tracker channel to use.
+ * \param sid               Signal identifier to use.
+ */
+void internal_data_init(tracker_internal_data_t *internal_data,
+                        gnss_signal_t sid)
+{
+  /* Initialize all fields to 0 */
+  memset(internal_data, 0, sizeof(tracker_internal_data_t));
+
+  internal_data->bit_polarity = BIT_POLARITY_UNKNOWN;
+
+  nav_bit_fifo_init(&internal_data->nav_bit_fifo);
+  nav_time_sync_init(&internal_data->nav_time_sync);
+  bit_sync_init(&internal_data->bit_sync, sid);
+}
+
+/** Initialize a nav_bit_fifo_t struct.
+ *
+ * \param fifo        nav_bit_fifo_t struct to use.
+ */
+void nav_bit_fifo_init(nav_bit_fifo_t *fifo)
+{
+  fifo->read_index = 0;
+  fifo->write_index = 0;
+}
+
+/** Write data to the nav bit FIFO.
+ *
+ * \note This function should only be called internally by the tracking thread.
+ *
+ * \param fifo        nav_bit_fifo_t struct to use.
+ * \param element     Element to write to the FIFO.
+ *
+ * \return true if element was read, false otherwise.
+ */
+bool nav_bit_fifo_write(nav_bit_fifo_t *fifo,
+                        const nav_bit_fifo_element_t *element)
+{
+  if (NAV_BIT_FIFO_LENGTH(fifo) < NAV_BIT_FIFO_SIZE) {
+    COMPILER_BARRIER(); /* Prevent compiler reordering */
+    memcpy(&fifo->elements[fifo->write_index & NAV_BIT_FIFO_INDEX_MASK],
+           element, sizeof(nav_bit_fifo_element_t));
+    COMPILER_BARRIER(); /* Prevent compiler reordering */
+    fifo->write_index++;
+    return true;
+  }
+
+  return false;
+}
+
+/** Read pending data from the nav bit FIFO.
+ *
+ * \note This function should only be called externally by the decoder thread.
+ *
+ * \param fifo        nav_bit_fifo_t struct to use.
+ * \param element     Output element read from the FIFO.
+ *
+ * \return true if element was read, false otherwise.
+ */
+bool nav_bit_fifo_read(nav_bit_fifo_t *fifo, nav_bit_fifo_element_t *element)
+{
+  if (NAV_BIT_FIFO_LENGTH(fifo) > 0) {
+    COMPILER_BARRIER(); /* Prevent compiler reordering */
+    memcpy(element, &fifo->elements[fifo->read_index & NAV_BIT_FIFO_INDEX_MASK],
+           sizeof(nav_bit_fifo_element_t));
+    COMPILER_BARRIER(); /* Prevent compiler reordering */
+    fifo->read_index++;
+    return true;
+  }
+
+  return false;
+}
+
+/** Initialize a nav_time_sync_t struct.
+ *
+ * \param sync          nav_time_sync_t struct to use.
+ */
+void nav_time_sync_init(nav_time_sync_t *sync)
+{
+  sync->valid = false;
+}
+
+/** Write pending time sync data from the decoder thread.
+ *
+ * \note This function should only be called externally by the decoder thread.
+ *
+ * \param sync          nav_time_sync_t struct to use.
+ * \param TOW_ms        TOW in ms.
+ * \param bit_polarity  Bit polarity.
+ * \param read_index    Nav bit FIFO read index to which the above values
+ *                      are synchronized.
+ *
+ * \return true if data was stored successfully, false otherwise.
+ */
+bool nav_time_sync_set(nav_time_sync_t *sync, s32 TOW_ms,
+                       s8 bit_polarity, nav_bit_fifo_index_t read_index)
+{
+  bool result = false;
+  chMtxLock(&nav_time_sync_mutex);
+
+  sync->TOW_ms = TOW_ms;
+  sync->bit_polarity = bit_polarity;
+  sync->read_index = read_index;
+  sync->valid = true;
+  result = true;
+
+  Mutex *m = chMtxUnlock();
+  assert(m == &nav_time_sync_mutex);
+  return result;
+}
+
+/** Read pending time sync data provided by the decoder thread.
+ *
+ * \note This function should only be called internally by the tracking thread.
+ *
+ * \param sync          nav_time_sync_t struct to use.
+ * \param TOW_ms        TOW in ms.
+ * \param bit_polarity  Bit polarity.
+ * \param read_index    Nav bit FIFO read index to which the above values
+ *                      are synchronized.
+ *
+ * \return true if outputs are valid, false otherwise.
+ */
+bool nav_time_sync_get(nav_time_sync_t *sync, s32 *TOW_ms,
+                       s8 *bit_polarity, nav_bit_fifo_index_t *read_index)
+{
+  bool result = false;
+  chMtxLock(&nav_time_sync_mutex);
+
+  if (sync->valid) {
+    *TOW_ms = sync->TOW_ms;
+    *bit_polarity = sync->bit_polarity;
+    *read_index = sync->read_index;
+    sync->valid = false;
+    result = true;
+  }
+
+  Mutex *m = chMtxUnlock();
+  assert(m == &nav_time_sync_mutex);
+  return result;
+}
+
+/** Compress a 32 bit integration value down to 8 bits.
+ *
+ * \param bit_integrate   Signed bit integration value.
+ */
+s8 nav_bit_quantize(s32 bit_integrate)
+{
+  //  0 through  2^24 - 1 ->  0 = weakest positive bit
+  // -1 through -2^24     -> -1 = weakest negative bit
+
+  if (bit_integrate >= 0)
+    return bit_integrate / (1 << 24);
+  else
+    return ((bit_integrate + 1) / (1 << 24)) - 1;
+}
+
+/** Increment and return the tracking lock counter for the specified sid.
+ *
+ * \param sid         Signal identifier to use.
+ */
+u16 tracking_lock_counter_increment(gnss_signal_t sid)
+{
+  return ++tracking_lock_counters[sid_to_global_index(sid)];
+}
+
+/** Return the tracking lock counter for the specified sid.
+ *
+ * \param sid         Signal identifier to use.
+ */
+u16 tracking_lock_counter_get(gnss_signal_t sid)
+{
+  return tracking_lock_counters[sid_to_global_index(sid)];
+}
+
+/** \} */

--- a/src/track_internal.h
+++ b/src/track_internal.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2016 Swift Navigation Inc.
+ * Contact: Jacob McNamee <jacob@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+#ifndef SWIFTNAV_TRACK_INTERNAL_H
+#define SWIFTNAV_TRACK_INTERNAL_H
+
+#include <libswiftnav/common.h>
+#include <libswiftnav/bit_sync.h>
+#include <libswiftnav/signal.h>
+
+#include "track_api.h"
+
+/** \addtogroup tracking
+ * \{ */
+
+#define NAV_BIT_FIFO_SIZE 32 /**< Size of nav bit FIFO. Must be a power of 2 */
+
+#define NAV_BIT_FIFO_INDEX_MASK ((NAV_BIT_FIFO_SIZE) - 1)
+#define NAV_BIT_FIFO_INDEX_DIFF(write_index, read_index) \
+          ((nav_bit_fifo_index_t)((write_index) - (read_index)))
+#define NAV_BIT_FIFO_LENGTH(p_fifo) \
+          (NAV_BIT_FIFO_INDEX_DIFF((p_fifo)->write_index, (p_fifo)->read_index))
+
+typedef struct {
+  s8 soft_bit;
+} nav_bit_fifo_element_t;
+
+typedef u8 nav_bit_fifo_index_t;
+
+typedef struct {
+  nav_bit_fifo_index_t read_index;
+  nav_bit_fifo_index_t write_index;
+  nav_bit_fifo_element_t elements[NAV_BIT_FIFO_SIZE];
+} nav_bit_fifo_t;
+
+typedef struct {
+  s32 TOW_ms;
+  s8 bit_polarity;
+  nav_bit_fifo_index_t read_index;
+  bool valid;
+} nav_time_sync_t;
+
+typedef struct {
+  /** FIFO for navigation message bits. */
+  nav_bit_fifo_t nav_bit_fifo;
+  /** Used to sync time decoded from navigation message
+   * back to tracking channel. */
+  nav_time_sync_t nav_time_sync;
+  /** Time since last nav bit was appended to the nav bit FIFO. */
+  u32 nav_bit_TOW_offset_ms;
+  /** Bit sync state. */
+  bit_sync_t bit_sync;
+  /** Polarity of nav message bits. */
+  s8 bit_polarity;
+  /** Increments when tracking new signal. */
+  u16 lock_counter;
+  /** Set if this channel should output I/Q samples on SBP. */
+  bool output_iq;
+} tracker_internal_data_t;
+
+/** \} */
+
+void track_internal_setup(void);
+
+tracker_interface_list_element_t ** tracker_interface_list_ptr_get(void);
+
+void tracker_internal_context_resolve(tracker_context_t *tracker_context,
+                                      const tracker_channel_info_t **channel_info,
+                                      tracker_internal_data_t **internal_data);
+
+void internal_data_init(tracker_internal_data_t *internal_data,
+                        gnss_signal_t sid);
+
+void nav_bit_fifo_init(nav_bit_fifo_t *fifo);
+bool nav_bit_fifo_write(nav_bit_fifo_t *fifo,
+                        const nav_bit_fifo_element_t *element);
+bool nav_bit_fifo_read(nav_bit_fifo_t *fifo, nav_bit_fifo_element_t *element);
+void nav_time_sync_init(nav_time_sync_t *sync);
+bool nav_time_sync_set(nav_time_sync_t *sync, s32 TOW_ms,
+                       s8 bit_polarity, nav_bit_fifo_index_t read_index);
+bool nav_time_sync_get(nav_time_sync_t *sync, s32 *TOW_ms,
+                       s8 *bit_polarity, nav_bit_fifo_index_t *read_index);
+
+s8 nav_bit_quantize(s32 bit_integrate);
+
+u16 tracking_lock_counter_increment(gnss_signal_t sid);
+u16 tracking_lock_counter_get(gnss_signal_t sid);
+
+#endif


### PR DESCRIPTION
Major overhaul of tracking module:
- No more global `tracking_channel[]`
- Code-specific tracking init and update implementations
- API for code-specific implementations to reuse common data / functions
- Thread safety improvements (copying out measurements, handling race condition w/NAP interrupts)
- Tracking startup queue to enable hot starting new channels from within the tracking loops