### PR TITLE
Uart state period and optional forward

### DIFF
--- a/src/base_obs.c
+++ b/src/base_obs.c
@@ -262,12 +262,6 @@ static void obs_callback(u16 sender_id, u8 len, u8 msg[], void* context)
     return;
   }
 
-  /* Calculate packet latency. */
-  if (time_quality >= TIME_COARSE) {
-    gps_time_t now = get_current_time();
-    float latency_ms = (float) ((now.tow - t.tow) * 1000.0);
-    log_obs_latency(latency_ms);
-  }
 
   /* Verify sequence integrity */
   if (count == 0) {
@@ -341,6 +335,12 @@ static void obs_callback(u16 sender_id, u8 len, u8 msg[], void* context)
    * obss. */
   if (count == total - 1) {
     update_obss(&base_obss_rx);
+  /* Calculate packet latency. */
+    if (time_quality >= TIME_COARSE) {
+      gps_time_t now = get_current_time();
+      float latency_ms = (float) ((now.tow - t.tow) * 1000.0);
+      log_obs_latency(latency_ms);
+    }
   }
 }
 

--- a/src/board/v2/nap/nap_exti.c
+++ b/src/board/v2/nap/nap_exti.c
@@ -14,6 +14,7 @@
 
 #include <ch.h>
 #include <hal.h>
+#include <libswiftnav/logging.h>
 
 #include "nap_exti.h"
 
@@ -25,7 +26,6 @@
 #include "../../ext_events.h"
 #include "../../system_monitor.h"
 #include "peripherals/spi_wrapper.h"
-
 /** \addtogroup nap
  * \{ */
 

--- a/src/peripherals/usart.c
+++ b/src/peripherals/usart.c
@@ -30,6 +30,7 @@ usart_settings_t ftdi_usart = {
   .baud_rate          = USART_DEFAULT_BAUD_FTDI,
   .sbp_message_mask   = 0xFFFF,
   .configure_telemetry_radio_on_boot = 0,
+  .sbp_fwd = 1,
 };
 
 usart_settings_t uarta_usart = {
@@ -37,6 +38,7 @@ usart_settings_t uarta_usart = {
   .baud_rate          = USART_DEFAULT_BAUD_RADIO,
   .sbp_message_mask   = 0x40,
   .configure_telemetry_radio_on_boot = 1,
+  .sbp_fwd = 0,
 };
 
 usart_settings_t uartb_usart = {
@@ -44,6 +46,7 @@ usart_settings_t uartb_usart = {
   .baud_rate        = USART_DEFAULT_BAUD_TTL,
   .sbp_message_mask = 0xFF00,
   .configure_telemetry_radio_on_boot = 1,
+  .sbp_fwd = 0,
 };
 
 bool all_uarts_enabled = false;
@@ -75,6 +78,7 @@ void usarts_setup()
 
   SETTING("uart_ftdi", "mode", ftdi_usart.mode, TYPE_PORTMODE);
   SETTING("uart_ftdi", "sbp_message_mask", ftdi_usart.sbp_message_mask, TYPE_INT);
+  SETTING("uart_ftdi", "fwd_msg", ftdi_usart.sbp_fwd, TYPE_INT);
   SETTING_NOTIFY("uart_ftdi", "baudrate", ftdi_usart.baud_rate, TYPE_INT,
                  baudrate_change_notify);
 
@@ -82,6 +86,7 @@ void usarts_setup()
   SETTING("uart_uarta", "sbp_message_mask", uarta_usart.sbp_message_mask, TYPE_INT);
   SETTING("uart_uarta", "configure_telemetry_radio_on_boot",
           uarta_usart.configure_telemetry_radio_on_boot, TYPE_BOOL);
+  SETTING("uart_uarta", "fwd_msg", uarta_usart.sbp_fwd, TYPE_INT);
   SETTING_NOTIFY("uart_uarta", "baudrate", uarta_usart.baud_rate, TYPE_INT,
           baudrate_change_notify);
 
@@ -89,6 +94,7 @@ void usarts_setup()
   SETTING("uart_uartb", "sbp_message_mask", uartb_usart.sbp_message_mask, TYPE_INT);
   SETTING("uart_uartb", "configure_telemetry_radio_on_boot",
           uartb_usart.configure_telemetry_radio_on_boot, TYPE_BOOL);
+  SETTING("uart_uartb", "fwd_msg", uartb_usart.sbp_fwd, TYPE_INT);
   SETTING_NOTIFY("uart_uartb", "baudrate", uartb_usart.baud_rate, TYPE_INT,
           baudrate_change_notify);
 

--- a/src/peripherals/usart.h
+++ b/src/peripherals/usart.h
@@ -31,6 +31,7 @@ typedef struct {
   u32 baud_rate;
   u32 sbp_message_mask;
   u8  configure_telemetry_radio_on_boot;
+  u8  sbp_fwd;
 } usart_settings_t;
 
 /** Message and baud rate settings for all USARTs. */


### PR DESCRIPTION
still waiting on new SBP release but in the mean time,  @jacobmcnamee any time to review?

This computes the uart period and sends it out over the UART
It also makes a setting to decide whether to forward data from base out of the uart so that we can configure the other uarts the same as the FTDI uart when necessary or turn off the base station forwarding behavoir when it it saturating our serial line.