### PR TITLE
v3: FFT improvements, add function to get raw samples

### DIFF
--- a/src/board/v3/nap/fft.c
+++ b/src/board/v3/nap/fft.c
@@ -30,11 +30,13 @@ static void axi_dma_tx_callback(bool success);
 static void axi_dma_rx_callback(bool success);
 static u32 length_points_get(u32 len_log2);
 static void control_set_dma(void);
-static void control_set_samples(fft_samples_input_t samples_input,
-                                u32 len_points);
+static void control_set_frontend_samples(fft_samples_input_t samples_input,
+                                         u32 len_points);
+static void control_set_raw_samples(u32 len_samples);
 static void sample_stream_start(void);
+static u32 sample_stream_snapshot_get(void);
 static void config_set(fft_dir_t dir, u32 scale_schedule);
-static void dma_start(const fft_cplx_t *in, fft_cplx_t *out, u32 len_log2);
+static void dma_start(const u8 *in, u8 *out, u32 len_bytes);
 static bool dma_wait(void);
 
 /** Callback for AXI DMA TX.
@@ -87,9 +89,12 @@ static void control_set_dma(void)
  * \param samples_input   Frontend sample input to use.
  * \param len_points      Number of points.
  */
-static void control_set_samples(fft_samples_input_t samples_input,
-                                u32 len_points)
+static void control_set_frontend_samples(fft_samples_input_t samples_input,
+                                         u32 len_points)
 {
+  assert(!(len_points &
+           ~(NAP_ACQ_CONTROL_LENGTH_Msk >> NAP_ACQ_CONTROL_LENGTH_Pos)));
+
   NAP->ACQ_CONTROL =
       (NAP_ACQ_CONTROL_DMA_INPUT_FFT      << NAP_ACQ_CONTROL_DMA_INPUT_Pos) |
       (NAP_ACQ_CONTROL_FFT_INPUT_FRONTEND << NAP_ACQ_CONTROL_FFT_INPUT_Pos) |
@@ -98,7 +103,25 @@ static void control_set_samples(fft_samples_input_t samples_input,
       (len_points                         << NAP_ACQ_CONTROL_LENGTH_Pos);
 }
 
-/** Start streaming samples from the frontend samples input.
+/** Set the ACQ control register for raw samples input.
+ *
+ * \param len_samples     Number of samples.
+ */
+static void control_set_raw_samples(u32 len_samples)
+{
+  assert(!(len_samples &
+           ~(NAP_ACQ_CONTROL_LENGTH_Msk >> NAP_ACQ_CONTROL_LENGTH_Pos)));
+
+  NAP->ACQ_CONTROL =
+      (NAP_ACQ_CONTROL_DMA_INPUT_SAMPLE_GRABBER
+                                          << NAP_ACQ_CONTROL_DMA_INPUT_Pos) |
+      (0                                  << NAP_ACQ_CONTROL_FFT_INPUT_Pos) |
+      (0                                  << NAP_ACQ_CONTROL_RF_FE_Pos) |
+      (0                                  << NAP_ACQ_CONTROL_RF_FE_CH_Pos) |
+      (len_samples                        << NAP_ACQ_CONTROL_LENGTH_Pos);
+}
+
+/** Start streaming samples from the frontend or raw samples input.
  */
 static void sample_stream_start(void)
 {
@@ -114,7 +137,20 @@ static void sample_stream_start(void)
   }
 }
 
+/** Returns the sample count corresponding to the first sample of the most
+ * recent sample stream.
+ */
+static u32 sample_stream_snapshot_get(void)
+{
+  return NAP->ACQ_START_SNAPSHOT;
+}
+
 /** Set the FFT config register.
+ *
+ * \param dir             FFT direction.
+ * \param scale_schedule  Bitfield representing the scaling (right shift) to
+ *                        be applied at each stage. Two bits per stage, Lsb
+ *                        first.
  */
 static void config_set(fft_dir_t dir, u32 scale_schedule)
 {
@@ -122,35 +158,27 @@ static void config_set(fft_dir_t dir, u32 scale_schedule)
                         (dir            << NAP_ACQ_FFT_CONFIG_DIR_Pos);
 }
 
