### PR TITLE
Fault handling improvements

### DIFF
--- a/src/board/v2/error.c
+++ b/src/board/v2/error.c
@@ -156,7 +156,7 @@ void fault_handling_setup(void) {
 
 /* The following CamelCase functions each override a 'weak' definition
    in ChibiOS-RT/os/ports/GCC/ARMCMx/STM32F4xx/vectors.c */
-void NMIVector(void)
+void NMI_Handler(void)
 {
   /* We don't expect to ever end up here - On the STM32F4 the NMI can
      only be triggered by the RCC Clock Security System, which we
@@ -165,8 +165,8 @@ void NMIVector(void)
 };
 
 
-void HardFaultVector(void) __attribute__((noreturn));
-void HardFaultVector(void)
+void HardFault_Handler(void) __attribute__((noreturn));
+void HardFault_Handler(void)
 {
   /* TODO: ChibiOS thread status dump
      TODO: Use MSG_PANIC to avoid sprintf

--- a/src/board/v2/error.c
+++ b/src/board/v2/error.c
@@ -151,8 +151,8 @@ void fault_handling_setup(void) {
   /* Enable trapping of integer division by zero - otherwise the
      operation will silently give a zero quotient. */
   SCB->CCR |= (1 << 4);  /* SCB_CCR_DIV_0_TRP */
-}
 #endif
+}
 
 /* The following CamelCase functions each override a 'weak' definition
    in ChibiOS-RT/os/ports/GCC/ARMCMx/STM32F4xx/vectors.c */
@@ -184,15 +184,18 @@ void HardFaultVector(void)
   asm("mov %0, lr" : "=r"(lr) : : );
   
   static char msg[256];
-  sprintf(msg, "HFSR=%08X CFSR=%08X MMFAR=%08X BFAR=%08X PSP=%08X LR=%08X "
-          "r0=%08X r1=%08X r2=%08X r3=%08X r12=%08X lr=%08X pc=%08X psr=%08X",
-          (unsigned int)SCB->HFSR, (unsigned int)SCB->CFSR,
-          (unsigned int)SCB->MMFAR, (unsigned int)SCB->BFAR,
-          (unsigned int)psp, (unsigned int)lr,
-          (unsigned int)psp[0], (unsigned int)psp[1],
-          (unsigned int)psp[2], (unsigned int)psp[3],
-          (unsigned int)psp[4], (unsigned int)psp[5],
-          (unsigned int)psp[6], (unsigned int)psp[7]);
+  extern int fallback_sprintf(char *str, const char *fmt, ...);
+  fallback_sprintf(msg,
+                  "HFSR=%08X CFSR=%08X MMFAR=%08X BFAR=%08X PSP=%08X LR=%08X "
+                  "r0=%08X r1=%08X r2=%08X r3=%08X r12=%08X "
+                  "lr=%08X pc=%08X psr=%08X",
+                  (unsigned int)SCB->HFSR, (unsigned int)SCB->CFSR,
+                  (unsigned int)SCB->MMFAR, (unsigned int)SCB->BFAR,
+                  (unsigned int)psp, (unsigned int)lr,
+                  (unsigned int)psp[0], (unsigned int)psp[1],
+                  (unsigned int)psp[2], (unsigned int)psp[3],
+                  (unsigned int)psp[4], (unsigned int)psp[5],
+                  (unsigned int)psp[6], (unsigned int)psp[7]);
   _screaming_death(__func__, msg);
 };
 

--- a/src/board/v3/Makefile.inc
+++ b/src/board/v3/Makefile.inc
@@ -82,6 +82,7 @@ BOARDSRC := \
 BOARDASM := \
         $(BOARDDIR)/cpu_init.s \
         $(BOARDDIR)/mmu_table.s \
+        $(BOARDDIR)/error_asm.s \
 
 # Define linker script file here
 LDSCRIPT= $(BOARDDIR)/ZYNQ7000.ld

