### PR TITLE
v3: Disallow access to FPGA slave 1 in MMU table

### DIFF
--- a/src/board/v3/mmu_table.s
+++ b/src/board/v3/mmu_table.s
@@ -35,8 +35,9 @@ MMUTable:
 .set    SECT, SECT+0x100000
 .endr
 
-.rept   0x0400              /* 0x80000000 - 0xbfffffff (FPGA slave1) */
-.word   SECT + 0xc02        /* S=b0 TEX=b000 AP=b11, Domain=b0, C=b0, B=b1 */
+.rept   0x0400              /* 0x80000000 - 0xbfffffff (FPGA slave1).
+							 * Generates a translation fault if accessed */
+.word   SECT + 0x0          /* S=b0 TEX=b000 AP=b00, Domain=b0, C=b0, B=b0 */
 .set    SECT, SECT+0x100000
 .endr
 


### PR DESCRIPTION
`M_AXI_GP1` is not used and not connected in the HDL, which causes an unrecoverable bus stall if accessed.