### PR TITLE
NMEA update

### DIFF
--- a/src/nmea.c
+++ b/src/nmea.c
@@ -167,22 +167,24 @@ void nmea_gpgga(const double pos_llh[3], const gps_time_t *gps_t, u8 n_used,
 
   unix_t = gps2time(gps_t);
   gmtime_r(&unix_t, &t);
+ 
+  double frac_s  = fmod(gps_t->tow, 1.0);
+  
+  double lat     = fabs( round( R2D * pos_llh[0] * 1e8 ) / 1e8 );
+  double lon     = fabs( round( R2D * pos_llh[1] * 1e8 ) / 1e8 );
 
-  double frac_s = fmod(gps_t->tow, 1.0);
+  char   lat_dir = pos_llh[0] < 0.0 ? 'S' : 'N';
+  u16    lat_deg = (u16)lat;
+  double lat_min = (lat - (double)lat_deg) * 60.0;
 
-  s16 lat_deg = R2D * (pos_llh[0]);
-  double lat_min = MINUTES(pos_llh[0]);
-  s16 lon_deg = R2D * (pos_llh[1]);
-  double lon_min = MINUTES(pos_llh[1]);
-  lat_deg = abs(lat_deg);
-  lon_deg = abs(lon_deg);
-  char lat_dir = pos_llh[0] < 0 ? 'S' : 'N';
-  char lon_dir = pos_llh[1] < 0 ? 'W' : 'E';
-
+  char   lon_dir = pos_llh[1] < 0.0 ? 'W' : 'E';
+  u16    lon_deg = (u16)lon;
+  double lon_min = (lon - (double)lon_deg) * 60.0;
+  
   NMEA_SENTENCE_START(120);
   /* Note, geoid separation is set to 0 because no geoid model exists*/
   NMEA_SENTENCE_PRINTF("$GPGGA,%02d%02d%06.3f,"
-                       "%02d%010.7f,%c,%03d%010.7f,%c,"
+                       "%02u%010.7f,%c,%03u%010.7f,%c,"
                        "%01d,%02d,%.1f,%.2f,M,0,M,",
                        t.tm_hour, t.tm_min, t.tm_sec + frac_s,
                        lat_deg, lat_min, lat_dir, lon_deg, lon_min, lon_dir,
@@ -294,17 +296,19 @@ void nmea_gprmc(const gnss_solution *soln, const gps_time_t *gps_t)
 
   unix_t = gps2time(gps_t);
   gmtime_r(&unix_t, &t);
-  double frac_s = fmod(gps_t->tow, 1.0);
+  
+  double frac_s  = fmod(gps_t->tow, 1.0);
 
-  s16 lat_deg = R2D * (soln->pos_llh[0]);
-  double lat_min = MINUTES(soln->pos_llh[0]);
-  s16 lon_deg = R2D * (soln->pos_llh[1]);
-  double lon_min = MINUTES(soln->pos_llh[1]);
-  lat_deg = abs(lat_deg);
-  lon_deg = abs(lon_deg);
+  double lat     = fabs( round( R2D * soln->pos_llh[0] * 1e8 ) / 1e8 );
+  double lon     = fabs( round( R2D * soln->pos_llh[1] * 1e8 ) / 1e8 );
 
-  char lat_dir = soln->pos_llh[0] < 0 ? 'S' : 'N';
-  char lon_dir = soln->pos_llh[1] < 0 ? 'W' : 'E';
+  char   lat_dir = soln->pos_llh[0] < 0.0 ? 'S' : 'N';
+  u16    lat_deg = (u16)lat;
+  double lat_min = (lat - (double)lat_deg) * 60.0;
+
+  char   lon_dir = soln->pos_llh[1] < 0.0 ? 'W' : 'E';
+  u16    lon_deg = (u16)lon;
+  double lon_min = (lon - (double)lon_deg) * 60.0;
 
   float velocity;
   float x,y,z;
@@ -319,7 +323,7 @@ void nmea_gprmc(const gnss_solution *soln, const gps_time_t *gps_t)
   NMEA_SENTENCE_START(140);
   NMEA_SENTENCE_PRINTF(
                 "$GPRMC,%02d%02d%06.3f,A," /* Command, Time (UTC), Valid */
-                "%02d%010.7f,%c,%03d%010.7f,%c," /* Lat/Lon */
+                "%02u%010.7f,%c,%03u%010.7f,%c," /* Lat/Lon */
                 "%06.2f,%05.1f," /* Speed, Course */
                 "%02d%02d%02d," /* Date Stamp */
                 ",", /* Variation */
@@ -389,20 +393,22 @@ void nmea_gpgll(const gnss_solution *soln, const gps_time_t *gps_t)
   unix_t = gps2time(gps_t);
   gmtime_r(&unix_t, &t);
 
-  double frac_s = fmod(gps_t->tow, 1.0);
-  s16 lat_deg = R2D * (soln->pos_llh[0]);
-  double lat_min = MINUTES(soln->pos_llh[0]);
-  s16 lon_deg = R2D * (soln->pos_llh[1]);
-  double lon_min =  MINUTES(soln->pos_llh[1]);
-  lat_deg = abs(lat_deg);
-  lon_deg = abs(lon_deg);
+  double frac_s  = fmod(gps_t->tow, 1.0);
+  
+  double lat     = fabs( round( R2D * soln->pos_llh[0] * 1e8 ) / 1e8 );
+  double lon     = fabs( round( R2D * soln->pos_llh[1] * 1e8 ) / 1e8 );
 
-  char lat_dir = soln->pos_llh[0] < 0 ? 'S' : 'N';
-  char lon_dir = soln->pos_llh[1] < 0 ? 'W' : 'E';
+  char   lat_dir = soln->pos_llh[0] < 0.0 ? 'S' : 'N';
+  u16    lat_deg = (u16)lat;
+  double lat_min = (lat - (double)lat_deg) * 60.0;
+
+  char   lon_dir = soln->pos_llh[1] < 0.0 ? 'W' : 'E';
+  u16    lon_deg = (u16)lon;
+  double lon_min = (lon - (double)lon_deg) * 60.0;  
 
   NMEA_SENTENCE_START(120);
   NMEA_SENTENCE_PRINTF("$GPGLL,"
-                "%02d%010.7f,%c,%03d%010.7f,%c," /* Lat/Lon */
+                "%02u%010.7f,%c,%03u%010.7f,%c," /* Lat/Lon */
                 "%02d%02d%06.3f,A", /* Time (UTC), Valid */
                 lat_deg, lat_min, lat_dir, lon_deg, lon_min, lon_dir,
                 t.tm_hour, t.tm_min, t.tm_sec + frac_s);

--- a/src/nmea.c
+++ b/src/nmea.c
@@ -435,7 +435,7 @@ void nmea_gpzda(const gps_time_t *gps_t )
                 "%02d,%02d,%d," /* Date Stamp */
                 "00,00", /* Time zone */
                 t.tm_hour, t.tm_min, t.tm_sec + frac_s,
-                t.tm_mday, t.tm_mon + 1, 2016);
+                t.tm_mday, t.tm_mon + 1, 1900 + t.tm_year );
   NMEA_SENTENCE_DONE();
 
 } // nmea_gpzda()