--- a/src/board/v3/error.c
+++ b/src/board/v3/error.c
@@ -122,7 +122,8 @@ void fault_handling_setup(void) {
 void fault_handler_screaming_death(const char *msg_str, u32 lr)
 {
   char msg[128];
-  sprintf(msg, "%s lr=%08X", msg_str, (unsigned int)lr);
+  extern int fallback_sprintf(char *str, const char *fmt, ...);
+  fallback_sprintf(msg, "%s lr=%08X", msg_str, (unsigned int)lr);
   screaming_death(msg);
 }
 

--- a/src/board/v3/error.c
+++ b/src/board/v3/error.c
@@ -71,7 +71,7 @@ void _screaming_death(const char *pos, const char *msg)
   sbp_state_init(&sbp_state);
 
   /* Continuously send error message */
-  #define APPROX_ONE_SEC 33000000
+  #define APPROX_ONE_SEC 200000000
   while (1) {
     led_toggle(LED_RED);
     for (u32 d = 0; d < APPROX_ONE_SEC; d++) {
@@ -118,34 +118,12 @@ void _exit(int status)
 void fault_handling_setup(void) {
 }
 
-__attribute__((interrupt("UNDEF")))
-void Und_Handler(void)
+/* Called by fault handlers in error_asm.s */
+void fault_handler_screaming_death(const char *msg_str, u32 lr)
 {
-  screaming_death("Undefined instruction!");
-}
-
-__attribute__((interrupt("ABORT")))
-void Prefetch_Handler(void)
-{
-  screaming_death("Prefetch Abort!");
-}
-
-__attribute__((interrupt("ABORT")))
-void Abort_Handler(void)
-{
-  screaming_death("Data Abort!");
-}
-
-__attribute__((interrupt("SWI")))
-void Swi_Handler(void)
-{
-  screaming_death("Software Interrupt!");
-}
-
-__attribute__((interrupt("FIQ")))
-void Fiq_Handler(void)
-{
-  screaming_death("Unused FIQ!");
+  char msg[128];
+  sprintf(msg, "%s lr=%08X", msg_str, (unsigned int)lr);
+  screaming_death(msg);
 }
 
 /** \} */

--- a/src/board/v3/error_asm.s
+++ b/src/board/v3/error_asm.s
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2016 Swift Navigation Inc.
+ * Contact: Jacob McNamee <jacob@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+.macro handler str
+    /* R1 = LR */
+    mov r1, lr
+    /* Switch to SYS mode with IRQs masked */
+    msr CPSR_c, #0x9F
+    /* R0 = str */
+    ldr r0, =\str
+    /* fault_handler_screaming_death(str, lr); */
+    blx fault_handler_screaming_death
+.endm
+
+    .data
+
+und_handler_str:
+    .asciz "Undefined instruction!"
+prefetch_handler_str:
+    .asciz "Prefetch Handler!"
+abort_handler_str:
+    .asciz "Abort Handler!"
+swi_handler_str:
+    .asciz "Software Interrupt!"
+fiq_handler_str:
+    .asciz "Unused FIQ!"
+
+    .text
+    .code   32
+    .balign 4
+
+.global Und_Handler
+Und_Handler:
+    handler und_handler_str
+
+.global Prefetch_Handler
+Prefetch_Handler:
+    handler prefetch_handler_str
+
+.global Abort_Handler
+Abort_Handler:
+    handler abort_handler_str
+
+.global Swi_Handler
+Swi_Handler:
+    handler swi_handler_str
+
+.global Fiq_Handler
+Fiq_Handler:
+    handler fiq_handler_str
+
+.end


### PR DESCRIPTION
v3: Switch to SYS stack and log LR, e.g.
`ERROR: /Swift/piksi_firmware//src/board/v3/error.c:140 : Prefetch Abort! lr=00110E7A`
Should be enough to figure out what instruction caused the problem.

v2: Update handler names to match symbols expected by ChibiOS 3

general: Bypass thread-safe `sprintf()` in fault handlers