### PR TITLE
Enable and use backup RAM

### DIFF
--- a/src/board/v2/STM32F405xG.ld
+++ b/src/board/v2/STM32F405xG.ld
@@ -59,6 +59,12 @@ SECTIONS {
     } > ram4
 }
 
+SECTIONS {
+    .bckpram (NOLOAD) : {
+      *(.bckpram*)
+    } > ram5
+}
+
 PROVIDE(_coffee_fs_area = ORIGIN(coffee_fs_rom));
 PROVIDE(_ecoffee_fs_area = ORIGIN(coffee_fs_rom) + LENGTH(coffee_fs_rom));
 

--- a/src/board/v2/board.h
+++ b/src/board/v2/board.h
@@ -373,10 +373,10 @@ extern struct usart_support_s SD1, SD3, SD6;
                                      PIN_MODE_OUTPUT(GPIOB_MAX_NSHDN) |     \
                                      PIN_MODE_OUTPUT(GPIOB_MAX_NIDLE) |     \
                                      PIN_MODE_OUTPUT(GPIOB_SPI2NSS_MAX) |   \
-                                     PIN_MODE_OUTPUT(GPIOB_SPI2NSS_FLASH) | \
-                                     PIN_MODE_ALTERNATE(GPIOB_SPI2SCK) |    \
-                                     PIN_MODE_ALTERNATE(GPIOB_SPI2MISO) |   \
-                                     PIN_MODE_ALTERNATE(GPIOB_SPI2MOSI))
+                                     PIN_MODE_INPUT(GPIOB_SPI2NSS_FLASH) | \
+                                     PIN_MODE_INPUT(GPIOB_SPI2SCK) |    \
+                                     PIN_MODE_INPUT(GPIOB_SPI2MISO) |   \
+                                     PIN_MODE_INPUT(GPIOB_SPI2MOSI))
 #define VAL_GPIOB_OTYPER            (PIN_OTYPE_PUSHPULL(GPIOB_V_USB) |      \
                                      PIN_OTYPE_PUSHPULL(GPIOB_FTDI_NRST) |  \
                                      PIN_OTYPE_PUSHPULL(GPIOB_PIN2) |       \
@@ -535,7 +535,7 @@ extern struct usart_support_s SD1, SD3, SD6;
                                      PIN_ODR_HIGH(GPIOC_PIN9) |             \
                                      PIN_ODR_HIGH(GPIOC_UART3_TX) |         \
                                      PIN_ODR_HIGH(GPIOC_UART3_RX) |         \
-                                     PIN_ODR_LOW(GPIOC_FPGA_PROGRAM_B) |   \
+                                     PIN_ODR_HIGH(GPIOC_FPGA_PROGRAM_B) |   \
                                      PIN_ODR_HIGH(GPIOC_PIN13) |            \
                                      PIN_ODR_HIGH(GPIOC_PIN14) |            \
                                      PIN_ODR_HIGH(GPIOC_PIN15))

--- a/src/board/v2/chconf_board.h
+++ b/src/board/v2/chconf_board.h
@@ -62,5 +62,13 @@ extern u64 g_ctime;
   }                                                                         \
 }
 
-#endif
+/* Change vector table location for compatibility with the bootloader. */
+#define CORTEX_VTOR_INIT 0x08004000
 
+#define _CCM __attribute__((section (".ccmram")))
+#define WORKING_AREA_CCM(s, n) THD_WORKING_AREA(s, n) _CCM
+
+#define _BCKP __attribute__((section (".bckpram")))
+#define WORKING_AREA_BCKP(s, n) THD_WORKING_AREA(s, n) _BCKP
+
+#endif

--- a/src/board/v2/mcuconf.h
+++ b/src/board/v2/mcuconf.h
@@ -60,7 +60,7 @@
 #define STM32_PLLI2SR_VALUE                 5
 #define STM32_PVD_ENABLE                    FALSE
 #define STM32_PLS                           STM32_PLS_LEV0
-#define STM32_BKPRAM_ENABLE                 FALSE
+#define STM32_BKPRAM_ENABLE                 TRUE
 
 /*
  * ADC driver system settings.

--- a/src/board/v3/chconf_board.h
+++ b/src/board/v3/chconf_board.h
@@ -75,6 +75,13 @@ extern uint64_t g_ctime;
  */
 #define ARM_FPU                 neon
 
+/* Change vector table location for compatibility with the bootloader. */
+#define CORTEX_VTOR_INIT 0x08004000
+
+#define _CCM
+#define WORKING_AREA_CCM(s, n) THD_WORKING_AREA(s, n) _CCM
+
+#define _BCKP
+#define WORKING_AREA_BCKP(s, n) THD_WORKING_AREA(s, n) _BCKP
 
 #endif
-

--- a/src/chconf.h
+++ b/src/chconf.h
@@ -468,12 +468,6 @@
 /* Port-specific settings (override port settings defaulted in chcore.h).    */
 /*===========================================================================*/
 
-/* Change vector table location for compatibility with the bootloader. */
-#define CORTEX_VTOR_INIT 0x08004000
-
-#define _CCM __attribute__((section (".ccmram")))
-#define WORKING_AREA_CCM(s, n) THD_WORKING_AREA(s, n) _CCM
-
 #include "chconf_board.h"
 
 #endif  /* _CHCONF_H_ */

