### PR TITLE
Wrap printf() and scanf() calls with mutex protection

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -33,7 +33,16 @@ endif
 
 # Linker extra options here.
 ifeq ($(USE_LDOPT),)
-  USE_LDOPT =
+  USE_LDOPT := --wrap=_vfprintf,--wrap=_vfprintf_r
+  USE_LDOPT := $(USE_LDOPT),--wrap=vfiprintf,--wrap=_vfiprintf_r
+  USE_LDOPT := $(USE_LDOPT),--wrap=_svfprintf_r
+  USE_LDOPT := $(USE_LDOPT),--wrap=_svfiprintf_r
+  USE_LDOPT := $(USE_LDOPT),--wrap=vfscanf,--wrap=_vfscanf_r
+  USE_LDOPT := $(USE_LDOPT),--wrap=__svfscanf,--wrap=__svfscanf_r
+  USE_LDOPT := $(USE_LDOPT),--wrap=vfiscanf,--wrap=_vfiscanf_r
+  USE_LDOPT := $(USE_LDOPT),--wrap=__svfiscanf,--wrap=__svfiscanf_r
+  USE_LDOPT := $(USE_LDOPT),--wrap=__ssvfscanf_r
+  USE_LDOPT := $(USE_LDOPT),--wrap=__ssvfiscanf_r
 endif
 
 # Enable this if you want link time optimizations (LTO)
@@ -106,6 +115,7 @@ CSRC := $(STARTUPSRC) \
         $(SWIFTNAV_ROOT)/src/base_obs.o \
         $(SWIFTNAV_ROOT)/src/simulator.o \
         $(SWIFTNAV_ROOT)/src/simulator_data.o \
+        $(SWIFTNAV_ROOT)/src/syscalls.o \
         $(SWIFTNAV_ROOT)/src/nmea.o \
         $(SWIFTNAV_ROOT)/src/system_monitor.o \
         $(SWIFTNAV_ROOT)/src/ephemeris.o \

--- a/src/board/v2/STM32F405xG.ld
+++ b/src/board/v2/STM32F405xG.ld
@@ -55,7 +55,6 @@ REGION_ALIAS("HEAP_RAM", ram0);
 SECTIONS {
     .ccmram (NOLOAD) : {
       *(.ccmram*)
-      *(.bss.nkf)
     } > ram4
 }
 

--- a/src/board/v2/init.c
+++ b/src/board/v2/init.c
@@ -258,30 +258,3 @@ static s8 compare_version(const char *a, const char *b)
 
   return (commit_a < commit_b) ? -1 : (commit_a > commit_b);
 }
-
-/** Our own basic implementation of sbrk().
- * This overrides the version provided by newlib/libnosys which now checks that
- * the heap_end pointer doesn't grow pass the stack pointer. Thats great except
- * on the STM32F4 we are putting our stack in the CCM memory region which has
- * an address lower than the main RAM region (where the heap is) causing the
- * default sbrk() to always return ENOMEM.
- *
- * \todo Re-implement stack pointer checking taking into account our memory
- *       layout.
- */
-void *_sbrk (int incr)
-{
-  extern char   end; /* Set by linker.  */
-  static char * heap_end;
-  char *        prev_heap_end;
-
-  if (heap_end == 0)
-    heap_end = & end;
-
-  prev_heap_end = heap_end;
-
-  heap_end += incr;
-
-  return (void *)prev_heap_end;
-}
-

--- a/src/board/v3/init.c
+++ b/src/board/v3/init.c
@@ -125,30 +125,3 @@ u8 nap_version_string_get(char *nap_version_string)
 {
   return nap_conf_rd_version_string(nap_version_string);
 }
