### PR TITLE
v3: NAPv3 refactoring

### DIFF
--- a/src/board/v3/nap/fft.c
+++ b/src/board/v3/nap/fft.c
@@ -75,8 +75,7 @@ static void control_set_dma(void)
   NAP->ACQ_CONTROL =
       (NAP_ACQ_CONTROL_DMA_INPUT_FFT      << NAP_ACQ_CONTROL_DMA_INPUT_Pos) |
       (NAP_ACQ_CONTROL_FFT_INPUT_DMA      << NAP_ACQ_CONTROL_FFT_INPUT_Pos) |
-      (0                                  << NAP_ACQ_CONTROL_RF_FE_Pos) |
-      (0                                  << NAP_ACQ_CONTROL_RF_FE_CH_Pos) |
+      (0                                  << NAP_ACQ_CONTROL_FRONTEND_Pos) |
       (0                                  << NAP_ACQ_CONTROL_LENGTH_Pos);
 }
 
@@ -91,8 +90,7 @@ static void control_set_samples(fft_samples_input_t samples_input,
   NAP->ACQ_CONTROL =
       (NAP_ACQ_CONTROL_DMA_INPUT_FFT      << NAP_ACQ_CONTROL_DMA_INPUT_Pos) |
       (NAP_ACQ_CONTROL_FFT_INPUT_FRONTEND << NAP_ACQ_CONTROL_FFT_INPUT_Pos) |
-      ((samples_input >> 1)               << NAP_ACQ_CONTROL_RF_FE_Pos) |
-      ((samples_input & 1)                << NAP_ACQ_CONTROL_RF_FE_CH_Pos) |
+      ((samples_input)                    << NAP_ACQ_CONTROL_FRONTEND_Pos) |
       (len_points                         << NAP_ACQ_CONTROL_LENGTH_Pos);
 
   /* Set up timing compare */

--- a/src/board/v3/nap/nap_common.c
+++ b/src/board/v3/nap/nap_common.c
@@ -48,7 +48,7 @@ void nap_setup(void)
   axi_dma_init();
   axi_dma_start(&AXIDMADriver1);
 
-  NAP->FE_PINC[0] = (u32)round(14.58e6 * pow(2.0, 32.0)
+  FE->BB_PINC[0] = (u32)round(14.58e6 * pow(2.0, 32.0)
                                    / NAP_FRONTEND_SAMPLE_RATE_Hz);
 
   /* Enable NAP interrupt */

--- a/src/board/v3/nap/nap_common.c
+++ b/src/board/v3/nap/nap_common.c
@@ -15,6 +15,7 @@
 #include "../../sbp.h"
 
 #include "nap_hw.h"
+#include "nap_fe_hw.h"
 #include "nap_constants.h"
 #include "axi_dma.h"
 
@@ -48,7 +49,7 @@ void nap_setup(void)
   axi_dma_init();
   axi_dma_start(&AXIDMADriver1);
 
-  FE->BB_PINC[0] = (u32)round(14.58e6 * pow(2.0, 32.0)
+  NAP_FE->BB_PINC[0] = (u32)round(14.58e6 * pow(2.0, 32.0)
                                    / NAP_FRONTEND_SAMPLE_RATE_Hz);
 
   /* Enable NAP interrupt */

--- a/src/board/v3/nap/nap_fe_hw.h
+++ b/src/board/v3/nap/nap_fe_hw.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2016 Swift Navigation Inc.
+ * Contact: Johannes Walter <johannes@swift-nav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef SWIFTNAV_NAP_FE_REGS_H
+#define SWIFTNAV_NAP_FE_REGS_H
+
+#include <stdint.h>
+
+typedef struct {
+  volatile uint32_t STATUS;
+  volatile uint32_t CONTROL;
+  volatile uint32_t VERSION;
+  volatile uint32_t IRQ;
+  volatile uint32_t IRQ_ERROR;
+  volatile uint32_t ACQ_STATUS;
+  volatile uint32_t TRK_STATUS[4];
+  volatile uint32_t BB_PINC[4];
+} nap_fe_t;
+
+/* Bitfields */
+#define NAP_FE_STATUS_CLOCK_LOCKED_Pos (0U)
+#define NAP_FE_STATUS_CLOCK_LOCKED_Msk (0x1U << NAP_FE_STATUS_CLOCK_LOCKED_Pos)
+
+#define NAP_FE_STATUS_FRONTEND_CH_Pos (1U)
+#define NAP_FE_STATUS_FRONTEND_CH_Msk (0xFU << NAP_FE_STATUS_FRONTEND_CH_Pos)
+
+#define NAP_FE_CONTROL_VERSION_ADDR_Pos (0U)
+#define NAP_FE_CONTROL_VERSION_ADDR_Msk (0xFU << NAP_FE_CONTROL_VERSION_ADDR_Pos)
+
+/* Instances */
+#define NAP_FE ((nap_fe_t *)0x43C10000)
+
+#endif /* SWIFTNAV_NAP_FE_REGS_H */

--- a/src/board/v3/nap/nap_hw.h
+++ b/src/board/v3/nap/nap_hw.h
@@ -65,17 +65,6 @@ typedef struct {
   nap_trk_regs_t TRK_CH[NAP_MAX_N_TRACK_CHANNELS];
 } nap_t;
 
-typedef struct {
-  volatile uint32_t STATUS;
-  volatile uint32_t CONTROL;
-  volatile uint32_t VERSION;
-  volatile uint32_t IRQ;
-  volatile uint32_t IRQ_ERROR;
-  volatile uint32_t ACQ_STATUS;
-  volatile uint32_t TRK_STATUS[4];
-  volatile uint32_t BB_PINC[4];
-} frontend_t;
-
 /* Bitfields */
 #define NAP_STATUS_TRACKING_CH_Pos (1U)
 #define NAP_STATUS_TRACKING_CH_Msk (0x3FU << NAP_STATUS_TRACKING_CH_Pos)
@@ -100,7 +89,7 @@ typedef struct {
 #define NAP_ACQ_CONTROL_FFT_INPUT_FRONTEND (1U)
 
 #define NAP_ACQ_CONTROL_FRONTEND_Pos (0U)
-#define NAP_ACQ_CONTROL_FRONTEND_Msk (0x7U << NAP_ACQ_CONTROL_RF_FE_Pos)
+#define NAP_ACQ_CONTROL_FRONTEND_Msk (0x7U << NAP_ACQ_CONTROL_FRONTEND_Pos)
 
 #define NAP_ACQ_CONTROL_LENGTH_Pos (7U)
 #define NAP_ACQ_CONTROL_LENGTH_Msk (0xFFFFFU << NAP_ACQ_CONTROL_LENGTH_Pos)
@@ -122,6 +111,5 @@ typedef struct {
 
 /* Instances */
 #define NAP ((nap_t *)0x43C00000)
-#define FE ((frontend_t *)0x43C10000)
 
 #endif /* SWIFTNAV_NAP_REGS_H */

--- a/src/board/v3/nap/nap_hw.h
+++ b/src/board/v3/nap/nap_hw.h
@@ -24,16 +24,16 @@ typedef struct {
   const volatile uint32_t START_SNAPSHOT;
   volatile uint32_t LENGTH;
   volatile uint32_t SPACING;
-  const volatile int32_t CARR_PHASE_INT;
-  const volatile uint32_t CARR_PHASE_FRAC;
-  volatile int32_t CARR_PINC;
   volatile uint32_t CODE_INIT_INT;
   volatile uint32_t CODE_INIT_FRAC;
-  const volatile uint32_t CODE_PHASE_INT;
-  const volatile uint32_t CODE_PHASE_FRAC;
-  volatile uint32_t CODE_PINC;
   volatile uint32_t CODE_INIT_G1;
   volatile uint32_t CODE_INIT_G2;
+  volatile int32_t  CARR_PINC;
+  volatile uint32_t CODE_PINC;
+  const volatile int32_t  CARR_PHASE_INT;
+  const volatile uint32_t CARR_PHASE_FRAC;
+  const volatile uint32_t CODE_PHASE_INT;
+  const volatile uint32_t CODE_PHASE_FRAC;
   struct {
     const volatile int32_t I;
     const volatile int32_t Q;
@@ -62,9 +62,19 @@ typedef struct {
   volatile uint32_t PPS_CONTROL;
   volatile uint32_t PPS_TIMING_COMPARE;
   volatile uint32_t EVENT_TIMING_SNAPSHOT;
-  volatile uint32_t FE_PINC[8];
   nap_trk_regs_t TRK_CH[NAP_MAX_N_TRACK_CHANNELS];
 } nap_t;
+
+typedef struct {
+  volatile uint32_t STATUS;
+  volatile uint32_t CONTROL;
+  volatile uint32_t VERSION;
+  volatile uint32_t IRQ;
+  volatile uint32_t IRQ_ERROR;
+  volatile uint32_t ACQ_STATUS;
+  volatile uint32_t TRK_STATUS[4];
+  volatile uint32_t BB_PINC[4];
+} frontend_t;
 
 /* Bitfields */
 #define NAP_STATUS_TRACKING_CH_Pos (1U)
@@ -79,23 +89,20 @@ typedef struct {
 #define NAP_CONTROL_KEY_BYTE_Pos (24U)
 #define NAP_CONTROL_KEY_BYTE_Msk (0xFFU << NAP_CONTROL_KEY_BYTE_Pos)
 
-#define NAP_ACQ_CONTROL_DMA_INPUT_Pos (0U)
+#define NAP_ACQ_CONTROL_DMA_INPUT_Pos (3U)
 #define NAP_ACQ_CONTROL_DMA_INPUT_Msk (0x1U << NAP_ACQ_CONTROL_DMA_INPUT_Pos)
 #define NAP_ACQ_CONTROL_DMA_INPUT_FFT (0U)
 #define NAP_ACQ_CONTROL_DMA_INPUT_SAMPLE_GRABBER (1U)
 
-#define NAP_ACQ_CONTROL_FFT_INPUT_Pos (1U)
+#define NAP_ACQ_CONTROL_FFT_INPUT_Pos (4U)
 #define NAP_ACQ_CONTROL_FFT_INPUT_Msk (0x1U << NAP_ACQ_CONTROL_FFT_INPUT_Pos)
 #define NAP_ACQ_CONTROL_FFT_INPUT_DMA (0U)
 #define NAP_ACQ_CONTROL_FFT_INPUT_FRONTEND (1U)
 
-#define NAP_ACQ_CONTROL_RF_FE_Pos (2U)
-#define NAP_ACQ_CONTROL_RF_FE_Msk (0x3U << NAP_ACQ_CONTROL_RF_FE_Pos)
+#define NAP_ACQ_CONTROL_FRONTEND_Pos (0U)
+#define NAP_ACQ_CONTROL_FRONTEND_Msk (0x7U << NAP_ACQ_CONTROL_RF_FE_Pos)
 
-#define NAP_ACQ_CONTROL_RF_FE_CH_Pos (4U)
-#define NAP_ACQ_CONTROL_RF_FE_CH_Msk (0x1U << NAP_ACQ_CONTROL_RF_FE_CH_Pos)
-
-#define NAP_ACQ_CONTROL_LENGTH_Pos (5U)
+#define NAP_ACQ_CONTROL_LENGTH_Pos (7U)
 #define NAP_ACQ_CONTROL_LENGTH_Msk (0xFFFFFU << NAP_ACQ_CONTROL_LENGTH_Pos)
 
 #define NAP_ACQ_FFT_CONFIG_DIR_Pos (0U)
@@ -104,12 +111,17 @@ typedef struct {
 #define NAP_ACQ_FFT_CONFIG_SCALE_Pos (1U)
 #define NAP_ACQ_FFT_CONFIG_SCALE_Msk (0x3FFFFFFFU << NAP_ACQ_FFT_CONFIG_SCALE_Pos)
 
-#define NAP_TRK_CONTROL_SAT_Pos (3u)
+#define NAP_TRK_CONTROL_SAT_Pos (3U)
 #define NAP_TRK_CONTROL_SAT_Msk (0x1FU << NAP_TRK_CONTROL_SAT_Pos)
 
-#define NAP_TRK_STATUS_RUNNING (1 << 31)
+#define NAP_TRK_STATUS_RUNNING_Pos (0U)
+#define NAP_TRK_STATUS_RUNNING_Msk (0x1U << NAP_TRK_STATUS_RUNNING_Pos)
+
+#define NAP_TRK_STATUS_CORR_OVF_Pos (1U)
+#define NAP_TRK_STATUS_CORR_OVF_Msk (0x3FFU << NAP_TRK_STATUS_CORR_OVF_Pos)
 
 /* Instances */
 #define NAP ((nap_t *)0x43C00000)
+#define FE ((frontend_t *)0x43C10000)
 
 #endif /* SWIFTNAV_NAP_REGS_H */

--- a/src/board/v3/nap/track_channel.c
+++ b/src/board/v3/nap/track_channel.c
@@ -123,7 +123,7 @@ void nap_track_read_results(u8 channel,
                             double *carrier_phase)
 {
   corr_t lc[5];
-  if (NAP->TRK_CH[channel].STATUS & 0x3F)
+  if (NAP->TRK_CH[channel].STATUS & NAP_TRK_STATUS_CORR_OVF_Msk)
     log_warn("Track correlator overflow 0x%08X on channel %d",
               NAP->TRK_CH[channel].STATUS, channel);
   for (u8 i = 0; i < 5; i++) {
@@ -143,8 +143,6 @@ void nap_track_read_results(u8 channel,
   nap_ch_state[channel].code_phase +=
     NAP->TRK_CH[channel].LENGTH * NAP->TRK_CH[channel].CODE_PINC;
   nap_ch_state[channel].len = NAP->TRK_CH[channel].LENGTH;
-  if (!(NAP->STATUS & 1))
-    asm("bkpt");
 }
 
 void nap_track_disable(u8 channel)


### PR DESCRIPTION
Modify the register map to be compatible with NAPv3 refactoring. The
frontend DSP chain was moved to its own IP block with a separate
register map.

/cc @jacobmcnamee @gsmcmullin 