### PR TITLE
Fix sid_from_sbp() for GPS L1CA 1

### DIFF
--- a/src/sbp_utils.c
+++ b/src/sbp_utils.c
@@ -55,9 +55,9 @@ gnss_signal_t sid_from_sbp(const sbp_gnss_signal_t from)
   /* Maintain legacy compatibility with GPS PRN encoding. Sat values for other
    * constellations are "real" satellite identifiers.
    */
-  if (sid_valid(sid)) {
-    if (sid_to_constellation(sid) == CONSTELLATION_GPS)
-      sid.sat += GPS_FIRST_PRN;
+  if (code_valid(sid.code) &&
+     (code_to_constellation(sid.code) == CONSTELLATION_GPS)) {
+    sid.sat += GPS_FIRST_PRN;
   }
 
   return sid;


### PR DESCRIPTION
`sid_valid()` would return false for `sid.sat = 0` and hence the offset would incorrectly not be applied.