### PR TITLE
v3: Explicitly enable SPI and UART REFCLKs

### DIFF
--- a/src/board/v3/board.c
+++ b/src/board/v3/board.c
@@ -51,18 +51,20 @@ void boardInit(void)
   *(volatile uint32_t *)0xF8000008 = 0xDF0D;
 
   /* Enable UART0 and UART1 clocks */
-  *(volatile uint32_t *)0xF800012C |= (1<<20) | (1 << 21);
+  *(volatile uint32_t *)0xF800012C |= (1 << 20) | (1 << 21);
 
   /* UART REFCLK = 1GHz / 20 = 50MHz */
   *(volatile uint32_t *)0xF8000154 &= ~(0x3F << 8);
   *(volatile uint32_t *)0xF8000154 |= (20 << 8);
+  *(volatile uint32_t *)0xF8000154 |= (1 << 0) | (1 << 1);
 
   /* Enable SPI0 and SPI1 clocks */
-  *(volatile uint32_t *)0xF800012C |= (1<<14) | (1 << 15);
+  *(volatile uint32_t *)0xF800012C |= (1 << 14) | (1 << 15);
 
   /* SPI REFCLK = 1GHz / 20 = 50MHz */
   *(volatile uint32_t *)0xF8000158 &= ~(0x3F << 8);
   *(volatile uint32_t *)0xF8000158 |= (20 << 8);
+  *(volatile uint32_t *)0xF8000158 |= (1 << 0) | (1 << 1);
 
   /* Assert FPGA resets */
   *(volatile uint32_t *)0xF8000240 = 0xf;


### PR DESCRIPTION
Enables UART0, which is apparently disabled by some part of the boot code.