### PR TITLE
Add install dependency on software-properties-common.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -150,7 +150,7 @@ function run_all_platforms () {
         log_info "Please enter your password for apt-get..."
         log_info "Updating..."
         sudo apt-get update
-        sudo apt-get install -y curl python-pip
+	sudo apt-get install -y curl python-pip software-properties-common
         sudo pip install ansible
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         piksi_splash_osx


### PR DESCRIPTION
setup.sh executes `add-apt-repository`, which comes from the
software-properties-common package and is not guaranteed to be installed.
This patch explitically checks that the software-properties-common package
is installed.
