### PR TITLE
Gracefully handle NAP errors

### DIFF
--- a/src/board/v2/nap/nap_exti.c
+++ b/src/board/v2/nap/nap_exti.c
@@ -29,6 +29,8 @@
 /** \addtogroup nap
  * \{ */
 
+#define PROCESS_PERIOD_ms (1000)
+
 /* Number of NAP exti ISR's that have occured.
  * TODO : if this starts being used for anything other than waiting to see
  *        if an exti has occurred, maybe we should change to u64? */
@@ -111,7 +113,7 @@ static void nap_exti_thread(void *arg)
 
   while (TRUE) {
     /* Waiting for the IRQ to happen.*/
-    chBSemWait(&nap_exti_sem);
+    chBSemWaitTimeout(&nap_exti_sem, MS2ST(PROCESS_PERIOD_ms));
 
     /* We need a level (not edge) sensitive interrupt -
      * if there is another interrupt pending on the Swift
@@ -123,6 +125,7 @@ static void nap_exti_thread(void *arg)
     while (palReadLine(LINE_NAP_IRQ)) {
       handle_nap_exti();
     }
+    tracking_channels_process();
     spi_unlock(SPI_SLAVE_FPGA);
 
   }

--- a/src/board/v2/nap/nap_exti.c
+++ b/src/board/v2/nap/nap_exti.c
@@ -102,6 +102,12 @@ static void handle_nap_exti(void)
   irq &= NAP_IRQ_TRACK_MASK;
   tracking_channels_update(irq);
 
+  u32 err = nap_error_rd_blocking();
+  if (err) {
+    log_error("SwiftNAP Error: 0x%08X", (unsigned int)err);
+    tracking_channels_missed_update_error(err);
+  }
+
   watchdog_notify(WD_NOTIFY_NAP_ISR);
   nap_exti_count++;
 }

--- a/src/system_monitor.c
+++ b/src/system_monitor.c
@@ -199,11 +199,6 @@ static void system_monitor_thread(void *arg)
      send_thread_states(); 
     );
 
-    u32 err = nap_error_rd_blocking();
-    if (err) {
-      log_error("SwiftNAP Error: 0x%08X", (unsigned int)err);
-    }
-
     sleep_until(&time, MS2ST(heartbeat_period_milliseconds));
   }
 }

--- a/src/track.h
+++ b/src/track.h
@@ -41,6 +41,7 @@ float propagate_code_phase(float code_phase, float carrier_freq, u32 n_samples);
 
 /* Update interface */
 void tracking_channels_update(u32 channels_mask);
+void tracking_channels_process(void);
 
 /* State management interface */
 bool tracker_channel_available(tracker_channel_id_t id, gnss_signal_t sid);

--- a/src/track.h
+++ b/src/track.h
@@ -42,6 +42,7 @@ float propagate_code_phase(float code_phase, float carrier_freq, u32 n_samples);
 /* Update interface */
 void tracking_channels_update(u32 channels_mask);
 void tracking_channels_process(void);
+void tracking_channels_missed_update_error(u32 channels_mask);
 
 /* State management interface */
 bool tracker_channel_available(tracker_channel_id_t id, gnss_signal_t sid);
@@ -56,6 +57,7 @@ void tracking_channel_lock(tracker_channel_id_t id);
 void tracking_channel_unlock(tracker_channel_id_t id);
 
 bool tracking_channel_running(tracker_channel_id_t id);
+bool tracking_channel_error(tracker_channel_id_t id);
 float tracking_channel_cn0_get(tracker_channel_id_t id);
 u32 tracking_channel_running_time_ms_get(tracker_channel_id_t id);
 u32 tracking_channel_cn0_useable_ms_get(tracker_channel_id_t id);


### PR DESCRIPTION
Set a flag if a NAP update is missed so that the channel may be dropped.

Also improves handling of NAP interrupts after disabling a tracking channel.