--- a/src/decode.c
+++ b/src/decode.c
@@ -79,7 +79,7 @@ typedef struct {
 static decoder_interface_list_element_t *decoder_interface_list = 0;
 static decoder_channel_t decoder_channels[NUM_DECODER_CHANNELS];
 
-static WORKING_AREA_CCM(wa_decode_thread, 3000);
+static WORKING_AREA_CCM(wa_decode_thread, 2000);
 
 static void decode_thread(void *arg);
 static const decoder_interface_t * decoder_interface_get(gnss_signal_t sid);

--- a/src/manage.c
+++ b/src/manage.c
@@ -162,7 +162,7 @@ static void mask_sat_callback(u16 sender_id, u8 len, u8 msg[], void* context)
   }
 }
 
-static WORKING_AREA_CCM(wa_manage_acq_thread, MANAGE_ACQ_THREAD_STACK);
+static WORKING_AREA_BCKP(wa_manage_acq_thread, MANAGE_ACQ_THREAD_STACK);
 static void manage_acq_thread(void *arg)
 {
   /* TODO: This should be trigged by a semaphore from the acq ISR code, not
@@ -459,7 +459,7 @@ static void check_clear_unhealthy(void)
   }
 }
 
-static WORKING_AREA_CCM(wa_manage_track_thread, MANAGE_TRACK_THREAD_STACK);
+static WORKING_AREA_BCKP(wa_manage_track_thread, MANAGE_TRACK_THREAD_STACK);
 static void manage_track_thread(void *arg)
 {
   (void)arg;

--- a/src/peripherals/spi_wrapper.c
+++ b/src/peripherals/spi_wrapper.c
@@ -45,41 +45,6 @@ static const spi_slave_t spi_slave[] = {
   [SPI_SLAVE_FRONTEND] = {&spi_bus_2, {NULL, PAL_PORT(LINE_SPI2NSS_MAX), PAL_PAD(LINE_SPI2NSS_MAX), 0, true}},
 };
 
-/** Set up the SPI buses.
- * Set up the SPI peripheral, SPI clocks, SPI pins, and SPI pins' clocks.
- */
-void spi_setup(void)
-{
-  palSetLineMode(LINE_SPI1NSS, PAL_MODE_OUTPUT_PUSHPULL);
-  palSetLineMode(LINE_SPI1SCK, PAL_MODE_ALTERNATE(5));
-  palSetLineMode(LINE_SPI1MISO, PAL_MODE_ALTERNATE(5));
-  palSetLineMode(LINE_SPI1MOSI, PAL_MODE_ALTERNATE(5));
-
-  palSetLineMode(LINE_SPI2NSS_MAX, PAL_MODE_OUTPUT_PUSHPULL);
-  palSetLineMode(LINE_SPI2NSS_FLASH, PAL_MODE_OUTPUT_PUSHPULL);
-  palSetLineMode(LINE_SPI2SCK, PAL_MODE_ALTERNATE(5));
-  palSetLineMode(LINE_SPI2MISO, PAL_MODE_ALTERNATE(5));
-  palSetLineMode(LINE_SPI2MOSI, PAL_MODE_ALTERNATE(5));
-}
-
-/** Deactivate SPI buses.
- * Disable SPI peripherals, SPI clocks, High-Z SPI pins, and disable SPI pins'
- * clocks.
- */
-void spi_deactivate(void)
-{
-  palSetLineMode(LINE_SPI1NSS, PAL_MODE_INPUT);
-  palSetLineMode(LINE_SPI1SCK, PAL_MODE_INPUT);
-  palSetLineMode(LINE_SPI1MISO, PAL_MODE_INPUT);
-  palSetLineMode(LINE_SPI1MOSI, PAL_MODE_INPUT);
-
-  palSetLineMode(LINE_SPI2NSS_MAX, PAL_MODE_INPUT);
-  palSetLineMode(LINE_SPI2NSS_FLASH, PAL_MODE_INPUT);
-  palSetLineMode(LINE_SPI2SCK, PAL_MODE_INPUT);
-  palSetLineMode(LINE_SPI2MISO, PAL_MODE_INPUT);
-  palSetLineMode(LINE_SPI2MOSI, PAL_MODE_INPUT);
-}
-
 /** Lock the SPI bus used by the selected peripheral.
  * \note This function may be called before spi_slave_select() to enforce
  * exclusive access to the SPI bus across multiple transactions.

--- a/src/peripherals/spi_wrapper.h
+++ b/src/peripherals/spi_wrapper.h
@@ -34,8 +34,6 @@ enum {
 
 #define SPI_USE_ASYNC    TRUE
 
-void spi_setup(void);
-void spi_deactivate(void);
 void spi_lock(u8 slave);
 void spi_unlock(u8 slave);
 void spi_slave_select(u8 slave);


### PR DESCRIPTION
- Changes around clock / HAL init to enable backup RAM
- Move acq and track thread stacks to backup RAM
- Reduce decode thread size

Should free > 4kB of main RAM