### PR TITLE
v3: Perform acquisition peak search in NAPv3.

### DIFF
--- a/src/board/v3/acq.c
+++ b/src/board/v3/acq.c
@@ -19,6 +19,7 @@
 #include <libswiftnav/logging.h>
 
 #include "nap/nap_constants.h"
+#include "nap/nap_hw.h"
 #include "nap/fft.h"
 
 #define CHIP_RATE 1.023e6f
@@ -102,26 +103,13 @@ bool acq_search(gnss_signal_t sid, float cf_min, float cf_max,
     }
 
     /* Peak search */
-    float mag_sq_sum = 0.0f;
-    bool match = false;
-    for (u32 i=0; i<fft_len; i++) {
-      const fft_cplx_t *r = &result_fft[i];
-
-      float re = (float)r->re;
-      float im = (float)r->im;
-      float mag_sq = re*re + im*im;
-      mag_sq_sum += mag_sq;
-
-      if (mag_sq > best_mag_sq) {
-        best_mag_sq = mag_sq;
-        best_doppler = doppler;
-        best_sample_offset = i;
-        match = true;
-      }
-    }
-
-    if (match) {
-      best_mag_sq_sum = mag_sq_sum;
+    float mag_sq = (float)NAP->ACQ_PEAK_MAGSQ;
+    if (mag_sq > best_mag_sq) {
+      best_doppler = doppler;
+      best_mag_sq = mag_sq;
+      best_mag_sq_sum = (float)NAP->ACQ_PEAK_SUM;
+      best_sample_offset = ((NAP->ACQ_STATUS & NAP_ACQ_STATUS_PEAK_INDEX_Msk)
+          >> NAP_ACQ_STATUS_PEAK_INDEX_Pos);
     }
   }
 

--- a/src/board/v3/acq.c
+++ b/src/board/v3/acq.c
@@ -103,13 +103,21 @@ bool acq_search(gnss_signal_t sid, float cf_min, float cf_max,
     }
 
     /* Peak search */
+    u32 acq_status = NAP->ACQ_STATUS;
     float mag_sq = (float)NAP->ACQ_PEAK_MAGSQ;
     if (mag_sq > best_mag_sq) {
       best_doppler = doppler;
       best_mag_sq = mag_sq;
-      best_mag_sq_sum = (float)NAP->ACQ_PEAK_SUM;
-      best_sample_offset = ((NAP->ACQ_STATUS & NAP_ACQ_STATUS_PEAK_INDEX_Msk)
+      best_mag_sq_sum = (float)NAP->ACQ_SUM_MAGSQ;
+      best_sample_offset = ((acq_status & NAP_ACQ_STATUS_PEAK_INDEX_Msk)
           >> NAP_ACQ_STATUS_PEAK_INDEX_Pos);
+    }
+
+    if (acq_status & NAP_ACQ_STATUS_PEAK_MAGSQ_OVF_Msk) {
+      log_error("Acquisition: Magnitude squared overflow.");
+    }
+    if (acq_status & NAP_ACQ_STATUS_SUM_MAGSQ_OVF_Msk) {
+      log_error("Acquisition: Magnitude squared sum overflow.");
     }
   }
 

--- a/src/board/v3/nap/fft.c
+++ b/src/board/v3/nap/fft.c
@@ -77,7 +77,8 @@ static void control_set_dma(void)
       (NAP_ACQ_CONTROL_FFT_INPUT_DMA      << NAP_ACQ_CONTROL_FFT_INPUT_Pos) |
       (0                                  << NAP_ACQ_CONTROL_RF_FE_Pos) |
       (0                                  << NAP_ACQ_CONTROL_RF_FE_CH_Pos) |
