### PR TITLE
Change ram4 memory segment length for Piksi v2

### DIFF
--- a/src/board/v2/STM32F405xG.ld
+++ b/src/board/v2/STM32F405xG.ld
@@ -28,7 +28,7 @@ MEMORY
     ram1  : org = 0x20000000, len = 112k    /* SRAM1 */
     ram2  : org = 0x2001C000, len = 16k     /* SRAM2 */
     ram3  : org = 0x00000000, len = 0
-    ram4  : org = 0x10000000, len = 64k     /* CCM SRAM */
+    ram4  : org = 0x10000000, len = 64k-0x400/* CCM SRAM */
     ram5  : org = 0x40024000, len = 4k      /* BCKP SRAM */
     ram6  : org = 0x00000000, len = 0
     ram7  : org = 0x00000000, len = 0


### PR DESCRIPTION
  Part of CCM memory is allocated for mstack and
  that has to be taken into account in declaration of
  ram4 memory segment where other data are placed.