-
-/** Our own basic implementation of sbrk().
- * This overrides the version provided by newlib/libnosys which now checks that
- * the heap_end pointer doesn't grow pass the stack pointer. Thats great except
- * on the STM32F4 we are putting our stack in the CCM memory region which has
- * an address lower than the main RAM region (where the heap is) causing the
- * default sbrk() to always return ENOMEM.
- *
- * \todo Re-implement stack pointer checking taking into account our memory
- *       layout.
- */
-void *_sbrk (int incr)
-{
-  extern char   end; /* Set by linker.  */
-  static char * heap_end;
-  char *        prev_heap_end;
-
-  if (heap_end == 0)
-    heap_end = & end;
-
-  prev_heap_end = heap_end;
-
-  heap_end += incr;
-
-  return (void *)prev_heap_end;
-}
-

--- a/src/decode.c
+++ b/src/decode.c
@@ -79,7 +79,7 @@ typedef struct {
 static decoder_interface_list_element_t *decoder_interface_list = 0;
 static decoder_channel_t decoder_channels[NUM_DECODER_CHANNELS];
 
-static WORKING_AREA_CCM(wa_decode_thread, 2000);
+static THD_WORKING_AREA(wa_decode_thread, 2000);
 
 static void decode_thread(void *arg);
 static const decoder_interface_t * decoder_interface_get(gnss_signal_t sid);

--- a/src/solution.c
+++ b/src/solution.c
@@ -396,7 +396,7 @@ static void sol_thd_sleep(systime_t *deadline, systime_t interval)
   chSysUnlock();
 }
 
-static WORKING_AREA_CCM(wa_solution_thread, 8000);
+static THD_WORKING_AREA(wa_solution_thread, 8000);
 static void solution_thread(void *arg)
 {
   (void)arg;
@@ -765,7 +765,7 @@ void process_matched_obs(u8 n_sds, gps_time_t *t, sdiff_t *sds, u16 base_id)
   }
 }
 