-/** Start an FFT DMA transfer.
+/** Start a DMA transfer.
  *
  * \param in              Input buffer, NULL if not used.
  * \param out             Output buffer.
- * \param len_log2        Log2 number of points.
- * \param dir             FFT direction.
- * \param scale_schedule  Bitfield representing the scaling (right shift) to
- *                        be applied at each stage. Two bits per stage, Lsb
- *                        first.
+ * \param len_bytes       Length of transfer (bytes).
  */
-static void dma_start(const fft_cplx_t *in, fft_cplx_t *out, u32 len_log2)
+static void dma_start(const u8 *in, u8 *out, u32 len_bytes)
 {
-  u32 len_bytes = length_points_get(len_log2) * sizeof(fft_cplx_t);
-
   if (in != 0) {
     /* Ensure that input accesses have completed */
     DATA_MEMORY_BARRIER();
 
-    /* Start DMA transfer from in buffer to FFT block */
-    axi_dma_write_begin(&AXIDMADriver1, (const u8 *)in, len_bytes,
-                        axi_dma_tx_callback);
+    /* Start DMA transfer from in buffer to FPGA */
+    axi_dma_write_begin(&AXIDMADriver1, in, len_bytes, axi_dma_tx_callback);
   }
 
   /* Make sure semaphore is in the TAKEN state. */
   chBSemWaitTimeout(&axi_dma_rx_bsem, TIME_IMMEDIATE);
 
-  /* Start DMA transfer from FFT block to out buffer */
-  axi_dma_read_begin(&AXIDMADriver1, (u8 *)out, len_bytes,
-                     axi_dma_rx_callback);
+  /* Start DMA transfer from FPGA to out buffer */
+  axi_dma_read_begin(&AXIDMADriver1, out, len_bytes, axi_dma_rx_callback);
 }
 
 /** Wait for an FFT result DMA transfer to complete.
@@ -185,9 +213,10 @@ static bool dma_wait(void)
 bool fft(const fft_cplx_t *in, fft_cplx_t *out, u32 len_log2,
          fft_dir_t dir, u32 scale_schedule)
 {
+  u32 len_bytes = length_points_get(len_log2) * sizeof(fft_cplx_t);
   config_set(dir, scale_schedule);
   control_set_dma();
-  dma_start(in, out, len_log2);
+  dma_start((const u8 *)in, (u8 *)out, len_bytes);
   return dma_wait();
 }
 
@@ -209,11 +238,30 @@ bool fft_samples(fft_samples_input_t samples_input, fft_cplx_t *out,
                  u32 *sample_count)
 {
   u32 len_points = length_points_get(len_log2);
+  u32 len_bytes = len_points * sizeof(fft_cplx_t);
   config_set(dir, scale_schedule);
-  control_set_samples(samples_input, len_points);
+  control_set_frontend_samples(samples_input, len_points);
   sample_stream_start();
-  dma_start(0, out, len_log2);
+  dma_start(0, (u8 *)out, len_bytes);
   bool result = dma_wait();
-  *sample_count = NAP->ACQ_START_SNAPSHOT;
+  *sample_count = sample_stream_snapshot_get();
+  return result;
+}
+
+/** Retrieve a buffer of raw samples.
+ *
+ * \param out             Output buffer.
+ * \param len_samples     Number of samples.
+ * \param sample_count    Output sample count of the first sample.
+ *
+ * \return True if the samples were successfully retrieved, false otherwise.
+ */
+bool raw_samples_get(u8 *out, u32 len_samples, u32 *sample_count)
+{
+  control_set_raw_samples(len_samples);
+  dma_start(0, out, len_samples);
+  sample_stream_start();
+  bool result = dma_wait();
+  *sample_count = sample_stream_snapshot_get();
   return result;
 }

--- a/src/board/v3/nap/fft.h
+++ b/src/board/v3/nap/fft.h
@@ -49,4 +49,6 @@ bool fft_samples(fft_samples_input_t samples_input, fft_cplx_t *out,
                  u32 len_log2, fft_dir_t dir, u32 scale_schedule,
                  u32 *sample_count);
 
+bool raw_samples_get(u8 *out, u32 len_samples, u32 *sample_count);
+
 #endif /* SWIFTNAV_FFT_H */


### PR DESCRIPTION
- Rename a few functions
- Configure FFT before setting `ACQ_TIMING_COMPARE` to avoid race condition
- Add `raw_samples_get()`