### PR TITLE
Define GIT_VERSION in version.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ scripts/RELEASE-VERSION
 .project
 .settings/
 
+src/version.h
+

--- a/src/Makefile
+++ b/src/Makefile
@@ -189,9 +189,11 @@ CPPWARN = -Wall -Wextra -Werror
 # Start of default section
 #
 
-# List all default C defines here, like -D_DEBUG=1
 GIT_VERSION := $(shell git describe --dirty)
-DDEFS = -DGIT_VERSION="\"$(GIT_VERSION)\""
+VERSION_H := $(shell echo "\#define GIT_VERSION \"$(GIT_VERSION)\"" > version.h)
+
+# List all default C defines here, like -D_DEBUG=1
+DDEFS =
 
 # List all default ASM defines here, like -D_DEBUG=1
 DADEFS =

--- a/src/main.c
+++ b/src/main.c
@@ -38,6 +38,7 @@
 #include "pps.h"
 #include "decode.h"
 #include "signal.h"
+#include "version.h"
 
 extern void ext_setup(void);
 

--- a/src/peripherals/usart.c
+++ b/src/peripherals/usart.c
@@ -18,6 +18,7 @@
 #include "../settings.h"
 #include "usart.h"
 #include "3drradio.h"
+#include "version.h"
 
 /** \addtogroup io
  * \{ */


### PR DESCRIPTION
This allows source files dependent on `GIT_VERSION` to be rebuilt when `version.h` changes using standard file dependencies.