-static THD_WORKING_AREA(wa_time_matched_obs_thread, 20000);
+static WORKING_AREA_CCM(wa_time_matched_obs_thread, 20000);
 static void time_matched_obs_thread(void *arg)
 {
   (void)arg;

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2016 Swift Navigation Inc.
+ * Contact: Jacob McNamee <jacob@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#include <ch.h>
+
+#include <libswiftnav/common.h>
+
+#include "error.h"
+
+#define WRAP(rtype, proto, usage)     \
+  rtype __wrap_##proto                \
+  {                                   \
+    reent_lock();                     \
+    extern rtype __real_##proto;      \
+    rtype ret = __real_##usage;       \
+    reent_unlock();                   \
+    return ret;                       \
+  }
+
+typedef struct {
+  mutex_t mutex;
+  thread_t *owner;
+  u8 nest;
+} reent_lock_state_t;
+
+static reent_lock_state_t reent_lock_state = {
+  .mutex = _MUTEX_DATA(reent_lock_state.mutex),
+  .owner = NULL,
+  .nest = 0
+};
+
+static void reent_lock(void);
+static void reent_unlock(void);
+
+static void reent_lock(void)
+{
+  thread_t *thread = chThdGetSelfX();
+
+  chSysLock();
+  if (reent_lock_state.owner != thread) {
+    chMtxLockS(&reent_lock_state.mutex);
+    reent_lock_state.owner = thread;
+  } else {
+    reent_lock_state.nest++;
+  }
+  chSysUnlock();
+}
+
+static void reent_unlock(void)
+{
+  if (reent_lock_state.nest > 0) {
+    reent_lock_state.nest--;
+  } else {
+    reent_lock_state.owner = NULL;
+    chMtxUnlock(&reent_lock_state.mutex);
+  }
+}
+
+/* Wrap vfprintf() functions exported by vfprintf.o */
+WRAP(int, vfprintf(FILE *f, _CONST char *fmt, va_list va),
+          vfprintf(f, fmt, va))
+
+WRAP(int, _vfprintf_r(struct _reent *r, FILE *f, _CONST char *fmt, va_list va),
+          _vfprintf_r(r, f, fmt, va))
+
+/* Wrap vfiprintf() functions exported by vfiprintf.o */
+WRAP(int, vfiprintf(FILE *f, _CONST char *fmt, va_list va),
+          vfiprintf(f, fmt, va))
+
+WRAP(int, _vfiprintf_r(struct _reent *r, FILE *f, _CONST char *fmt, va_list va),
+          _vfiprintf_r(r, f, fmt, va))
+
+/* Wrap svfprintf() functions exported by svfprintf.o */
+WRAP(int, _svfprintf_r(struct _reent *r, FILE *f, _CONST char *fmt, va_list va),
+          _svfprintf_r(r, f, fmt, va))
+
+/* Wrap svfiprintf() functions exported by svfiprintf.o */
+WRAP(int, _svfiprintf_r(struct _reent *r, FILE *f, _CONST char *fmt, va_list va),
+          _svfiprintf_r(r, f, fmt, va))
+
+/* Wrap vfscanf() functions exported by vfscanf.o */
+WRAP(int, vfscanf(FILE *f, const char *fmt, va_list va),
+          vfscanf(f, fmt, va))
+
+WRAP(int, _vfscanf_r(struct _reent *r, FILE *f, const char *fmt, va_list va),
+          _vfscanf_r(r, f, fmt, va))
+
+WRAP(int, __svfscanf(FILE *f, const char *fmt, va_list va),
+          __svfscanf(f, fmt, va))
+
+WRAP(int, __svfscanf_r(struct _reent *r, FILE *f, const char *fmt, va_list va),
+          __svfscanf_r(r, f, fmt, va))
+
+/* Wrap vfiscanf() functions exported by vfiscanf.o */
+WRAP(int, vfiscanf(FILE *f, const char *fmt, va_list va),
+          vfiscanf(f, fmt, va))
+
+WRAP(int, _vfiscanf_r(struct _reent *r, FILE *f, const char *fmt, va_list va),
+          _vfiscanf_r(r, f, fmt, va))
+
+WRAP(int, __svfiscanf(FILE *f, const char *fmt, va_list va),
+          __svfiscanf(f, fmt, va))
+
+WRAP(int, __svfiscanf_r(struct _reent *r, FILE *f, const char *fmt, va_list va),
+          __svfiscanf_r(r, f, fmt, va))
+
+/* wrap svfscanf() functions exported by svfscanf.o */
+WRAP(int, __ssvfscanf_r(struct _reent *r, FILE *f, const char *fmt, va_list va),
+          __ssvfscanf_r(r, f, fmt, va))
+
+/* wrap svfiscanf() functions exported by svfiscanf.o */
+WRAP(int, __ssvfiscanf_r(struct _reent *r, FILE *f, const char *fmt, va_list va),
+          __ssvfiscanf_r(r, f, fmt, va))

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -13,10 +13,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <errno.h>
 
 #include <ch.h>
 
 #include <libswiftnav/common.h>
+#include <libswiftnav/logging.h>
 
 #include "error.h"
 
@@ -124,3 +126,16 @@ WRAP(int, __ssvfscanf_r(struct _reent *r, FILE *f, const char *fmt, va_list va),
 /* wrap svfiscanf() functions exported by svfiscanf.o */
 WRAP(int, __ssvfiscanf_r(struct _reent *r, FILE *f, const char *fmt, va_list va),
           __ssvfiscanf_r(r, f, fmt, va))
+
+/* Implement sbrk() */
+void * _sbrk(int incr)
+{
+  chDbgCheck(incr >= 0);
+  void *p = chCoreAlloc(incr);
+  if (p == NULL) {
+    log_error("sbrk() failed");
+    errno = ENOMEM;
+    p = (void *)-1;
+  }
+  return p;
+}


### PR DESCRIPTION
Standard library `printf()` and `scanf()` are not thread-safe and use dynamic memory. Wrap the corresponding low-level functions with mutex protection.

Also logs an error if `sbrk()` fails.