### PR TITLE
Timeout related to solution rate

### DIFF
--- a/src/solution.c
+++ b/src/solution.c
@@ -42,6 +42,13 @@
 #include "signal.h"
 #include "system_monitor.h"
 
+/** number of solution periods before SPP resumes in pseudo-absolute mode */
+#define DGNSS_TIMEOUT_PERIODS 2
+
+/** number of OS ticks before SPP resumes in pseudo-absolute mode */
+#define DGNSS_TIMEOUT(soln_freq_hz) MS2ST((DGNSS_TIMEOUT_PERIODS * \
+  1/((float) (soln_freq_hz)) * 1000))
+
 MemoryPool obs_buff_pool;
 mailbox_t obs_mailbox;
 
@@ -73,7 +80,7 @@ void solution_send_sbp(gnss_solution *soln, dops_t *dops)
     msg_gps_time_t gps_time;
     sbp_make_gps_time(&gps_time, &soln->time, 0);
     sbp_send_msg(SBP_MSG_GPS_TIME, sizeof(gps_time), (u8 *) &gps_time);
-    if (chVTTimeElapsedSinceX(last_dgnss) > DGNSS_TIMEOUT) {
+    if (chVTTimeElapsedSinceX(last_dgnss) > DGNSS_TIMEOUT(soln_freq)) {
       /* Position in LLH. */
       msg_pos_llh_t pos_llh;
       sbp_make_pos_llh(&pos_llh, soln, 0);
@@ -107,7 +114,7 @@ void solution_send_nmea(gnss_solution *soln, dops_t *dops,
                         u8 n, navigation_measurement_t *nm,
                         u8 fix_mode)
 {
-  if (chVTTimeElapsedSinceX(last_dgnss) > DGNSS_TIMEOUT) {
+  if (chVTTimeElapsedSinceX(last_dgnss) > DGNSS_TIMEOUT(soln_freq)) {
     nmea_gpgga(soln->pos_llh, &soln->time, soln->n_used,
                fix_mode, dops->hdop, 0, 0);
   }
@@ -750,8 +757,7 @@ void init_base_callback(u16 sender_id, u8 len, u8 msg[], void* context)
 void solution_setup()
 {
   /* Set time of last differential solution in the past. */
-  last_dgnss = chVTGetSystemTime() - DGNSS_TIMEOUT;
-
+  last_dgnss = chVTGetSystemTime() - DGNSS_TIMEOUT(soln_freq);
   SETTING("solution", "soln_freq", soln_freq, TYPE_FLOAT);
   SETTING("solution", "output_every_n_obs", obs_output_divisor, TYPE_INT);
 

--- a/src/solution.h
+++ b/src/solution.h
@@ -35,8 +35,6 @@ typedef enum {
 
 #define MAX_AGE_OF_DIFFERENTIAL 1.0
 
-#define DGNSS_TIMEOUT S2ST(2)
-
 #define OBS_N_BUFF 5
 #define OBS_BUFF_SIZE (OBS_N_BUFF * sizeof(obss_t))
 


### PR DESCRIPTION
After putting in the fixed timeout for PR #642 , I realized that the timeout needed to be parameterized by the solution rate.  This PR says that the SBP SPP output will be suppressed until 2 solution intervals have passed without a psuedo-absolute position.  It should not change any behavior when not operating in psuedo-absolute mode.

@jacobmcnamee 
Please review. I'm not sure if my use of the preprocessor is advised from a style perspective.