### PR TITLE
Check for high RTK DOPs

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -244,4 +244,3 @@ ULIBS =
 include $(SWIFTNAV_ROOT)/ext/Makefile.include
 
 include $(RULESPATH)/rules.mk
-

--- a/src/base_obs.c
+++ b/src/base_obs.c
@@ -116,17 +116,55 @@ static void update_obss(obss_t *new_obss)
    * is the only thread that writes to base_obss. */
   chMtxLock(&base_obs_lock);
 
+  for (u8 i = 0; i < new_obss->n; i++) {
+    /* Set the time */
+    new_obss->nm[i].tot = new_obss->tor;
+    new_obss->nm[i].tot.tow -=
+          new_obss->nm[i].raw_pseudorange / GPS_C;
+    normalize_gps_time(&new_obss->nm[i].tot);
+
+    double clock_err;
+    double clock_rate_err;
+    /* Calculate satellite parameters using the ephemeris. */
+    ephemeris_lock();
+    ephemeris_t *e = ephemeris_get(new_obss->nm[i].sid);
+    if (calc_sat_state(e, &new_obss->nm[i].tot,
+                   new_obss->nm[i].sat_pos,
+                   new_obss->nm[i].sat_vel,
+                   &clock_err, &clock_rate_err) != 0) {
+      continue;
+    }
+    ephemeris_unlock();
+
+    /* Apply corrections to the raw pseudorange, carrier phase and Doppler. */
+    /* TODO Make a function to apply some of these corrections.
+     *      They are used in a couple places. */
+    new_obss->nm[i].pseudorange =
+          new_obss->nm[i].raw_pseudorange
+          + clock_err * GPS_C;
+    new_obss->nm[i].carrier_phase =
+          new_obss->nm[i].raw_carrier_phase
+          - clock_err * GPS_L1_HZ;
+
+    /* Used in tdcp_doppler */
+    new_obss->nm[i].doppler = clock_rate_err * GPS_L1_HZ;
+
+    /* We also apply the clock correction to the time of transmit. */
+    new_obss->nm[i].tot.tow -= clock_err;
+    normalize_gps_time(&new_obss->nm[i].tot);
+  }
+
   /* Create a set of navigation measurements to store the previous
    * observations. */
   static u8 n_old = 0;
+  static gps_time_t tor_old = {.wn = 0, .tow = 0};
   static navigation_measurement_t nm_old[MAX_CHANNELS];
 
   /* Fill in the navigation measurements in base_obss, using TDCP method to
    * calculate the Doppler shift. */
   base_obss.n = tdcp_doppler(new_obss->n, new_obss->nm,
-                             n_old, nm_old, base_obss.nm);
-  /* Copy over the time. */
-  base_obss.t = new_obss->t;
+                             n_old, nm_old, base_obss.nm,
+                             gpsdifftime(&new_obss->tor, &tor_old));
 
   /* Copy over sender ID. */
   base_obss.sender_id = new_obss->sender_id;
@@ -136,23 +174,16 @@ static void update_obss(obss_t *new_obss)
   memcpy(nm_old, new_obss->nm,
          new_obss->n * sizeof(navigation_measurement_t));
   n_old = new_obss->n;
-  
+  tor_old = new_obss->tor;
+
+  /* Copy over the time. */
+  base_obss.tor = new_obss->tor;
+
   /* Reset the `has_pos` flag. */
   u8 has_pos_old = base_obss.has_pos;
   base_obss.has_pos = 0;
-  /* Check if the base station has sent us its position explicitly via a
-   * BASE_POS SBP message (as indicated by #base_pos_known), and if so use
-   * that. No need to lock before reading here as base_pos_* is only written
-   * from this thread (SBP).
-   */
-  if (base_pos_known) {
-    /* Copy the known base station position into `base_obss`. */
-    memcpy(base_obss.pos_ecef, base_pos_ecef, sizeof(base_pos_ecef));
-    /* Indicate that the position is valid. */
-    base_obss.has_pos = 1;
-  /* The base station wasn't sent to us explicitly but if we have >= 4
-   * satellites we can calculate it ourselves (approximately). */
-  } else if (base_obss.n >= 4) {
+
+  if (base_obss.n >= 4) {
     gnss_solution soln;
     dops_t dops;
 
@@ -178,23 +209,40 @@ static void update_obss(obss_t *new_obss)
         memcpy(base_obss.pos_ecef, soln.pos_ecef, 3 * sizeof(double));
       }
       base_obss.has_pos = 1;
+
+      if (base_pos_known) {
+       double base_distance = vector_distance(3, soln.pos_ecef, base_pos_ecef);
+
+       if (base_distance > BASE_STATION_DISTANCE_THRESHOLD) {
+         log_warn("Received base station position %f m from PVT position.",
+                  base_distance);
+       }
+      }
     } else {
       /* TODO(dsk) check for repair failure */
       /* There was an error calculating the position solution. */
       log_warn("Error calculating base station position: (%s).", pvt_err_msg[-ret-1]);
     }
   }
+
   /* If the base station position is known then calculate the satellite ranges.
    * This calculation will be used later by the propagation functions. */
   if (base_obss.has_pos) {
+    /* Check if the base station has sent us its position explicitly via a
+     * BASE_POS SBP message (as indicated by #base_pos_known).
+     * No need to lock before reading here as base_pos_* is only written
+     * from this thread (SBP).
+     */
+
     for (u8 i=0; i < base_obss.n; i++) {
-      double dx[3];
-      vector_subtract(3, base_obss.nm[i].sat_pos, base_obss.pos_ecef, dx);
-      base_obss.sat_dists[i] = vector_norm(3, dx);
+      base_obss.sat_dists[i] = vector_distance(3, base_obss.nm[i].sat_pos,
+                                               base_obss.pos_ecef);
     }
   }
+
   /* Unlock base_obss mutex. */
   chMtxUnlock(&base_obs_lock);
+
   /* Signal that a complete base observation has been received. */
   chBSemSignal(&base_obs_received);
 }