--- a/src/nmea.c
+++ b/src/nmea.c
@@ -177,8 +177,8 @@ void nmea_gpgga(const double pos_llh[3], const gps_time_t *gps_t, u8 n_used,
  
   double frac_s  = fmod(gps_t->tow, 1.0);
   
-  double lat     = fabs( round( R2D * pos_llh[0] * 1e8 ) / 1e8 );
-  double lon     = fabs( round( R2D * pos_llh[1] * 1e8 ) / 1e8 );
+  double lat     = fabs(round(R2D * pos_llh[0] * 1e8) /1e8);
+  double lon     = fabs(round(R2D * pos_llh[1] * 1e8) /1e8);
 
   char   lat_dir = pos_llh[0] < 0.0 ? 'S' : 'N';
   u16    lat_deg = (u16)lat;
@@ -188,7 +188,7 @@ void nmea_gpgga(const double pos_llh[3], const gps_time_t *gps_t, u8 n_used,
   u16    lon_deg = (u16)lon;
   double lon_min = (lon - (double)lon_deg) * 60.0;
   
-  NMEA_SENTENCE_START( 120 );
+  NMEA_SENTENCE_START(120);
   NMEA_SENTENCE_PRINTF("$GPGGA,%02d%02d%06.3f,"
                        "%02u%010.7f,%c,%03u%010.7f,%c,"
                        "%01d,%02d,%.1f,%.2f,M,0.0,M,",
@@ -290,8 +290,8 @@ void nmea_gprmc(const gnss_solution *soln, const gps_time_t *gps_t)
   
   double frac_s  = fmod(gps_t->tow, 1.0);
 
-  double lat     = fabs( round( R2D * soln->pos_llh[0] * 1e8 ) / 1e8 );
-  double lon     = fabs( round( R2D * soln->pos_llh[1] * 1e8 ) / 1e8 );
+  double lat     = fabs(round(R2D * soln->pos_llh[0] * 1e8) / 1e8);
+  double lon     = fabs(round(R2D * soln->pos_llh[1] * 1e8) / 1e8);
 
   char   lat_dir = soln->pos_llh[0] < 0.0 ? 'S' : 'N';
   u16    lat_deg = (u16)lat;
@@ -306,7 +306,7 @@ void nmea_gprmc(const gnss_solution *soln, const gps_time_t *gps_t)
   y = soln->vel_ned[1];
   z = soln->vel_ned[2];
   float course = R2D * atan2(y,x);
-  if ( course < 0.0 ) { 
+  if (course < 0.0) { 
     course += 360.0;
   }
   /* Conversion to magnitue knots */
@@ -338,7 +338,7 @@ void nmea_gpvtg(const gnss_solution *soln)
   y = soln->vel_ned[1];
   z = soln->vel_ned[2];
   float course = R2D * atan2(y,x);
-  if ( course < 0.0 ) {
+  if (course < 0.0) {
     course += 360.0;
   }
   /* Conversion to magnitue knots */
@@ -372,8 +372,8 @@ void nmea_gpgll(const gnss_solution *soln, const gps_time_t *gps_t)
 
   double frac_s  = fmod(gps_t->tow, 1.0);
   
-  double lat     = fabs( round( R2D * soln->pos_llh[0] * 1e8 ) / 1e8 );
-  double lon     = fabs( round( R2D * soln->pos_llh[1] * 1e8 ) / 1e8 );
+  double lat     = fabs(round(R2D * soln->pos_llh[0] * 1e8) / 1e8);
+  double lon     = fabs(round(R2D * soln->pos_llh[1] * 1e8) / 1e8);
 
   char   lat_dir = soln->pos_llh[0] < 0.0 ? 'S' : 'N';
   u16    lat_deg = (u16)lat;
@@ -397,14 +397,14 @@ void nmea_gpgll(const gnss_solution *soln, const gps_time_t *gps_t)
  *
  * \param gps_t Pointer to the current GPS Time.
  */
-void nmea_gpzda( const gps_time_t *gps_t )
+void nmea_gpzda(const gps_time_t *gps_t)
 {
   time_t unix_t;
   struct tm t;
 
-  unix_t = gps2time( gps_t );
-  gmtime_r( &unix_t, &t );
-  double frac_s = fmod( gps_t->tow, 1.0 );
+  unix_t = gps2time(gps_t);
+  gmtime_r(&unix_t, &t);
+  double frac_s = fmod(gps_t->tow, 1.0);
 
   NMEA_SENTENCE_START(40); 
   NMEA_SENTENCE_PRINTF(
@@ -412,7 +412,7 @@ void nmea_gpzda( const gps_time_t *gps_t )
                 "%02d,%02d,%d,"          /* Date Stamp */
                 ",",                     /* Time zone */
                 t.tm_hour, t.tm_min, t.tm_sec + frac_s,
-                t.tm_mday, t.tm_mon + 1, 1900 + t.tm_year );
+                t.tm_mday, t.tm_mon + 1, 1900 + t.tm_year);
   NMEA_SENTENCE_DONE();
 
 } // nmea_gpzda()

--- a/src/nmea.c
+++ b/src/nmea.c
@@ -191,7 +191,7 @@ void nmea_gpgga(const double pos_llh[3], const gps_time_t *gps_t, u8 n_used,
   NMEA_SENTENCE_START( 120 );
   NMEA_SENTENCE_PRINTF("$GPGGA,%02d%02d%06.3f,"
                        "%02u%010.7f,%c,%03u%010.7f,%c,"
-                       "%01d,%02d,%.1f,%.2f,M,,M,",
+                       "%01d,%02d,%.1f,%.2f,M,0.0,M,",
                        t.tm_hour, t.tm_min, t.tm_sec + frac_s,
                        lat_deg, lat_min, lat_dir, lon_deg, lon_min, lon_dir,
                        fix_type, n_used, hdop, pos_llh[2]

--- a/src/nmea.h
+++ b/src/nmea.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2014 Swift Navigation Inc.
+ * Copyright (C) 2013-2016 Swift Navigation Inc.
  * Contact: Fergus Noble <fergus@swift-nav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -32,8 +32,8 @@
 #define NMEA_GGA_FIX_MANUAL  7
 #define NMEA_GGA_FIX_SIM     8
 
-#define MS2KNOTTS(x,y,z) sqrt((x)*(x) + (y)*(y) + (z)*(z)) * 1.94385
-#define MS2KMHR(x,y,z) sqrt((x)*(x)+(y)*(y)+(z)*(z)) * (3600/1000)
+#define MS2KNOTTS(x,y,z)     sqrt((x)*(x) + (y)*(y) + (z)*(z)) * 1.94385
+#define MS2KMHR(x,y,z)       sqrt((x)*(x)+(y)*(y)+(z)*(z)) * (3600.0/1000.0)
 
 
 void nmea_setup(void);
@@ -45,6 +45,7 @@ void nmea_gpgsv(u8 n_used, const navigation_measurement_t *nav_meas,
 void nmea_gprmc(const gnss_solution *soln, const gps_time_t *gps_t);
 void nmea_gpvtg(const gnss_solution *soln);
 void nmea_gpgll(const gnss_solution *soln, const gps_time_t *gps_t);
+void nmea_gpzda(const gps_time_t *gps_t);
 void nmea_send_msgs(gnss_solution *soln, u8 n, 
                     navigation_measurement_t *nm, const dops_t *dops);
 

--- a/src/nmea.h
+++ b/src/nmea.h
@@ -32,7 +32,6 @@
 #define NMEA_GGA_FIX_MANUAL  7
 #define NMEA_GGA_FIX_SIM     8
 
-#define MINUTES(X) fabs(60 * (R2D * (X) - ((s16)(R2D * (X)))));
 #define MS2KNOTTS(x,y,z) sqrt((x)*(x) + (y)*(y) + (z)*(z)) * 1.94385
 #define MS2KMHR(x,y,z) sqrt((x)*(x)+(y)*(y)+(z)*(z)) * (3600/1000)
 


### PR DESCRIPTION
This is the first round of NMEA module update. Changes:
- small code cleanup
- comments updated, message examples removed
- lat/lon computation is changed to avoid case where number of minutes is rounded to 60 in the final snprintf()
- reported year in ZDA message is corrected
- order of outputting messages is changed to output more important messages first 

Cc: @denniszollo @swift-nav/firmware 