### PR TITLE
v3: Update register map to support NAP v3.2.0

### DIFF
--- a/src/board/v3/nap/nap_hw.h
+++ b/src/board/v3/nap/nap_hw.h
@@ -54,6 +54,7 @@ typedef struct {
   volatile uint32_t ACQ_TIMING_SNAPSHOT;
   volatile uint32_t ACQ_START_SNAPSHOT;
   volatile uint32_t ACQ_FFT_CONFIG;
+  volatile uint32_t ACQ_PINC;
   volatile uint32_t TRK_CONTROL;
   volatile uint32_t TRK_IRQ;
   volatile uint32_t TRK_IRQ_ERROR;

--- a/src/board/v3/nap/nap_hw.h
+++ b/src/board/v3/nap/nap_hw.h
@@ -54,7 +54,7 @@ typedef struct {
   volatile uint32_t ACQ_TIMING_SNAPSHOT;
   volatile uint32_t ACQ_START_SNAPSHOT;
   volatile uint32_t ACQ_FFT_CONFIG;
-  volatile uint32_t ACQ_PINC;
+  volatile int32_t  ACQ_PINC;
   volatile uint32_t TRK_CONTROL;
   volatile uint32_t TRK_IRQ;
   volatile uint32_t TRK_IRQ_ERROR;


### PR DESCRIPTION
NAPv3.2.0 has a mixer in the acquisition engine to support satellite selection for Glonass acquisition.
This is to unblock Exafore on some GLO development on the side.

/cc @jacobmcnamee @gsmcmullin 