@@ -219,7 +267,7 @@ static void obs_callback(u16 sender_id, u8 len, u8 msg[], void* context)
    * so we can verify we haven't dropped a message. */
   static s16 prev_count = 0;
 
-  static gps_time_t prev_t = {.tow = 0.0, .wn = 0};
+  static gps_time_t prev_tor = {.tow = 0.0, .wn = 0};
 
   /* As we receive observation messages we assemble them into a working
    * `obss_t` (`base_obss_rx`) so as not to disturb the global `base_obss`
@@ -241,7 +289,7 @@ static void obs_callback(u16 sender_id, u8 len, u8 msg[], void* context)
   sbp_send_msg_(SBP_MSG_OBS, len, msg, 0);
 
   /* GPS time of observation. */
-  gps_time_t t;
+  gps_time_t tor;
   /* Total number of messages in the observation set / sequence. */
   u8 total;
   /* The current message number in the sequence. */
@@ -249,32 +297,32 @@ static void obs_callback(u16 sender_id, u8 len, u8 msg[], void* context)
 
   /* Decode the message header to get the time and how far through the sequence
    * we are. */
-  unpack_obs_header((observation_header_t*)msg, &t, &total, &count);
+  unpack_obs_header((observation_header_t*)msg, &tor, &total, &count);
 
   /* Check to see if the observation is aligned with our internal observations,
    * i.e. is it going to time match one of our local obs. */
   u32 obs_freq = soln_freq / obs_output_divisor;
-  double epoch_count = t.tow * obs_freq;
+  double epoch_count = tor.tow * obs_freq;
   double dt = fabs(epoch_count - round(epoch_count)) / obs_freq;
   if (dt > TIME_MATCH_THRESHOLD) {
     log_warn("Unaligned observation from base station ignored, "
-             "tow = %.3f, dt = %.3f", t.tow, dt);
+             "tow = %.3f, dt = %.3f", tor.tow, dt);
     return;
   }
 
   /* Calculate packet latency. */
   if (time_quality >= TIME_COARSE) {
     gps_time_t now = get_current_time();
-    float latency_ms = (float) ((now.tow - t.tow) * 1000.0);
+    float latency_ms = (float) ((now.tow - tor.tow) * 1000.0);
     log_obs_latency(latency_ms);
   }
 
   /* Verify sequence integrity */
   if (count == 0) {
-    prev_t = t;
+    prev_tor = tor;
     prev_count = 0;
-  } else if (prev_t.tow != t.tow ||
-             prev_t.wn != t.wn ||
+  } else if (prev_tor.tow != tor.tow ||
+             prev_tor.wn != tor.wn ||
              prev_count + 1 != count) {
     log_info("Dropped one of the observation packets! Skipping this sequence.");
     prev_count = -1;
@@ -291,7 +339,7 @@ static void obs_callback(u16 sender_id, u8 len, u8 msg[], void* context)
    * state. */
   if (count == 0) {
     base_obss_rx.n = 0;
-    base_obss_rx.t = t;
+    base_obss_rx.tor = tor;
   }
 
   /* Pull out the contents of the message. */
@@ -308,33 +356,16 @@ static void obs_callback(u16 sender_id, u8 len, u8 msg[], void* context)
      * fill in satellite position etc. parameters. */
     ephemeris_lock();
     ephemeris_t *e = ephemeris_get(sid);
-    if (ephemeris_valid(e, &t)) {
+    if (ephemeris_valid(e, &tor)) {
       /* Unpack the observation into a navigation_measurement_t. */
       unpack_obs_content(
         &obs[i],
         &base_obss_rx.nm[base_obss_rx.n].raw_pseudorange,
-        &base_obss_rx.nm[base_obss_rx.n].carrier_phase,
+        &base_obss_rx.nm[base_obss_rx.n].raw_carrier_phase,
         &base_obss_rx.nm[base_obss_rx.n].snr,
         &base_obss_rx.nm[base_obss_rx.n].lock_counter,
         &base_obss_rx.nm[base_obss_rx.n].sid
       );
-      double clock_err;
-      double clock_rate_err;
-      /* Calculate satellite parameters using the ephemeris. */
-      if (calc_sat_state(e, &t,
-                     base_obss_rx.nm[base_obss_rx.n].sat_pos,
-                     base_obss_rx.nm[base_obss_rx.n].sat_vel,
-                     &clock_err, &clock_rate_err) != 0) {
-        continue;
-      }
-      /* Apply corrections to the raw pseudorange. */
-      /* TODO Make a function to apply some of these corrections.
-       *      They are used in a couple places. */
-      base_obss_rx.nm[base_obss_rx.n].pseudorange =
-            base_obss_rx.nm[base_obss_rx.n].raw_pseudorange + clock_err * GPS_C;
-      /* Set the time */
-      /* TODO: (kleeman) this is definitely wrong. */
-      base_obss_rx.nm[base_obss_rx.n].tot = t;
       base_obss_rx.n++;
     }
     ephemeris_unlock();

--- a/src/base_obs.c
+++ b/src/base_obs.c
@@ -179,10 +179,7 @@ static void update_obss(obss_t *new_obss)
   /* Copy over the time. */
   base_obss.tor = new_obss->tor;
 
-  /* Reset the `has_pos` flag. */
   u8 has_pos_old = base_obss.has_pos;
-  base_obss.has_pos = 0;
-
   if (base_obss.n >= 4) {
     gnss_solution soln;
     dops_t dops;
@@ -219,10 +216,13 @@ static void update_obss(obss_t *new_obss)
        }
       }
     } else {
+      base_obss.has_pos = 0;
       /* TODO(dsk) check for repair failure */
       /* There was an error calculating the position solution. */
       log_warn("Error calculating base station position: (%s).", pvt_err_msg[-ret-1]);
     }
