### PR TITLE
v3: Remove unused NAPv3 frontend channels.

### DIFF
--- a/src/board/v3/acq.c
+++ b/src/board/v3/acq.c
@@ -28,7 +28,7 @@
 #define FFT_SCALE_SCHED_CODE 0x15555555
 #define FFT_SCALE_SCHED_SAMPLES 0x15555555
 #define FFT_SCALE_SCHED_INV 0x15550000
-#define FFT_SAMPLES_INPUT FFT_SAMPLES_INPUT_RF1_CH0
+#define FFT_SAMPLES_INPUT FFT_SAMPLES_INPUT_RF1
 
 static void code_resample(gnss_signal_t sid, float chips_per_sample,
                           fft_cplx_t *resampled, u32 resampled_length);

--- a/src/board/v3/nap/fft.c
+++ b/src/board/v3/nap/fft.c
@@ -76,7 +76,6 @@ static void control_set_dma(void)
       (NAP_ACQ_CONTROL_DMA_INPUT_FFT      << NAP_ACQ_CONTROL_DMA_INPUT_Pos) |
       (NAP_ACQ_CONTROL_FFT_INPUT_DMA      << NAP_ACQ_CONTROL_FFT_INPUT_Pos) |
       (0                                  << NAP_ACQ_CONTROL_RF_FE_Pos) |
-      (0                                  << NAP_ACQ_CONTROL_RF_FE_CH_Pos) |
       (0                                  << NAP_ACQ_CONTROL_LENGTH_Pos);
 }
 
@@ -91,8 +90,7 @@ static void control_set_samples(fft_samples_input_t samples_input,
   NAP->ACQ_CONTROL =
       (NAP_ACQ_CONTROL_DMA_INPUT_FFT      << NAP_ACQ_CONTROL_DMA_INPUT_Pos) |
       (NAP_ACQ_CONTROL_FFT_INPUT_FRONTEND << NAP_ACQ_CONTROL_FFT_INPUT_Pos) |
-      ((samples_input >> 1)               << NAP_ACQ_CONTROL_RF_FE_Pos) |
-      ((samples_input & 1)                << NAP_ACQ_CONTROL_RF_FE_CH_Pos) |
+      ((samples_input)                    << NAP_ACQ_CONTROL_RF_FE_Pos) |
       (len_points                         << NAP_ACQ_CONTROL_LENGTH_Pos);
 
   /* Set up timing compare */

--- a/src/board/v3/nap/fft.h
+++ b/src/board/v3/nap/fft.h
@@ -32,14 +32,10 @@ typedef enum {
 } fft_dir_t;
 
 typedef enum {
-  FFT_SAMPLES_INPUT_RF1_CH0 = 0,
-  FFT_SAMPLES_INPUT_RF1_CH1 = 1,
-  FFT_SAMPLES_INPUT_RF2_CH0 = 2,
-  FFT_SAMPLES_INPUT_RF2_CH1 = 3,
-  FFT_SAMPLES_INPUT_RF3_CH0 = 4,
-  FFT_SAMPLES_INPUT_RF3_CH1 = 5,
-  FFT_SAMPLES_INPUT_RF4_CH0 = 6,
-  FFT_SAMPLES_INPUT_RF5_CH1 = 7
+  FFT_SAMPLES_INPUT_RF1 = 0,
+  FFT_SAMPLES_INPUT_RF2 = 1,
+  FFT_SAMPLES_INPUT_RF3 = 2,
+  FFT_SAMPLES_INPUT_RF4 = 3,
 } fft_samples_input_t;
 
 bool fft(const fft_cplx_t *in, fft_cplx_t *out, u32 len_log2,

--- a/src/board/v3/nap/nap_hw.h
+++ b/src/board/v3/nap/nap_hw.h
@@ -62,7 +62,7 @@ typedef struct {
   volatile uint32_t PPS_CONTROL;
   volatile uint32_t PPS_TIMING_COMPARE;
   volatile uint32_t EVENT_TIMING_SNAPSHOT;
-  volatile uint32_t FE_PINC[8];
+  volatile uint32_t FE_PINC[4];
   nap_trk_regs_t TRK_CH[NAP_MAX_N_TRACK_CHANNELS];
 } nap_t;
 
@@ -90,10 +90,7 @@ typedef struct {
 #define NAP_ACQ_CONTROL_FFT_INPUT_FRONTEND (1U)
 
 #define NAP_ACQ_CONTROL_RF_FE_Pos (2U)
-#define NAP_ACQ_CONTROL_RF_FE_Msk (0x3U << NAP_ACQ_CONTROL_RF_FE_Pos)
-
-#define NAP_ACQ_CONTROL_RF_FE_CH_Pos (4U)
-#define NAP_ACQ_CONTROL_RF_FE_CH_Msk (0x1U << NAP_ACQ_CONTROL_RF_FE_CH_Pos)
+#define NAP_ACQ_CONTROL_RF_FE_Msk (0x7U << NAP_ACQ_CONTROL_RF_FE_Pos)
 
 #define NAP_ACQ_CONTROL_LENGTH_Pos (5U)
 #define NAP_ACQ_CONTROL_LENGTH_Msk (0xFFFFFU << NAP_ACQ_CONTROL_LENGTH_Pos)


### PR DESCRIPTION
GPS+Glonass only need 4 frontend channels in SwiftNAP v3.3.0. Removed the rest in order to free up resources.

/cc @jacobmcnamee @gsmcmullin 