### PR TITLE
Compute measurement time delta in tracking_channel_measurement_get()

### DIFF
--- a/src/solution.c
+++ b/src/solution.c
@@ -411,12 +411,13 @@ static void solution_thread(void *arg)
       solution_simulation();
     }
 
+    u64 nav_tc = nap_timing_count();
     u8 n_ready = 0;
     channel_measurement_t meas[MAX_CHANNELS];
     for (u8 i=0; i<nap_track_n_channels; i++) {
       tracking_channel_lock(i);
       if (use_tracking_channel(i)) {
-        tracking_channel_measurement_get(i, &meas[n_ready]);
+        tracking_channel_measurement_get(i, nav_tc, &meas[n_ready]);
         n_ready++;
       }
       tracking_channel_unlock(i);
@@ -432,7 +433,6 @@ static void solution_thread(void *arg)
      * more intelligent with the solution time.
      */
     static u8 n_ready_old = 0;
-    u64 nav_tc = nap_timing_count();
     static navigation_measurement_t nav_meas[MAX_CHANNELS];
 
     const channel_measurement_t *p_meas[n_ready];
@@ -445,8 +445,7 @@ static void solution_thread(void *arg)
     }
 
     ephemeris_lock();
-    if (calc_navigation_measurement(n_ready, p_meas, p_nav_meas,
-                                    (double)((u32)nav_tc)/SAMPLE_FREQ, p_e_meas)
+    if (calc_navigation_measurement(n_ready, p_meas, p_nav_meas, p_e_meas)
         != 0) {
       log_error("calc_navigation_measurement() returned an error");
       ephemeris_unlock();

--- a/src/track.c
+++ b/src/track.c
@@ -553,9 +553,10 @@ bool tracking_channel_bit_polarity_resolved(tracker_channel_id_t id)
 /** Retrieve a channel measurement for a tracker channel.
  *
  * \param id      ID of the tracker channel to use.
+ * \param ref_tc  Reference timing count.
  * \param meas    Pointer to output channel_measurement_t.
  */
-void tracking_channel_measurement_get(tracker_channel_id_t id,
+void tracking_channel_measurement_get(tracker_channel_id_t id, u32 ref_tc,
                                       channel_measurement_t *meas)
 {
   tracker_channel_t *tracker_channel = tracker_channel_get(id);
@@ -570,7 +571,8 @@ void tracking_channel_measurement_get(tracker_channel_id_t id,
   meas->carrier_phase = common_data->carrier_phase;
   meas->carrier_freq = common_data->carrier_freq;
   meas->time_of_week_ms = common_data->TOW_ms;
-  meas->receiver_time = (double)common_data->sample_count / SAMPLE_FREQ;
+  meas->rec_time_delta = (double)((s32)(common_data->sample_count - ref_tc))
+                             / SAMPLE_FREQ;
   meas->snr = common_data->cn0;
   if (internal_data->bit_polarity == BIT_POLARITY_INVERTED) {
     meas->carrier_phase += 0.5;

--- a/src/track.h
+++ b/src/track.h
@@ -70,7 +70,7 @@ double tracking_channel_carrier_freq_get(tracker_channel_id_t id);
 s32 tracking_channel_tow_ms_get(tracker_channel_id_t id);
 bool tracking_channel_bit_sync_resolved(tracker_channel_id_t id);
 bool tracking_channel_bit_polarity_resolved(tracker_channel_id_t id);
-void tracking_channel_measurement_get(tracker_channel_id_t id,
+void tracking_channel_measurement_get(tracker_channel_id_t id, u32 ref_tc,
                                       channel_measurement_t *meas);
 
 bool tracking_channel_evelation_degrees_set(gnss_signal_t sid, s8 elevation);


### PR DESCRIPTION
Compute the integer difference between `nav_tc` and tracking channel timing count inside `tracking_channel_measurement_get()` instead of converting both to doubles and subtracting in libswiftnav. Better numerically and facilitates computing 64bit timing count for the tracking channel for #651.