-      (0                                  << NAP_ACQ_CONTROL_LENGTH_Pos);
+      (0                                  << NAP_ACQ_CONTROL_LENGTH_Pos) |
+      (NAP_ACQ_CONTROL_PEAK_SEARCH        << NAP_ACQ_CONTROL_PEAK_SEARCH_Pos);
 }
 
 /** Set the ACQ control register for frontend samples input.

--- a/src/board/v3/nap/nap_hw.h
+++ b/src/board/v3/nap/nap_hw.h
@@ -54,6 +54,8 @@ typedef struct {
   volatile uint32_t ACQ_TIMING_SNAPSHOT;
   volatile uint32_t ACQ_START_SNAPSHOT;
   volatile uint32_t ACQ_FFT_CONFIG;
+  volatile uint32_t ACQ_PEAK_MAGSQ;
+  volatile uint32_t ACQ_PEAK_SUM;
   volatile uint32_t TRK_CONTROL;
   volatile uint32_t TRK_IRQ;
   volatile uint32_t TRK_IRQ_ERROR;
@@ -79,6 +81,9 @@ typedef struct {
 #define NAP_CONTROL_KEY_BYTE_Pos (24U)
 #define NAP_CONTROL_KEY_BYTE_Msk (0xFFU << NAP_CONTROL_KEY_BYTE_Pos)
 
+#define NAP_ACQ_STATUS_PEAK_INDEX_Pos (7U)
+#define NAP_ACQ_STATUS_PEAK_INDEX_Msk (0x7FFFU << NAP_ACQ_STATUS_PEAK_INDEX_Pos)
+
 #define NAP_ACQ_CONTROL_DMA_INPUT_Pos (0U)
 #define NAP_ACQ_CONTROL_DMA_INPUT_Msk (0x1U << NAP_ACQ_CONTROL_DMA_INPUT_Pos)
 #define NAP_ACQ_CONTROL_DMA_INPUT_FFT (0U)
@@ -97,6 +102,9 @@ typedef struct {
 
 #define NAP_ACQ_CONTROL_LENGTH_Pos (5U)
 #define NAP_ACQ_CONTROL_LENGTH_Msk (0xFFFFFU << NAP_ACQ_CONTROL_LENGTH_Pos)
+
+#define NAP_ACQ_CONTROL_PEAK_SEARCH_Pos (25U)
+#define NAP_ACQ_CONTROL_PEAK_SEARCH (1U)
 
 #define NAP_ACQ_FFT_CONFIG_DIR_Pos (0U)
 #define NAP_ACQ_FFT_CONFIG_DIR_Msk (0x1U << NAP_ACQ_FFT_CONFIG_DIR_Pos)

--- a/src/board/v3/nap/nap_hw.h
+++ b/src/board/v3/nap/nap_hw.h
@@ -55,7 +55,7 @@ typedef struct {
   volatile uint32_t ACQ_START_SNAPSHOT;
   volatile uint32_t ACQ_FFT_CONFIG;
   volatile uint32_t ACQ_PEAK_MAGSQ;
-  volatile uint32_t ACQ_PEAK_SUM;
+  volatile uint32_t ACQ_SUM_MAGSQ;
   volatile uint32_t TRK_CONTROL;
   volatile uint32_t TRK_IRQ;
   volatile uint32_t TRK_IRQ_ERROR;
@@ -84,6 +84,12 @@ typedef struct {
 #define NAP_ACQ_STATUS_PEAK_INDEX_Pos (7U)
 #define NAP_ACQ_STATUS_PEAK_INDEX_Msk (0x7FFFU << NAP_ACQ_STATUS_PEAK_INDEX_Pos)
 
+#define NAP_ACQ_STATUS_PEAK_MAGSQ_OVF_Pos (22U)
+#define NAP_ACQ_STATUS_PEAK_MAGSQ_OVF_Msk (0x1U << NAP_ACQ_STATUS_PEAK_MAGSQ_OVF_Pos)
+
+#define NAP_ACQ_STATUS_SUM_MAGSQ_OVF_Pos (23U)
+#define NAP_ACQ_STATUS_SUM_MAGSQ_OVF_Msk (0x1U << NAP_ACQ_STATUS_SUM_MAGSQ_OVF_Pos)
+
 #define NAP_ACQ_CONTROL_DMA_INPUT_Pos (0U)
 #define NAP_ACQ_CONTROL_DMA_INPUT_Msk (0x1U << NAP_ACQ_CONTROL_DMA_INPUT_Pos)
 #define NAP_ACQ_CONTROL_DMA_INPUT_FFT (0U)
@@ -104,6 +110,7 @@ typedef struct {
 #define NAP_ACQ_CONTROL_LENGTH_Msk (0xFFFFFU << NAP_ACQ_CONTROL_LENGTH_Pos)
 
 #define NAP_ACQ_CONTROL_PEAK_SEARCH_Pos (25U)
+#define NAP_ACQ_CONTROL_PEAK_SEARCH_Msk (0x1U << NAP_ACQ_CONTROL_PEAK_SEARCH_Pos)
 #define NAP_ACQ_CONTROL_PEAK_SEARCH (1U)
 
 #define NAP_ACQ_FFT_CONFIG_DIR_Pos (0U)


### PR DESCRIPTION
Performs the acquisition peak search in the NAP. SwiftNAP v3.1.0 has a peak search component connected to the FFT output. Whenever peak search is enabled, the magnitude squared, accumulated values and FFT index will be available right after all values were read out of the FFT. This PR enables peak search whenever an IFFT is performed.

/cc @jacobmcnamee @gsmcmullin 