+  } else {
+    base_obss.has_pos = 0;
   }
 
   /* If the base station position is known then calculate the satellite ranges.

--- a/src/base_obs.c
+++ b/src/base_obs.c
@@ -333,6 +333,7 @@ static void obs_callback(u16 sender_id, u8 len, u8 msg[], void* context)
       base_obss_rx.nm[base_obss_rx.n].pseudorange =
             base_obss_rx.nm[base_obss_rx.n].raw_pseudorange + clock_err * GPS_C;
       /* Set the time */
+      /* TODO: (kleeman) this is definitely wrong. */
       base_obss_rx.nm[base_obss_rx.n].tot = t;
       base_obss_rx.n++;
     }

--- a/src/base_obs.h
+++ b/src/base_obs.h
@@ -24,8 +24,8 @@
  * \{ */
 
 typedef struct {
-  /** GPS time of the observation. */
-  gps_time_t t;
+  /** GPS system time of the observation. */
+  gps_time_t tor;
   /** Approximate base station position.
    * This may be the position as reported by the base station itself or the
    * position obtained from doing a single point solution using the base
@@ -46,6 +46,11 @@ typedef struct {
 /** Maximum difference between observation times to consider them matched. */
 #define TIME_MATCH_THRESHOLD 2e-3
 
+/* Maximum distance between calculated and surveyed base station single point
+ * position for error checking. In metres.
+ */
+#define BASE_STATION_DISTANCE_THRESHOLD 50
+
 /* \} */
 
 extern mutex_t base_obs_lock;
@@ -59,4 +64,3 @@ extern double base_pos_ecef[3];
 void base_obs_setup(void);
 
 #endif
-

--- a/src/manage.c
+++ b/src/manage.c
@@ -685,6 +685,18 @@ static void manage_tracking_startup(void)
       continue;
     }
 
+    /* Transition to tracking. */
+    u64 track_count = nap_timing_count() + 20000;
+    float cp = propagate_code_phase(startup_params.code_phase,
+                                    startup_params.carrier_freq,
+                                    track_count -
+                                        startup_params.sample_count);
+
+    /* Contrive for the timing strobe to occur at or close to a
+     * PRN edge (code phase = 0) */
+    track_count += 16 * (1023.0-cp) *
+                      (1.0 + startup_params.carrier_freq / GPS_L1_HZ);
+
     /* Start the tracking channel */
     if(!tracker_channel_init(chan, startup_params.sid,
                              startup_params.sample_count,

--- a/src/manage.c
+++ b/src/manage.c
@@ -685,18 +685,6 @@ static void manage_tracking_startup(void)
       continue;
     }
 
-    /* Transition to tracking. */
-    u64 track_count = nap_timing_count() + 20000;
-    float cp = propagate_code_phase(startup_params.code_phase,
-                                    startup_params.carrier_freq,
-                                    track_count -
-                                        startup_params.sample_count);
-
-    /* Contrive for the timing strobe to occur at or close to a
-     * PRN edge (code phase = 0) */
-    track_count += 16 * (1023.0-cp) *
-                      (1.0 + startup_params.carrier_freq / GPS_L1_HZ);
-
     /* Start the tracking channel */
     if(!tracker_channel_init(chan, startup_params.sid,
                              startup_params.sample_count,

--- a/src/nmea.h
+++ b/src/nmea.h
@@ -46,8 +46,10 @@ void nmea_gpgsv(u8 n_used, const navigation_measurement_t *nav_meas,
 void nmea_gprmc(const gnss_solution *soln, const gps_time_t *gps_t);
 void nmea_gpvtg(const gnss_solution *soln);
 void nmea_gpgll(const gnss_solution *soln, const gps_time_t *gps_t);
-void nmea_send_msgs(gnss_solution *soln, u8 n, 
-                    navigation_measurement_t *nm, const dops_t *dops);
+void nmea_send_msgs(gnss_solution *soln, u8 n,
+                    navigation_measurement_t *nm,
+                    const dops_t *dops,
+                    bool skip_velocity);
 
 /** Register a new dispatcher for NMEA messages
  *
@@ -71,4 +73,3 @@ void _nmea_dispatcher_register(struct nmea_dispatcher *);
 /** \} */
 
 #endif  /* SWIFTNAV_NMEA_H */
-

--- a/src/simulator.c
+++ b/src/simulator.c
@@ -352,9 +352,9 @@ void populate_nav_meas(navigation_measurement_t *nav_meas, double dist, double e
   nav_meas->raw_pseudorange += rand_gaussian(sim_settings.pseudorange_sigma *
                                              sim_settings.pseudorange_sigma);
 
-  nav_meas->carrier_phase =    dist / (GPS_C / GPS_L1_HZ);
-  nav_meas->carrier_phase +=   simulation_fake_carrier_bias[almanac_i];
-  nav_meas->carrier_phase +=   rand_gaussian(sim_settings.phase_sigma *
+  nav_meas->raw_carrier_phase =    dist / (GPS_C / GPS_L1_HZ);
+  nav_meas->raw_carrier_phase +=   simulation_fake_carrier_bias[almanac_i];
+  nav_meas->raw_carrier_phase +=   rand_gaussian(sim_settings.phase_sigma *
                                              sim_settings.phase_sigma);
 
   nav_meas->snr             =  lerp(elevation, 0, M_PI/2, 35, 45) +

--- a/src/solution.c
+++ b/src/solution.c
@@ -475,6 +475,11 @@ static void solution_thread(void *arg)
     }
     ephemeris_unlock();
 
+    for (u32 i=0; i<n_ready; i++) {
+      printf("%d: tot: %.7f rpr: %.7f", nav_meas[i].sid.sat, nav_meas[i].tot.tow,
+          nav_meas[i].raw_pseudorange);
+    }
+
     static navigation_measurement_t nav_meas_tdcp[MAX_CHANNELS];
     u8 n_ready_tdcp = tdcp_doppler(n_ready, nav_meas, n_ready_old,
                                    nav_meas_old, nav_meas_tdcp);
@@ -592,9 +597,10 @@ static void solution_thread(void *arg)
         fabs(t_check - (u32)t_check) < TIME_MATCH_THRESHOLD) {
       /* Propagate observation to desired time. */
       for (u8 i=0; i<n_ready_tdcp; i++) {
-        nav_meas_tdcp[i].pseudorange -= t_err * nav_meas_tdcp[i].doppler *
+        nav_meas_tdcp[i].raw_pseudorange -= t_err * nav_meas_tdcp[i].doppler *
           (GPS_C / GPS_L1_HZ);
         nav_meas_tdcp[i].carrier_phase += t_err * nav_meas_tdcp[i].doppler;
+
       }
 
       /* Update observation time. */

--- a/src/solution.c
+++ b/src/solution.c
@@ -10,6 +10,7 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
+#include <stdio.h>
 #include <string.h>
 
 #include <libsbp/sbp.h>
@@ -438,6 +439,10 @@ static void solution_thread(void *arg)
     const channel_measurement_t *p_meas[n_ready];
     navigation_measurement_t *p_nav_meas[n_ready];
     const ephemeris_t *p_e_meas[n_ready];
+
+    /* Create navigation measurements from the channel measurements*/
+
+    /* Create arrays of pointers for use in calc_navigation_measurement */
     for (u8 i=0; i<n_ready; i++) {
       p_meas[i] = &meas[i];
       p_nav_meas[i] = &nav_meas[i];
@@ -445,11 +450,28 @@ static void solution_thread(void *arg)
     }
 
     ephemeris_lock();
-    if (calc_navigation_measurement(n_ready, p_meas, p_nav_meas, p_e_meas)
-        != 0) {
-      log_error("calc_navigation_measurement() returned an error");
-      ephemeris_unlock();
-      continue;
+    gps_time_t nav_time = rx2gpstime(nav_tc);
+    if (time_quality == TIME_FINE) {
+      /* If we have timing then we can calculate the relationship between
+       * receiver time and GPS time and hence provide the pseudorange
+       * calculation with the local GPS time of reception. */
+      if (calc_navigation_measurement(n_ready, p_meas, p_nav_meas,
+                                      &nav_time, p_e_meas) != 0) {
+                                    log_error("calc_navigation_measurement() returned an error");
+                                    ephemeris_unlock();
+                                    continue;
+      }
+    } else {
+      /* If a FINE quality time solution is not available then don't pass in a
+       * `nav_time`. This will result in valid pseudoranges but with a large
+       * and arbitrary receiver clock error. We may want to discard these
+       * observations after doing a PVT solution. */
+      if calc_navigation_measurement(n_ready, p_meas, p_nav_meas,
+                                     NULL, p_e_meas) != 0) {
+                                    log_error("calc_navigation_measurement() returned an error");
+                                    ephemeris_unlock();
+                                    continue;
+      }
     }
     ephemeris_unlock();
 
@@ -468,140 +490,11 @@ static void solution_thread(void *arg)
     }
 
     dops_t dops;
-    s8 ret;
-    /* disable_raim controlled by external setting. Defaults to false. */
-    if ((ret = calc_PVT(n_ready_tdcp, nav_meas_tdcp, disable_raim,
-                        &position_solution, &dops)) >= 0) {
-
-      if (ret == 1)
-        log_warn("calc_PVT: RAIM repair");
-
-      /* Update global position solution state. */
-      position_updated();
-      set_time_fine(nav_tc, position_solution.time);
-
-      /* Save elevation angles every so often */
-      DO_EVERY((u32)soln_freq,
-               update_sat_elevations(nav_meas_tdcp, n_ready_tdcp,
-                                     position_solution.pos_ecef));
-
-      if (!simulation_enabled()) {
-        /* Output solution. */
-        solution_send_sbp(&position_solution, &dops);
-        solution_send_nmea(&position_solution, &dops,
-                           n_ready_tdcp, nav_meas_tdcp,
-                           NMEA_GGA_FIX_GPS);
-      }
-
-      /* If we have a recent set of observations from the base station, do a
-       * differential solution. */
-      double pdt;
-      chMtxLock(&base_obs_lock);
-      if (base_obss.n > 0 && !simulation_enabled()) {
-        if ((pdt = gpsdifftime(&position_solution.time, &base_obss.t))
-              < MAX_AGE_OF_DIFFERENTIAL) {
-
-          /* Propagate base station observations to the current time and
-           * process a low-latency differential solution. */
-
-          /* Hook in low-latency filter here. */
-          if (dgnss_soln_mode == SOLN_MODE_LOW_LATENCY &&
-              base_obss.has_pos) {
-
-            ephemeris_lock();
-            const ephemeris_t *e_nav_meas_tdcp[n_ready_tdcp];
-            for (u32 i=0; i<n_ready_tdcp; i++)
-              e_nav_meas_tdcp[i] = ephemeris_get(nav_meas_tdcp[i].sid);
-
-            sdiff_t sdiffs[MAX(base_obss.n, n_ready_tdcp)];
-            u8 num_sdiffs = make_propagated_sdiffs(n_ready_tdcp, nav_meas_tdcp,
-                                    base_obss.n, base_obss.nm,
-                                    base_obss.sat_dists, base_obss.pos_ecef,
-                                    e_nav_meas_tdcp, &position_solution.time,
-                                    sdiffs);
-            ephemeris_unlock();
-            if (num_sdiffs >= 4) {
-              output_baseline(num_sdiffs, sdiffs, &position_solution.time, pdt,
-                              dops.hdop, base_obss.sender_id);
-            }
-          }
-
-        }
-      }
-      chMtxUnlock(&base_obs_lock);
-
-      /* Calculate the time of the nearest solution epoch, were we expected
-       * to be and calculate how far we were away from it. */
-      double expected_tow = round(position_solution.time.tow*soln_freq)
-                              / soln_freq;
-      double t_err = expected_tow - position_solution.time.tow;
-
-      /* Only send observations that are closely aligned with the desired
-       * solution epochs to ensure they haven't been propagated too far. */
-      /* Output obervations only every obs_output_divisor times, taking
-       * care to ensure that the observations are aligned. */
-      double t_check = expected_tow * (soln_freq / obs_output_divisor);
-      if (fabs(t_err) < OBS_PROPAGATION_LIMIT &&
-          fabs(t_check - (u32)t_check) < TIME_MATCH_THRESHOLD) {
-        /* Propagate observation to desired time. */
-        for (u8 i=0; i<n_ready_tdcp; i++) {
-          nav_meas_tdcp[i].pseudorange -= t_err * nav_meas_tdcp[i].doppler *
-            (GPS_C / GPS_L1_HZ);
-          nav_meas_tdcp[i].carrier_phase += t_err * nav_meas_tdcp[i].doppler;
-        }
-
-        /* Update observation time. */
-        gps_time_t new_obs_time;
-        new_obs_time.wn = position_solution.time.wn;
-        new_obs_time.tow = expected_tow;
-
-        if (!simulation_enabled()) {
-          send_observations(n_ready_tdcp, &new_obs_time, nav_meas_tdcp);
-        }
-
-        /* TODO: use a buffer from the pool from the start instead of
-         * allocating nav_meas_tdcp as well. Downside, if we don't end up
-         * pushing the message into the mailbox then we just wasted an
-         * observation from the mailbox for no good reason. */
-
-        obss_t *obs = chPoolAlloc(&obs_buff_pool);
-        msg_t ret;
-        if (obs == NULL) {
-          /* Pool is empty, grab a buffer from the mailbox instead, i.e.
-           * overwrite the oldest item in the queue. */
-          ret = chMBFetch(&obs_mailbox, (msg_t *)&obs, TIME_IMMEDIATE);
-          if (ret != MSG_OK) {
-            log_error("Pool full and mailbox empty!");
-          }
-        }
-        obs->t = new_obs_time;
-        obs->n = n_ready_tdcp;
-        memcpy(obs->nm, nav_meas_tdcp, obs->n * sizeof(navigation_measurement_t));
-        ret = chMBPost(&obs_mailbox, (msg_t)obs, TIME_IMMEDIATE);
-        if (ret != MSG_OK) {
-          /* We could grab another item from the mailbox, discard it and then
-           * post our obs again but if the size of the mailbox and the pool
-           * are equal then we should have already handled the case where the
-           * mailbox is full when we handled the case that the pool was full.
-           * */
-          log_error("Mailbox should have space!");
-        }
-      }
-
-      /* Calculate time till the next desired solution epoch. */
-      double dt = expected_tow - position_solution.time.tow;
-
-      /* Limit dt to 1 second maximum to prevent hang if dt calculated
-       * incorrectly. */
-      if (fabs(dt) > 1.0) {
-        dt = (dt > 0.0) ? 1.0 : -1.0;
-      }
-
-      /* Reset timer period with the count that we will estimate will being
-       * us up to the next solution time. */
-      deadline += dt * CH_CFG_ST_FREQUENCY;
-
-    } else {
+    /* Calculate the SPP position
+     * disable_raim controlled by external setting. Defaults to false. */
+    s8 ret = calc_PVT(n_ready_tdcp, nav_meas_tdcp, disable_raim,
+                      &position_solution, &dops);
+    if (ret < 0) {
       /* An error occurred with calc_PVT! */
       /* TODO: Make this based on time since last error instead of a simple
        * count. */
@@ -610,9 +503,149 @@ static void solution_thread(void *arg)
         log_warn("PVT solver: %s (code %d)", pvt_err_msg[-ret-1], ret);
       );
 
-      /* Send just the DOPs */
+      /* Send just the DOPs and exit the loop*/
       solution_send_sbp(0, &dops);
+      continue;
     }
+
+    if (ret == 1)
+	  log_warn("calc_PVT: RAIM repair");
+
+    if (time_quality < TIME_FINE) {
+      /* If the time quality is not FINE then our receiver clock bias isn't
+       * known. We should only use this PVT solution to update our time
+       * estimate and then skip all other processing.
+       *
+       * Note that the lack of knowledge of the receiver clock bias does NOT
+       * degrade the quality of the position solution but the rapid change in
+       * bias after the time estimate is first improved may cause issues for
+       * e.g. carrier smoothing. Easier just to discard this first solution.
+       */
+      set_time_fine(nav_tc, position_solution.time);
+      continue;
+    }
+
+    /* Update global position solution state. */
+    position_updated();
+    set_time_fine(nav_tc, position_solution.time);
+
+    /* Save elevation angles every so often */
+    DO_EVERY((u32)soln_freq,
+             update_sat_elevations(nav_meas_tdcp, n_ready_tdcp,
+                                   position_solution.pos_ecef));
+
+    if (!simulation_enabled()) {
+      /* Output solution. */
+      solution_send_sbp(&position_solution, &dops);
+      solution_send_nmea(&position_solution, &dops,
+                         n_ready_tdcp, nav_meas_tdcp,
+                         NMEA_GGA_FIX_GPS);
+    }
+
+    /* If we have a recent set of observations from the base station, do a
+     * differential solution. */
+    double pdt;
+    chMtxLock(&base_obs_lock);
+    if (base_obss.n > 0 && !simulation_enabled()) {
+      if ((pdt = gpsdifftime(&position_solution.time, &base_obss.t))
+            < MAX_AGE_OF_DIFFERENTIAL) {
+
+        /* Propagate base station observations to the current time and
+         * process a low-latency differential solution. */
+
+        /* Hook in low-latency filter here. */
+        if (dgnss_soln_mode == SOLN_MODE_LOW_LATENCY &&
+            base_obss.has_pos) {
+
+          ephemeris_lock();
+          const ephemeris_t *e_nav_meas_tdcp[n_ready_tdcp];
+          for (u32 i=0; i<n_ready_tdcp; i++)
+            e_nav_meas_tdcp[i] = ephemeris_get(nav_meas_tdcp[i].sid);
+
+          sdiff_t sdiffs[MAX(base_obss.n, n_ready_tdcp)];
+          u8 num_sdiffs = make_propagated_sdiffs(n_ready_tdcp, nav_meas_tdcp,
+                                  base_obss.n, base_obss.nm,
+                                  base_obss.sat_dists, base_obss.pos_ecef,
+                                  e_nav_meas_tdcp, position_solution.time,
+                                  sdiffs);
+          ephemeris_unlock();
+          if (num_sdiffs >= 4) {
+            output_baseline(num_sdiffs, sdiffs, &position_solution.time, pdt,
+                            dops.hdop, base_obss.sender_id);
+          }
+        }
+      }
+    }
+    chMtxUnlock(&base_obs_lock);
+
+    /* Calculate the time of the nearest solution epoch, where we expected
+     * to be, and calculate how far we were away from it. */
+    double expected_tow = round(position_solution.time.tow*soln_freq)
+                            / soln_freq;
+    double t_err = expected_tow - position_solution.time.tow;
+    /* Only send observations that are closely aligned with the desired
+     * solution epochs to ensure they haven't been propagated too far. */
+    /* Output obervations only every obs_output_divisor times, taking
+     * care to ensure that the observations are aligned. */
+    double t_check = expected_tow * (soln_freq / obs_output_divisor);
+    if (fabs(t_err) < OBS_PROPAGATION_LIMIT &&
+        fabs(t_check - (u32)t_check) < TIME_MATCH_THRESHOLD) {
+      /* Propagate observation to desired time. */
+      for (u8 i=0; i<n_ready_tdcp; i++) {
+        nav_meas_tdcp[i].pseudorange -= t_err * nav_meas_tdcp[i].doppler *
+          (GPS_C / GPS_L1_HZ);
+        nav_meas_tdcp[i].carrier_phase += t_err * nav_meas_tdcp[i].doppler;
+      }
+
+      /* Update observation time. */
+      gps_time_t new_obs_time;
+      new_obs_time.wn = position_solution.time.wn;
+      new_obs_time.tow = expected_tow;
+      if (!simulation_enabled() && time_quality == TIME_FINE) {
+        send_observations(n_ready_tdcp, &new_obs_time, nav_meas_tdcp);
+      }
+
+      /* TODO: use a buffer from the pool from the start instead of
+       * allocating nav_meas_tdcp as well. Downside, if we don't end up
+       * pushing the message into the mailbox then we just wasted an
+       * observation from the mailbox for no good reason. */
+
+      obss_t *obs = chPoolAlloc(&obs_buff_pool);
+      msg_t ret;
+      if (obs == NULL) {
+        /* Pool is empty, grab a buffer from the mailbox instead, i.e.
+         * overwrite the oldest item in the queue. */
+        ret = chMBFetch(&obs_mailbox, (msg_t *)&obs, TIME_IMMEDIATE);
+        if (ret != MSG_OK) {
+          log_error("Pool full and mailbox empty!");
+        }
+      }
+      obs->t = new_obs_time;
+      obs->n = n_ready_tdcp;
+      memcpy(obs->nm, nav_meas_tdcp, obs->n * sizeof(navigation_measurement_t));
+      ret = chMBPost(&obs_mailbox, (msg_t)obs, TIME_IMMEDIATE);
+      if (ret != MSG_OK) {
+        /* We could grab another item from the mailbox, discard it and then
+         * post our obs again but if the size of the mailbox and the pool
+         * are equal then we should have already handled the case where the
+         * mailbox is full when we handled the case that the pool was full.
+         * */
+        log_error("Mailbox should have space!");
+      }
+    }
+
+    /* Calculate time till the next desired solution epoch. */
+    double dt = expected_tow - position_solution.time.tow;
+
+    /* Limit dt to 1 second maximum to prevent hang if dt calculated
+     * incorrectly. */
+    if (fabs(dt) > 1.0) {
+      dt = (dt > 0.0) ? 1.0 : -1.0;
+    }
+
+    /* Reset timer period with the count that we will estimate will being
+     * us up to the next solution time. */
+    deadline += dt * CH_CFG_ST_FREQUENCY;
   }
 }
 

--- a/src/solution.c
+++ b/src/solution.c
@@ -153,7 +153,7 @@ double calc_heading(const double b_ned[3])
  * \param flags u8 RTK solution flags. 1 if float, 0 if fixed
  */
 void solution_send_baseline(const gps_time_t *t, u8 n_sats, double b_ecef[3],
-                            double ref_ecef[3], u8 flags, double hdop, 
+                            double ref_ecef[3], u8 flags, double hdop,
                             double corrections_age, u16 sender_id)
 {
   double* base_station_pos;
@@ -411,12 +411,13 @@ static void solution_thread(void *arg)
       solution_simulation();
     }
 
+    u64 nav_tc = nap_timing_count();
     u8 n_ready = 0;
     channel_measurement_t meas[MAX_CHANNELS];
     for (u8 i=0; i<nap_track_n_channels; i++) {
       tracking_channel_lock(i);
       if (use_tracking_channel(i)) {
-        tracking_channel_measurement_get(i, &meas[n_ready]);
+        tracking_channel_measurement_get(i, nav_tc, &meas[n_ready]);
         n_ready++;
       }
       tracking_channel_unlock(i);
@@ -432,7 +433,6 @@ static void solution_thread(void *arg)
      * more intelligent with the solution time.
      */
     static u8 n_ready_old = 0;
-    u64 nav_tc = nap_timing_count();
     static navigation_measurement_t nav_meas[MAX_CHANNELS];
 
     const channel_measurement_t *p_meas[n_ready];
@@ -445,8 +445,7 @@ static void solution_thread(void *arg)
     }
 
     ephemeris_lock();
-    if (calc_navigation_measurement(n_ready, p_meas, p_nav_meas,
-                                    (double)((u32)nav_tc)/SAMPLE_FREQ, p_e_meas)
+    if (calc_navigation_measurement(n_ready, p_meas, p_nav_meas, p_e_meas)
         != 0) {
       log_error("calc_navigation_measurement() returned an error");
       ephemeris_unlock();
@@ -522,7 +521,7 @@ static void solution_thread(void *arg)
                                     sdiffs);
             ephemeris_unlock();
             if (num_sdiffs >= 4) {
-              output_baseline(num_sdiffs, sdiffs, &position_solution.time, pdt, 
+              output_baseline(num_sdiffs, sdiffs, &position_solution.time, pdt,
                               dops.hdop, base_obss.sender_id);
             }
           }

--- a/src/solution.h
+++ b/src/solution.h
@@ -41,10 +41,10 @@ typedef enum {
 extern double soln_freq;
 extern u32 obs_output_divisor;
 
-void solution_send_sbp(gnss_solution *soln, dops_t *dops);
+void solution_send_sbp(gnss_solution *soln, dops_t *dops, bool clock_jump);
 void solution_send_nmea(gnss_solution *soln, dops_t *dops,
                         u8 n, navigation_measurement_t *nm,
-                        u8 fix_type);
+                        u8 fix_type, bool clock_jump);
 double calc_heading(const double b_ned[3]);
 void solution_send_baseline(const gps_time_t *t, u8 n_sats, double b_ecef[3],
                             double ref_ecef[3], u8 flags, double hdop, 
@@ -52,4 +52,3 @@ void solution_send_baseline(const gps_time_t *t, u8 n_sats, double b_ecef[3],
 void solution_setup(void);
 
 #endif
-

--- a/src/system_monitor.c
+++ b/src/system_monitor.c
@@ -32,14 +32,10 @@
 #include "simulator.h"
 #include "system_monitor.h"
 #include "position.h"
+#include "base_obs.h"
 
 #define WATCHDOG_THREAD_PERIOD_MS 15000
 extern const WDGConfig board_wdg_config;
-
-/* Maximum distance between calculated and surveyed base station single point
- * position for error checking.
- */
-#define BASE_STATION_DISTANCE_THRESHOLD 15000
 
 /* Time between sending system monitor and heartbeat messages in milliseconds */
 static uint32_t heartbeat_period_milliseconds = 1000;
@@ -177,11 +173,10 @@ static void system_monitor_thread(void *arg)
       llhdeg2rad(base_llh, tmp);
       wgsllh2ecef(tmp, base_ecef);
 
-      vector_subtract(3, base_ecef, position_solution.pos_ecef, tmp);
-      base_distance = vector_norm(3, tmp);
+      base_distance = vector_distance(3, base_ecef, position_solution.pos_ecef);
 
       if (base_distance > BASE_STATION_DISTANCE_THRESHOLD) {
-        log_warn("Invalid surveyed position coordinates\n");
+        log_warn("Sending invalid surveyed position coordinates.");
       } else {
         sbp_send_msg(SBP_MSG_BASE_POS_ECEF, sizeof(msg_base_pos_ecef_t), (u8 *)&base_ecef);
       }

--- a/src/system_monitor.c
+++ b/src/system_monitor.c
@@ -176,7 +176,7 @@ static void system_monitor_thread(void *arg)
       base_distance = vector_distance(3, base_ecef, position_solution.pos_ecef);
 
       if (base_distance > BASE_STATION_DISTANCE_THRESHOLD) {
-        log_warn("Sending invalid surveyed position coordinates.");
+        log_warn("Invalid surveyed position coordinates. No base position message will be sent.");
       } else {
         sbp_send_msg(SBP_MSG_BASE_POS_ECEF, sizeof(msg_base_pos_ecef_t), (u8 *)&base_ecef);
       }

--- a/src/track.c
+++ b/src/track.c
@@ -29,6 +29,7 @@
 #include "simulator.h"
 #include "settings.h"
 #include "signal.h"
+#include "timing.h"
 
 /** \defgroup tracking Tracking
  * Track satellites via interrupt driven updates to SwiftNAP tracking channels.
@@ -84,6 +85,10 @@ typedef struct {
   mutex_t mutex;
   /** Elevation angle, degrees. TODO: find a better place for this. */
   s8 elevation;
+  /** Carrier phase integer offset in cycles. */
+  double carrier_phase_offset;
+  /** Used to detect a cycle slip. */
+  u16 carrier_phase_offset_lock;
   /** Associated tracker interface. */
   const tracker_interface_t *interface;
   /** Associated tracker instance. */
@@ -328,6 +333,10 @@ bool tracker_channel_init(tracker_channel_id_t id, gnss_signal_t sid,
     tracker_channel->tracker = tracker;
 
     tracker_channel->elevation = elevation;
+
+    /* Reset the carrier phase offset so it gets set again. */
+    tracker_channel->carrier_phase_offset = 0.0;
+    tracker_channel->carrier_phase_offset_lock = 0;
 
     common_data_init(&tracker_channel->common_data, ref_sample_count,
                      carrier_freq, cn0_init);
@@ -578,6 +587,27 @@ void tracking_channel_measurement_get(tracker_channel_id_t id, u32 ref_tc,
     meas->carrier_phase += 0.5;
   }
   meas->lock_counter = internal_data->lock_counter;
+
+  /* Check if lock counter changed */
+  if (tracker_channel->carrier_phase_offset_lock
+      != internal_data->lock_counter) {
+    tracker_channel->carrier_phase_offset_lock = internal_data->lock_counter;
+    tracker_channel->carrier_phase_offset = 0.0;
+  }
+
+  /* Adjust carrier phase initial integer offset to be approximately equal to
+     pseudorange. */
+  if ((time_quality == TIME_FINE)
+      && (tracker_channel->carrier_phase_offset == 0.0)) {
+      gps_time_t tor = rx2gpstime(common_data->sample_count);
+      gps_time_t tot;
+      tot.tow = 1e-3 * meas->time_of_week_ms;
+      tot.tow += meas->code_phase_chips / GPS_CA_CHIPPING_RATE;
+      gps_time_match_weeks(&tot, &tor);
+      tracker_channel->carrier_phase_offset = round(GPS_L1_HZ
+                                                    * gpsdifftime(&tor, &tot));
+  }
+  meas->carrier_phase -= tracker_channel->carrier_phase_offset;
 }
 
 /** Set the elevation angle for a tracker channel by sid.

--- a/src/track.c
+++ b/src/track.c
@@ -553,9 +553,10 @@ bool tracking_channel_bit_polarity_resolved(tracker_channel_id_t id)
 /** Retrieve a channel measurement for a tracker channel.
  *
  * \param id      ID of the tracker channel to use.
+ * \param ref_tc  Reference timing count.
  * \param meas    Pointer to output channel_measurement_t.
  */
-void tracking_channel_measurement_get(tracker_channel_id_t id,
+void tracking_channel_measurement_get(tracker_channel_id_t id, u32 ref_tc,
                                       channel_measurement_t *meas)
 {
   tracker_channel_t *tracker_channel = tracker_channel_get(id);
@@ -570,7 +571,8 @@ void tracking_channel_measurement_get(tracker_channel_id_t id,
   meas->carrier_phase = common_data->carrier_phase;
   meas->carrier_freq = common_data->carrier_freq;
   meas->time_of_week_ms = common_data->TOW_ms;
-  meas->receiver_time = (double)common_data->sample_count / SAMPLE_FREQ;
+  meas->rec_time_delta = (double)((s32)(common_data->sample_count - ref_tc))
+                             / SAMPLE_FREQ;
   meas->snr = common_data->cn0;
   if (internal_data->bit_polarity == BIT_POLARITY_INVERTED) {
     meas->carrier_phase += 0.5;

--- a/src/track.h
+++ b/src/track.h
@@ -47,7 +47,7 @@ void tracking_channels_missed_update_error(u32 channels_mask);
 /* State management interface */
 bool tracker_channel_available(tracker_channel_id_t id, gnss_signal_t sid);
 bool tracker_channel_init(tracker_channel_id_t id, gnss_signal_t sid,
-                          u32 ref_sample_count, float code_phase,
+                          u32 start_sample_count, float code_phase,
                           float carrier_freq, float cn0_init, s8 elevation);
 bool tracker_channel_disable(tracker_channel_id_t id);
 

--- a/src/track.h
+++ b/src/track.h
@@ -47,7 +47,7 @@ void tracking_channels_missed_update_error(u32 channels_mask);
 /* State management interface */
 bool tracker_channel_available(tracker_channel_id_t id, gnss_signal_t sid);
 bool tracker_channel_init(tracker_channel_id_t id, gnss_signal_t sid,
-                          u32 start_sample_count, float code_phase,
+                          u32 ref_sample_count, float code_phase,
                           float carrier_freq, float cn0_init, s8 elevation);
 bool tracker_channel_disable(tracker_channel_id_t id);
 

--- a/src/track.h
+++ b/src/track.h
@@ -70,7 +70,7 @@ double tracking_channel_carrier_freq_get(tracker_channel_id_t id);
 s32 tracking_channel_tow_ms_get(tracker_channel_id_t id);
 bool tracking_channel_bit_sync_resolved(tracker_channel_id_t id);
 bool tracking_channel_bit_polarity_resolved(tracker_channel_id_t id);
-void tracking_channel_measurement_get(tracker_channel_id_t id, u32 ref_tc,
+void tracking_channel_measurement_get(tracker_channel_id_t id, u64 ref_tc,
                                       channel_measurement_t *meas);
 
 bool tracking_channel_evelation_degrees_set(gnss_signal_t sid, s8 elevation);

--- a/src/track.h
+++ b/src/track.h
@@ -70,7 +70,7 @@ double tracking_channel_carrier_freq_get(tracker_channel_id_t id);
 s32 tracking_channel_tow_ms_get(tracker_channel_id_t id);
 bool tracking_channel_bit_sync_resolved(tracker_channel_id_t id);
 bool tracking_channel_bit_polarity_resolved(tracker_channel_id_t id);
-void tracking_channel_measurement_get(tracker_channel_id_t id,
+void tracking_channel_measurement_get(tracker_channel_id_t id, u32 ref_tc,
                                       channel_measurement_t *meas);
 
 bool tracking_channel_evelation_degrees_set(gnss_signal_t sid, s8 elevation);

--- a/src/track_api.c
+++ b/src/track_api.c
@@ -227,6 +227,7 @@ void tracker_ambiguity_unknown(tracker_context_t *context)
   internal_data->bit_polarity = BIT_POLARITY_UNKNOWN;
   internal_data->lock_counter =
       tracking_lock_counter_increment(channel_info->sid);
+  internal_data->carrier_phase_offset = 0.0;
 }
 
 /** Output a correlation data message for a tracker channel.

--- a/src/track_internal.c
+++ b/src/track_internal.c
@@ -62,6 +62,9 @@ void internal_data_init(tracker_internal_data_t *internal_data,
 
   internal_data->bit_polarity = BIT_POLARITY_UNKNOWN;
 
+  /* Reset the carrier phase offset so it gets set again. */
+  internal_data->carrier_phase_offset = 0.0;
+
   nav_bit_fifo_init(&internal_data->nav_bit_fifo);
   nav_time_sync_init(&internal_data->nav_time_sync);
   bit_sync_init(&internal_data->bit_sync, sid);

--- a/src/track_internal.h
+++ b/src/track_internal.h
@@ -64,6 +64,8 @@ typedef struct {
   u16 lock_counter;
   /** Set if this channel should output I/Q samples on SBP. */
   bool output_iq;
+  /** Carrier phase integer offset in cycles. */
+  double carrier_phase_offset;
 } tracker_internal_data_t;
 
 /** \} */


### PR DESCRIPTION
This PR checks for RTK solutions with PDOPs > 20 and prevents a solution being sent.

I hope this will fix occasional float solution outliers that have been observed recently up to 200km in error.

The current firmware only checks the DOPs of the SPP solution, but due to cycle slips or missing base observations the RTK solution might use less satellites than SPP and try to output solutions with very high DOPs.

This PR is based on https://github.com/swift-nav/piksi_firmware/pull/651 so that must be merged first.

Requires libswiftnav with https://github.com/swift-nav/libswiftnav/pull/351

/cc @swift-nav/firmware @swift-nav/estimation @denniszollo @anth-cole 
